### PR TITLE
Closing the response body when done uploading

### DIFF
--- a/upload/upload.go
+++ b/upload/upload.go
@@ -57,6 +57,7 @@ func UploadResource(resource interface{}, baseURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer response.Body.Close()
 	loc := response.Header.Get("Location")
 
 	regs := []string{".*/([^/]+)/_history/.*", ".*/([^/]+)"}


### PR DESCRIPTION
This appears to fix the too many open files issue when generating patients.