### PR TITLE
Fix places where a nil object might be accessed

### DIFF
--- a/models/bundle_test.go
+++ b/models/bundle_test.go
@@ -128,8 +128,9 @@ func (s *BundleSuite) TestUnmarshalJSON(c *check.C) {
 
 func LoadBundleFromFixture(fileName string) *Bundle {
 	data, err := os.Open(fileName)
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
+
 	decoder := json.NewDecoder(data)
 	bundle := &Bundle{}
 	err = decoder.Decode(bundle)

--- a/models/util_test.go
+++ b/models/util_test.go
@@ -32,8 +32,9 @@ func (s *UtilSuite) TestUnmarshalJSON(c *check.C) {
 
 func LoadMapFromFixture(fileName string) interface{} {
 	data, err := os.Open(fileName)
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
+
 	decoder := json.NewDecoder(data)
 	i := make(map[string]interface{})
 	err = decoder.Decode(&i)

--- a/server/batch_controller_test.go
+++ b/server/batch_controller_test.go
@@ -51,8 +51,8 @@ func (s *BatchControllerSuite) TearDownSuite(c *C) {
 
 func (s *BatchControllerSuite) TestUploadPatientBundle(c *C) {
 	data, err := os.Open("../fixtures/john_peters_bundle.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 
 	decoder := json.NewDecoder(data)
 	requestBundle := &models.Bundle{}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -218,8 +218,9 @@ func (s *ServerSuite) TestShowPatient(c *C) {
 
 func (s *ServerSuite) TestCreatePatient(c *C) {
 	data, err := os.Open("../fixtures/patient-example-b.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
+
 	res, err := http.Post(s.Server.URL+"/Patient", "application/json", data)
 	util.CheckErr(err)
 
@@ -235,8 +236,8 @@ func (s *ServerSuite) TestCreatePatient(c *C) {
 
 func (s *ServerSuite) TestUpdatePatient(c *C) {
 	data, err := os.Open("../fixtures/patient-example-c.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
 
 	client := &http.Client{}
 	req, err := http.NewRequest("PUT", s.Server.URL+"/Patient/"+s.FixtureId, data)
@@ -253,8 +254,9 @@ func (s *ServerSuite) TestUpdatePatient(c *C) {
 func (s *ServerSuite) TestDeletePatient(c *C) {
 
 	data, err := os.Open("../fixtures/patient-example-d.json")
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
+
 	res, err := http.Post(s.Server.URL+"/Patient", "application/json", data)
 	util.CheckErr(err)
 
@@ -311,8 +313,9 @@ func insertPatientFromFixture(filePath string) *models.Patient {
 
 func loadPatientFromFixture(fileName string) *models.Patient {
 	data, err := os.Open(fileName)
-	defer data.Close()
 	util.CheckErr(err)
+	defer data.Close()
+
 	decoder := json.NewDecoder(data)
 	patient := &models.Patient{}
 	err = decoder.Decode(patient)


### PR DESCRIPTION
While `defer data.Close()` is generally _good_, it's important to call it only after you've verified that `data` was successfully opened in the first place.  Otherwise, you're trying to call a function on a nil object.