### PR TITLE
Base resource support

### DIFF
--- a/fixtures/loaded_condition.json
+++ b/fixtures/loaded_condition.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "Condition",
+  "id": "8664777288161060797",
+  "meta": {
+    "versionId": "8664777288161060797-1",
+    "lastUpdated": "2014-02-12T07:30:00-05:00",
+    "tag": [{
+      "system": "http://intervention-engine.org/tag",
+      "code": "FOO"
+    }, {
+      "system": "http://intervention-engine.org/tag",
+      "code": "BAR"
+    }]
+  },
+  "text": {
+    "status": "additional",
+    "div": "<div>HTML in JavaScript.  Wow.</div>"
+  },
+  "contained": [{
+    "resourceType": "Practitioner",
+    "id": "pract1",
+    "name": {
+      "family": ["Doofenshmirtz"],
+      "given": ["Heinz"],
+      "suffix": ["MD"]
+    }
+  }],
+  "patient": {
+    "reference": "https://example.com/base/Patient/4954037118555241963"
+  },
+  "asserter": {
+    "reference": "#pract1"
+  },
+  "code": {
+    "coding": [{
+      "system": "http://snomed.info/sct",
+      "code": "10091002"
+    }, {
+      "system": "http://hl7.org/fhir/sid/icd-9",
+      "code": "428.0"
+    }, {
+      "system": "http://hl7.org/fhir/sid/icd-10",
+      "code": "I50.1"
+    }],
+    "text": "Heart failure"
+  },
+  "onsetDateTime": "2012-03-01T07:00:00-05:00"
+}

--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -29,21 +29,21 @@ package models
 import "encoding/json"
 
 type AllergyIntolerance struct {
-	Id            string                                `json:"id" bson:"_id"`
-	Identifier    []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Onset         *FHIRDateTime                         `bson:"onset,omitempty" json:"onset,omitempty"`
-	RecordedDate  *FHIRDateTime                         `bson:"recordedDate,omitempty" json:"recordedDate,omitempty"`
-	Recorder      *Reference                            `bson:"recorder,omitempty" json:"recorder,omitempty"`
-	Patient       *Reference                            `bson:"patient,omitempty" json:"patient,omitempty"`
-	Reporter      *Reference                            `bson:"reporter,omitempty" json:"reporter,omitempty"`
-	Substance     *CodeableConcept                      `bson:"substance,omitempty" json:"substance,omitempty"`
-	Status        string                                `bson:"status,omitempty" json:"status,omitempty"`
-	Criticality   string                                `bson:"criticality,omitempty" json:"criticality,omitempty"`
-	Type          string                                `bson:"type,omitempty" json:"type,omitempty"`
-	Category      string                                `bson:"category,omitempty" json:"category,omitempty"`
-	LastOccurence *FHIRDateTime                         `bson:"lastOccurence,omitempty" json:"lastOccurence,omitempty"`
-	Note          *Annotation                           `bson:"note,omitempty" json:"note,omitempty"`
-	Reaction      []AllergyIntoleranceReactionComponent `bson:"reaction,omitempty" json:"reaction,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Onset          *FHIRDateTime                         `bson:"onset,omitempty" json:"onset,omitempty"`
+	RecordedDate   *FHIRDateTime                         `bson:"recordedDate,omitempty" json:"recordedDate,omitempty"`
+	Recorder       *Reference                            `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	Patient        *Reference                            `bson:"patient,omitempty" json:"patient,omitempty"`
+	Reporter       *Reference                            `bson:"reporter,omitempty" json:"reporter,omitempty"`
+	Substance      *CodeableConcept                      `bson:"substance,omitempty" json:"substance,omitempty"`
+	Status         string                                `bson:"status,omitempty" json:"status,omitempty"`
+	Criticality    string                                `bson:"criticality,omitempty" json:"criticality,omitempty"`
+	Type           string                                `bson:"type,omitempty" json:"type,omitempty"`
+	Category       string                                `bson:"category,omitempty" json:"category,omitempty"`
+	LastOccurence  *FHIRDateTime                         `bson:"lastOccurence,omitempty" json:"lastOccurence,omitempty"`
+	Note           *Annotation                           `bson:"note,omitempty" json:"note,omitempty"`
+	Reaction       []AllergyIntoleranceReactionComponent `bson:"reaction,omitempty" json:"reaction,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -56,6 +56,23 @@ func (resource *AllergyIntolerance) MarshalJSON() ([]byte, error) {
 		AllergyIntolerance: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "allergyIntolerance" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type allergyIntolerance AllergyIntolerance
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *AllergyIntolerance) UnmarshalJSON(data []byte) (err error) {
+	x2 := allergyIntolerance{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = AllergyIntolerance(x2)
+	}
+	return
 }
 
 type AllergyIntoleranceReactionComponent struct {

--- a/models/appointment.go
+++ b/models/appointment.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Appointment struct {
-	Id              string                            `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Identifier      []Identifier                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status          string                            `bson:"status,omitempty" json:"status,omitempty"`
 	Type            *CodeableConcept                  `bson:"type,omitempty" json:"type,omitempty"`
@@ -54,6 +54,23 @@ func (resource *Appointment) MarshalJSON() ([]byte, error) {
 		Appointment:  *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "appointment" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type appointment Appointment
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Appointment) UnmarshalJSON(data []byte) (err error) {
+	x2 := appointment{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Appointment(x2)
+	}
+	return
 }
 
 type AppointmentParticipantComponent struct {

--- a/models/appointmentresponse.go
+++ b/models/appointmentresponse.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type AppointmentResponse struct {
-	Id                string            `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Appointment       *Reference        `bson:"appointment,omitempty" json:"appointment,omitempty"`
 	Start             *FHIRDateTime     `bson:"start,omitempty" json:"start,omitempty"`
@@ -50,4 +50,21 @@ func (resource *AppointmentResponse) MarshalJSON() ([]byte, error) {
 		AppointmentResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "appointmentResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type appointmentResponse AppointmentResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *AppointmentResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := appointmentResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = AppointmentResponse(x2)
+	}
+	return
 }

--- a/models/binary.go
+++ b/models/binary.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Binary struct {
-	Id          string `json:"id" bson:"_id"`
+	Resource    `bson:",inline"`
 	ContentType string `bson:"contentType,omitempty" json:"contentType,omitempty"`
 	Content     string `bson:"content,omitempty" json:"content,omitempty"`
 }

--- a/models/bodysite.go
+++ b/models/bodysite.go
@@ -29,13 +29,13 @@ package models
 import "encoding/json"
 
 type BodySite struct {
-	Id          string            `json:"id" bson:"_id"`
-	Patient     *Reference        `bson:"patient,omitempty" json:"patient,omitempty"`
-	Identifier  []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Code        *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
-	Modifier    []CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
-	Description string            `bson:"description,omitempty" json:"description,omitempty"`
-	Image       []Attachment      `bson:"image,omitempty" json:"image,omitempty"`
+	DomainResource `bson:",inline"`
+	Patient        *Reference        `bson:"patient,omitempty" json:"patient,omitempty"`
+	Identifier     []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code           *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
+	Modifier       []CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Description    string            `bson:"description,omitempty" json:"description,omitempty"`
+	Image          []Attachment      `bson:"image,omitempty" json:"image,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -48,4 +48,21 @@ func (resource *BodySite) MarshalJSON() ([]byte, error) {
 		BodySite:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "bodySite" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type bodySite BodySite
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *BodySite) UnmarshalJSON(data []byte) (err error) {
+	x2 := bodySite{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = BodySite(x2)
+	}
+	return
 }

--- a/models/bundle.go
+++ b/models/bundle.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Bundle struct {
-	Id        string                 `json:"id" bson:"_id"`
+	Resource  `bson:",inline"`
 	Type      string                 `bson:"type,omitempty" json:"type,omitempty"`
 	Total     *uint32                `bson:"total,omitempty" json:"total,omitempty"`
 	Link      []BundleLinkComponent  `bson:"link,omitempty" json:"link,omitempty"`

--- a/models/careplan.go
+++ b/models/careplan.go
@@ -29,23 +29,23 @@ package models
 import "encoding/json"
 
 type CarePlan struct {
-	Id          string                         `json:"id" bson:"_id"`
-	Identifier  []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Subject     *Reference                     `bson:"subject,omitempty" json:"subject,omitempty"`
-	Status      string                         `bson:"status,omitempty" json:"status,omitempty"`
-	Context     *Reference                     `bson:"context,omitempty" json:"context,omitempty"`
-	Period      *Period                        `bson:"period,omitempty" json:"period,omitempty"`
-	Author      []Reference                    `bson:"author,omitempty" json:"author,omitempty"`
-	Modified    *FHIRDateTime                  `bson:"modified,omitempty" json:"modified,omitempty"`
-	Category    []CodeableConcept              `bson:"category,omitempty" json:"category,omitempty"`
-	Description string                         `bson:"description,omitempty" json:"description,omitempty"`
-	Addresses   []Reference                    `bson:"addresses,omitempty" json:"addresses,omitempty"`
-	Support     []Reference                    `bson:"support,omitempty" json:"support,omitempty"`
-	RelatedPlan []CarePlanRelatedPlanComponent `bson:"relatedPlan,omitempty" json:"relatedPlan,omitempty"`
-	Participant []CarePlanParticipantComponent `bson:"participant,omitempty" json:"participant,omitempty"`
-	Goal        []Reference                    `bson:"goal,omitempty" json:"goal,omitempty"`
-	Activity    []CarePlanActivityComponent    `bson:"activity,omitempty" json:"activity,omitempty"`
-	Note        *Annotation                    `bson:"note,omitempty" json:"note,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Subject        *Reference                     `bson:"subject,omitempty" json:"subject,omitempty"`
+	Status         string                         `bson:"status,omitempty" json:"status,omitempty"`
+	Context        *Reference                     `bson:"context,omitempty" json:"context,omitempty"`
+	Period         *Period                        `bson:"period,omitempty" json:"period,omitempty"`
+	Author         []Reference                    `bson:"author,omitempty" json:"author,omitempty"`
+	Modified       *FHIRDateTime                  `bson:"modified,omitempty" json:"modified,omitempty"`
+	Category       []CodeableConcept              `bson:"category,omitempty" json:"category,omitempty"`
+	Description    string                         `bson:"description,omitempty" json:"description,omitempty"`
+	Addresses      []Reference                    `bson:"addresses,omitempty" json:"addresses,omitempty"`
+	Support        []Reference                    `bson:"support,omitempty" json:"support,omitempty"`
+	RelatedPlan    []CarePlanRelatedPlanComponent `bson:"relatedPlan,omitempty" json:"relatedPlan,omitempty"`
+	Participant    []CarePlanParticipantComponent `bson:"participant,omitempty" json:"participant,omitempty"`
+	Goal           []Reference                    `bson:"goal,omitempty" json:"goal,omitempty"`
+	Activity       []CarePlanActivityComponent    `bson:"activity,omitempty" json:"activity,omitempty"`
+	Note           *Annotation                    `bson:"note,omitempty" json:"note,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -58,6 +58,23 @@ func (resource *CarePlan) MarshalJSON() ([]byte, error) {
 		CarePlan:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "carePlan" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type carePlan CarePlan
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *CarePlan) UnmarshalJSON(data []byte) (err error) {
+	x2 := carePlan{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = CarePlan(x2)
+	}
+	return
 }
 
 type CarePlanRelatedPlanComponent struct {

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ClaimResponse struct {
-	Id                      string                            `json:"id" bson:"_id"`
+	DomainResource          `bson:",inline"`
 	Identifier              []Identifier                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Request                 *Reference                        `bson:"request,omitempty" json:"request,omitempty"`
 	Ruleset                 *Coding                           `bson:"ruleset,omitempty" json:"ruleset,omitempty"`
@@ -68,6 +68,23 @@ func (resource *ClaimResponse) MarshalJSON() ([]byte, error) {
 		ClaimResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "claimResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type claimResponse ClaimResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ClaimResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := claimResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ClaimResponse(x2)
+	}
+	return
 }
 
 type ClaimResponseItemsComponent struct {

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ClinicalImpression struct {
-	Id                     string                                      `json:"id" bson:"_id"`
+	DomainResource         `bson:",inline"`
 	Patient                *Reference                                  `bson:"patient,omitempty" json:"patient,omitempty"`
 	Assessor               *Reference                                  `bson:"assessor,omitempty" json:"assessor,omitempty"`
 	Status                 string                                      `bson:"status,omitempty" json:"status,omitempty"`
@@ -60,6 +60,23 @@ func (resource *ClinicalImpression) MarshalJSON() ([]byte, error) {
 		ClinicalImpression: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "clinicalImpression" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type clinicalImpression ClinicalImpression
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ClinicalImpression) UnmarshalJSON(data []byte) (err error) {
+	x2 := clinicalImpression{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ClinicalImpression(x2)
+	}
+	return
 }
 
 type ClinicalImpressionInvestigationsComponent struct {

--- a/models/communication.go
+++ b/models/communication.go
@@ -29,20 +29,20 @@ package models
 import "encoding/json"
 
 type Communication struct {
-	Id            string                          `json:"id" bson:"_id"`
-	Identifier    []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Category      *CodeableConcept                `bson:"category,omitempty" json:"category,omitempty"`
-	Sender        *Reference                      `bson:"sender,omitempty" json:"sender,omitempty"`
-	Recipient     []Reference                     `bson:"recipient,omitempty" json:"recipient,omitempty"`
-	Payload       []CommunicationPayloadComponent `bson:"payload,omitempty" json:"payload,omitempty"`
-	Medium        []CodeableConcept               `bson:"medium,omitempty" json:"medium,omitempty"`
-	Status        string                          `bson:"status,omitempty" json:"status,omitempty"`
-	Encounter     *Reference                      `bson:"encounter,omitempty" json:"encounter,omitempty"`
-	Sent          *FHIRDateTime                   `bson:"sent,omitempty" json:"sent,omitempty"`
-	Received      *FHIRDateTime                   `bson:"received,omitempty" json:"received,omitempty"`
-	Reason        []CodeableConcept               `bson:"reason,omitempty" json:"reason,omitempty"`
-	Subject       *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
-	RequestDetail *Reference                      `bson:"requestDetail,omitempty" json:"requestDetail,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Category       *CodeableConcept                `bson:"category,omitempty" json:"category,omitempty"`
+	Sender         *Reference                      `bson:"sender,omitempty" json:"sender,omitempty"`
+	Recipient      []Reference                     `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	Payload        []CommunicationPayloadComponent `bson:"payload,omitempty" json:"payload,omitempty"`
+	Medium         []CodeableConcept               `bson:"medium,omitempty" json:"medium,omitempty"`
+	Status         string                          `bson:"status,omitempty" json:"status,omitempty"`
+	Encounter      *Reference                      `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Sent           *FHIRDateTime                   `bson:"sent,omitempty" json:"sent,omitempty"`
+	Received       *FHIRDateTime                   `bson:"received,omitempty" json:"received,omitempty"`
+	Reason         []CodeableConcept               `bson:"reason,omitempty" json:"reason,omitempty"`
+	Subject        *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
+	RequestDetail  *Reference                      `bson:"requestDetail,omitempty" json:"requestDetail,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -55,6 +55,23 @@ func (resource *Communication) MarshalJSON() ([]byte, error) {
 		Communication: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "communication" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type communication Communication
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Communication) UnmarshalJSON(data []byte) (err error) {
+	x2 := communication{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Communication(x2)
+	}
+	return
 }
 
 type CommunicationPayloadComponent struct {

--- a/models/communicationrequest.go
+++ b/models/communicationrequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type CommunicationRequest struct {
-	Id                string                                 `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Identifier        []Identifier                           `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Category          *CodeableConcept                       `bson:"category,omitempty" json:"category,omitempty"`
 	Sender            *Reference                             `bson:"sender,omitempty" json:"sender,omitempty"`
@@ -57,6 +57,23 @@ func (resource *CommunicationRequest) MarshalJSON() ([]byte, error) {
 		CommunicationRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "communicationRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type communicationRequest CommunicationRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *CommunicationRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := communicationRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = CommunicationRequest(x2)
+	}
+	return
 }
 
 type CommunicationRequestPayloadComponent struct {

--- a/models/conceptmap.go
+++ b/models/conceptmap.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ConceptMap struct {
-	Id              string                             `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Url             string                             `bson:"url,omitempty" json:"url,omitempty"`
 	Identifier      *Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Version         string                             `bson:"version,omitempty" json:"version,omitempty"`
@@ -60,6 +60,23 @@ func (resource *ConceptMap) MarshalJSON() ([]byte, error) {
 		ConceptMap:   *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "conceptMap" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type conceptMap ConceptMap
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ConceptMap) UnmarshalJSON(data []byte) (err error) {
+	x2 := conceptMap{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ConceptMap(x2)
+	}
+	return
 }
 
 type ConceptMapContactComponent struct {

--- a/models/condition.go
+++ b/models/condition.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Condition struct {
-	Id                 string                       `json:"id" bson:"_id"`
+	DomainResource     `bson:",inline"`
 	Identifier         []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Patient            *Reference                   `bson:"patient,omitempty" json:"patient,omitempty"`
 	Encounter          *Reference                   `bson:"encounter,omitempty" json:"encounter,omitempty"`
@@ -67,6 +67,23 @@ func (resource *Condition) MarshalJSON() ([]byte, error) {
 		Condition:    *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "condition" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type condition Condition
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Condition) UnmarshalJSON(data []byte) (err error) {
+	x2 := condition{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Condition(x2)
+	}
+	return
 }
 
 type ConditionStageComponent struct {

--- a/models/contract.go
+++ b/models/contract.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Contract struct {
-	Id                string                                `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Identifier        *Identifier                           `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Issued            *FHIRDateTime                         `bson:"issued,omitempty" json:"issued,omitempty"`
 	Applies           *Period                               `bson:"applies,omitempty" json:"applies,omitempty"`
@@ -61,6 +61,23 @@ func (resource *Contract) MarshalJSON() ([]byte, error) {
 		Contract:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "contract" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type contract Contract
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Contract) UnmarshalJSON(data []byte) (err error) {
+	x2 := contract{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Contract(x2)
+	}
+	return
 }
 
 type ContractActorComponent struct {

--- a/models/coverage.go
+++ b/models/coverage.go
@@ -29,21 +29,21 @@ package models
 import "encoding/json"
 
 type Coverage struct {
-	Id           string       `json:"id" bson:"_id"`
-	Issuer       *Reference   `bson:"issuer,omitempty" json:"issuer,omitempty"`
-	Bin          *Identifier  `bson:"bin,omitempty" json:"bin,omitempty"`
-	Period       *Period      `bson:"period,omitempty" json:"period,omitempty"`
-	Type         *Coding      `bson:"type,omitempty" json:"type,omitempty"`
-	SubscriberId *Identifier  `bson:"subscriberId,omitempty" json:"subscriberId,omitempty"`
-	Identifier   []Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Group        string       `bson:"group,omitempty" json:"group,omitempty"`
-	Plan         string       `bson:"plan,omitempty" json:"plan,omitempty"`
-	SubPlan      string       `bson:"subPlan,omitempty" json:"subPlan,omitempty"`
-	Dependent    *uint32      `bson:"dependent,omitempty" json:"dependent,omitempty"`
-	Sequence     *uint32      `bson:"sequence,omitempty" json:"sequence,omitempty"`
-	Subscriber   *Reference   `bson:"subscriber,omitempty" json:"subscriber,omitempty"`
-	Network      *Identifier  `bson:"network,omitempty" json:"network,omitempty"`
-	Contract     []Reference  `bson:"contract,omitempty" json:"contract,omitempty"`
+	DomainResource `bson:",inline"`
+	Issuer         *Reference   `bson:"issuer,omitempty" json:"issuer,omitempty"`
+	Bin            *Identifier  `bson:"bin,omitempty" json:"bin,omitempty"`
+	Period         *Period      `bson:"period,omitempty" json:"period,omitempty"`
+	Type           *Coding      `bson:"type,omitempty" json:"type,omitempty"`
+	SubscriberId   *Identifier  `bson:"subscriberId,omitempty" json:"subscriberId,omitempty"`
+	Identifier     []Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Group          string       `bson:"group,omitempty" json:"group,omitempty"`
+	Plan           string       `bson:"plan,omitempty" json:"plan,omitempty"`
+	SubPlan        string       `bson:"subPlan,omitempty" json:"subPlan,omitempty"`
+	Dependent      *uint32      `bson:"dependent,omitempty" json:"dependent,omitempty"`
+	Sequence       *uint32      `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Subscriber     *Reference   `bson:"subscriber,omitempty" json:"subscriber,omitempty"`
+	Network        *Identifier  `bson:"network,omitempty" json:"network,omitempty"`
+	Contract       []Reference  `bson:"contract,omitempty" json:"contract,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -56,4 +56,21 @@ func (resource *Coverage) MarshalJSON() ([]byte, error) {
 		Coverage:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "coverage" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type coverage Coverage
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Coverage) UnmarshalJSON(data []byte) (err error) {
+	x2 := coverage{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Coverage(x2)
+	}
+	return
 }

--- a/models/dataelement.go
+++ b/models/dataelement.go
@@ -29,21 +29,21 @@ package models
 import "encoding/json"
 
 type DataElement struct {
-	Id           string                        `json:"id" bson:"_id"`
-	Url          string                        `bson:"url,omitempty" json:"url,omitempty"`
-	Identifier   []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Version      string                        `bson:"version,omitempty" json:"version,omitempty"`
-	Name         string                        `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                        `bson:"status,omitempty" json:"status,omitempty"`
-	Experimental *bool                         `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []DataElementContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                 `bson:"date,omitempty" json:"date,omitempty"`
-	UseContext   []CodeableConcept             `bson:"useContext,omitempty" json:"useContext,omitempty"`
-	Copyright    string                        `bson:"copyright,omitempty" json:"copyright,omitempty"`
-	Stringency   string                        `bson:"stringency,omitempty" json:"stringency,omitempty"`
-	Mapping      []DataElementMappingComponent `bson:"mapping,omitempty" json:"mapping,omitempty"`
-	Element      []ElementDefinition           `bson:"element,omitempty" json:"element,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                        `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier     []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version        string                        `bson:"version,omitempty" json:"version,omitempty"`
+	Name           string                        `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                        `bson:"status,omitempty" json:"status,omitempty"`
+	Experimental   *bool                         `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []DataElementContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                 `bson:"date,omitempty" json:"date,omitempty"`
+	UseContext     []CodeableConcept             `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Copyright      string                        `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Stringency     string                        `bson:"stringency,omitempty" json:"stringency,omitempty"`
+	Mapping        []DataElementMappingComponent `bson:"mapping,omitempty" json:"mapping,omitempty"`
+	Element        []ElementDefinition           `bson:"element,omitempty" json:"element,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -56,6 +56,23 @@ func (resource *DataElement) MarshalJSON() ([]byte, error) {
 		DataElement:  *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "dataElement" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type dataElement DataElement
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DataElement) UnmarshalJSON(data []byte) (err error) {
+	x2 := dataElement{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DataElement(x2)
+	}
+	return
 }
 
 type DataElementContactComponent struct {

--- a/models/detectedissue.go
+++ b/models/detectedissue.go
@@ -29,17 +29,17 @@ package models
 import "encoding/json"
 
 type DetectedIssue struct {
-	Id         string                             `json:"id" bson:"_id"`
-	Patient    *Reference                         `bson:"patient,omitempty" json:"patient,omitempty"`
-	Category   *CodeableConcept                   `bson:"category,omitempty" json:"category,omitempty"`
-	Severity   string                             `bson:"severity,omitempty" json:"severity,omitempty"`
-	Implicated []Reference                        `bson:"implicated,omitempty" json:"implicated,omitempty"`
-	Detail     string                             `bson:"detail,omitempty" json:"detail,omitempty"`
-	Date       *FHIRDateTime                      `bson:"date,omitempty" json:"date,omitempty"`
-	Author     *Reference                         `bson:"author,omitempty" json:"author,omitempty"`
-	Identifier *Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Reference  string                             `bson:"reference,omitempty" json:"reference,omitempty"`
-	Mitigation []DetectedIssueMitigationComponent `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
+	DomainResource `bson:",inline"`
+	Patient        *Reference                         `bson:"patient,omitempty" json:"patient,omitempty"`
+	Category       *CodeableConcept                   `bson:"category,omitempty" json:"category,omitempty"`
+	Severity       string                             `bson:"severity,omitempty" json:"severity,omitempty"`
+	Implicated     []Reference                        `bson:"implicated,omitempty" json:"implicated,omitempty"`
+	Detail         string                             `bson:"detail,omitempty" json:"detail,omitempty"`
+	Date           *FHIRDateTime                      `bson:"date,omitempty" json:"date,omitempty"`
+	Author         *Reference                         `bson:"author,omitempty" json:"author,omitempty"`
+	Identifier     *Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Reference      string                             `bson:"reference,omitempty" json:"reference,omitempty"`
+	Mitigation     []DetectedIssueMitigationComponent `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -52,6 +52,23 @@ func (resource *DetectedIssue) MarshalJSON() ([]byte, error) {
 		DetectedIssue: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "detectedIssue" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type detectedIssue DetectedIssue
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DetectedIssue) UnmarshalJSON(data []byte) (err error) {
+	x2 := detectedIssue{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DetectedIssue(x2)
+	}
+	return
 }
 
 type DetectedIssueMitigationComponent struct {

--- a/models/devicecomponent.go
+++ b/models/devicecomponent.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DeviceComponent struct {
-	Id                      string                                            `json:"id" bson:"_id"`
+	DomainResource          `bson:",inline"`
 	Type                    *CodeableConcept                                  `bson:"type,omitempty" json:"type,omitempty"`
 	Identifier              *Identifier                                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	LastSystemChange        *FHIRDateTime                                     `bson:"lastSystemChange,omitempty" json:"lastSystemChange,omitempty"`
@@ -52,6 +52,23 @@ func (resource *DeviceComponent) MarshalJSON() ([]byte, error) {
 		DeviceComponent: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "deviceComponent" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type deviceComponent DeviceComponent
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DeviceComponent) UnmarshalJSON(data []byte) (err error) {
+	x2 := deviceComponent{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DeviceComponent(x2)
+	}
+	return
 }
 
 type DeviceComponentProductionSpecificationComponent struct {

--- a/models/devicemetric.go
+++ b/models/devicemetric.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DeviceMetric struct {
-	Id                string                             `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Type              *CodeableConcept                   `bson:"type,omitempty" json:"type,omitempty"`
 	Identifier        *Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Unit              *CodeableConcept                   `bson:"unit,omitempty" json:"unit,omitempty"`
@@ -52,6 +52,23 @@ func (resource *DeviceMetric) MarshalJSON() ([]byte, error) {
 		DeviceMetric: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "deviceMetric" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type deviceMetric DeviceMetric
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DeviceMetric) UnmarshalJSON(data []byte) (err error) {
+	x2 := deviceMetric{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DeviceMetric(x2)
+	}
+	return
 }
 
 type DeviceMetricCalibrationComponent struct {

--- a/models/deviceuserequest.go
+++ b/models/deviceuserequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DeviceUseRequest struct {
-	Id                      string            `json:"id" bson:"_id"`
+	DomainResource          `bson:",inline"`
 	BodySiteCodeableConcept *CodeableConcept  `bson:"bodySiteCodeableConcept,omitempty" json:"bodySiteCodeableConcept,omitempty"`
 	BodySiteReference       *Reference        `bson:"bodySiteReference,omitempty" json:"bodySiteReference,omitempty"`
 	Status                  string            `bson:"status,omitempty" json:"status,omitempty"`
@@ -58,4 +58,21 @@ func (resource *DeviceUseRequest) MarshalJSON() ([]byte, error) {
 		DeviceUseRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "deviceUseRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type deviceUseRequest DeviceUseRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DeviceUseRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := deviceUseRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DeviceUseRequest(x2)
+	}
+	return
 }

--- a/models/deviceusestatement.go
+++ b/models/deviceusestatement.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DeviceUseStatement struct {
-	Id                      string            `json:"id" bson:"_id"`
+	DomainResource          `bson:",inline"`
 	BodySiteCodeableConcept *CodeableConcept  `bson:"bodySiteCodeableConcept,omitempty" json:"bodySiteCodeableConcept,omitempty"`
 	BodySiteReference       *Reference        `bson:"bodySiteReference,omitempty" json:"bodySiteReference,omitempty"`
 	WhenUsed                *Period           `bson:"whenUsed,omitempty" json:"whenUsed,omitempty"`
@@ -54,4 +54,21 @@ func (resource *DeviceUseStatement) MarshalJSON() ([]byte, error) {
 		DeviceUseStatement: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "deviceUseStatement" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type deviceUseStatement DeviceUseStatement
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DeviceUseStatement) UnmarshalJSON(data []byte) (err error) {
+	x2 := deviceUseStatement{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DeviceUseStatement(x2)
+	}
+	return
 }

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DiagnosticOrder struct {
-	Id                    string                          `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Subject               *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
 	Orderer               *Reference                      `bson:"orderer,omitempty" json:"orderer,omitempty"`
 	Identifier            []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
@@ -54,6 +54,23 @@ func (resource *DiagnosticOrder) MarshalJSON() ([]byte, error) {
 		DiagnosticOrder: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "diagnosticOrder" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type diagnosticOrder DiagnosticOrder
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DiagnosticOrder) UnmarshalJSON(data []byte) (err error) {
+	x2 := diagnosticOrder{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DiagnosticOrder(x2)
+	}
+	return
 }
 
 type DiagnosticOrderEventComponent struct {

--- a/models/diagnosticreport.go
+++ b/models/diagnosticreport.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DiagnosticReport struct {
-	Id                string                           `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Identifier        []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status            string                           `bson:"status,omitempty" json:"status,omitempty"`
 	Category          *CodeableConcept                 `bson:"category,omitempty" json:"category,omitempty"`
@@ -60,6 +60,23 @@ func (resource *DiagnosticReport) MarshalJSON() ([]byte, error) {
 		DiagnosticReport: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "diagnosticReport" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type diagnosticReport DiagnosticReport
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DiagnosticReport) UnmarshalJSON(data []byte) (err error) {
+	x2 := diagnosticReport{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DiagnosticReport(x2)
+	}
+	return
 }
 
 type DiagnosticReportImageComponent struct {

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type DocumentReference struct {
-	Id               string                                `json:"id" bson:"_id"`
+	DomainResource   `bson:",inline"`
 	MasterIdentifier *Identifier                           `bson:"masterIdentifier,omitempty" json:"masterIdentifier,omitempty"`
 	Identifier       []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Subject          *Reference                            `bson:"subject,omitempty" json:"subject,omitempty"`
@@ -59,6 +59,23 @@ func (resource *DocumentReference) MarshalJSON() ([]byte, error) {
 		DocumentReference: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "documentReference" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type documentReference DocumentReference
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *DocumentReference) UnmarshalJSON(data []byte) (err error) {
+	x2 := documentReference{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = DocumentReference(x2)
+	}
+	return
 }
 
 type DocumentReferenceRelatesToComponent struct {

--- a/models/domainresource.go
+++ b/models/domainresource.go
@@ -26,7 +26,10 @@
 
 package models
 
-type Element struct {
-	Id        string      `bson:"_id,omitempty" json:"id,omitempty"`
-	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+type DomainResource struct {
+	Resource          `bson:",inline"`
+	Text              *Narrative    `bson:"text,omitempty" json:"text,omitempty"`
+	Contained         []interface{} `bson:"contained,omitempty" json:"contained,omitempty"`
+	Extension         []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Encounter struct {
-	Id               string                             `json:"id" bson:"_id"`
+	DomainResource   `bson:",inline"`
 	Identifier       []Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status           string                             `bson:"status,omitempty" json:"status,omitempty"`
 	StatusHistory    []EncounterStatusHistoryComponent  `bson:"statusHistory,omitempty" json:"statusHistory,omitempty"`
@@ -61,6 +61,23 @@ func (resource *Encounter) MarshalJSON() ([]byte, error) {
 		Encounter:    *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "encounter" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type encounter Encounter
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Encounter) UnmarshalJSON(data []byte) (err error) {
+	x2 := encounter{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Encounter(x2)
+	}
+	return
 }
 
 type EncounterStatusHistoryComponent struct {

--- a/models/enrollmentrequest.go
+++ b/models/enrollmentrequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type EnrollmentRequest struct {
-	Id              string        `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Identifier      []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Ruleset         *Coding       `bson:"ruleset,omitempty" json:"ruleset,omitempty"`
 	OriginalRuleset *Coding       `bson:"originalRuleset,omitempty" json:"originalRuleset,omitempty"`
@@ -52,4 +52,21 @@ func (resource *EnrollmentRequest) MarshalJSON() ([]byte, error) {
 		EnrollmentRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "enrollmentRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type enrollmentRequest EnrollmentRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *EnrollmentRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := enrollmentRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = EnrollmentRequest(x2)
+	}
+	return
 }

--- a/models/enrollmentresponse.go
+++ b/models/enrollmentresponse.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type EnrollmentResponse struct {
-	Id                  string        `json:"id" bson:"_id"`
+	DomainResource      `bson:",inline"`
 	Identifier          []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Request             *Reference    `bson:"request,omitempty" json:"request,omitempty"`
 	Outcome             string        `bson:"outcome,omitempty" json:"outcome,omitempty"`
@@ -52,4 +52,21 @@ func (resource *EnrollmentResponse) MarshalJSON() ([]byte, error) {
 		EnrollmentResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "enrollmentResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type enrollmentResponse EnrollmentResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *EnrollmentResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := enrollmentResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = EnrollmentResponse(x2)
+	}
+	return
 }

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type EpisodeOfCare struct {
-	Id                   string                                `json:"id" bson:"_id"`
+	DomainResource       `bson:",inline"`
 	Identifier           []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status               string                                `bson:"status,omitempty" json:"status,omitempty"`
 	StatusHistory        []EpisodeOfCareStatusHistoryComponent `bson:"statusHistory,omitempty" json:"statusHistory,omitempty"`
@@ -53,6 +53,23 @@ func (resource *EpisodeOfCare) MarshalJSON() ([]byte, error) {
 		EpisodeOfCare: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "episodeOfCare" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type episodeOfCare EpisodeOfCare
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *EpisodeOfCare) UnmarshalJSON(data []byte) (err error) {
+	x2 := episodeOfCare{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = EpisodeOfCare(x2)
+	}
+	return
 }
 
 type EpisodeOfCareStatusHistoryComponent struct {

--- a/models/explanationofbenefit.go
+++ b/models/explanationofbenefit.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ExplanationOfBenefit struct {
-	Id                  string        `json:"id" bson:"_id"`
+	DomainResource      `bson:",inline"`
 	Identifier          []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Request             *Reference    `bson:"request,omitempty" json:"request,omitempty"`
 	Outcome             string        `bson:"outcome,omitempty" json:"outcome,omitempty"`
@@ -52,4 +52,21 @@ func (resource *ExplanationOfBenefit) MarshalJSON() ([]byte, error) {
 		ExplanationOfBenefit: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "explanationOfBenefit" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type explanationOfBenefit ExplanationOfBenefit
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ExplanationOfBenefit) UnmarshalJSON(data []byte) (err error) {
+	x2 := explanationOfBenefit{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ExplanationOfBenefit(x2)
+	}
+	return
 }

--- a/models/familymemberhistory.go
+++ b/models/familymemberhistory.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type FamilyMemberHistory struct {
-	Id              string                                  `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Identifier      []Identifier                            `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Patient         *Reference                              `bson:"patient,omitempty" json:"patient,omitempty"`
 	Date            *FHIRDateTime                           `bson:"date,omitempty" json:"date,omitempty"`
@@ -62,6 +62,23 @@ func (resource *FamilyMemberHistory) MarshalJSON() ([]byte, error) {
 		FamilyMemberHistory: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "familyMemberHistory" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type familyMemberHistory FamilyMemberHistory
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *FamilyMemberHistory) UnmarshalJSON(data []byte) (err error) {
+	x2 := familyMemberHistory{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = FamilyMemberHistory(x2)
+	}
+	return
 }
 
 type FamilyMemberHistoryConditionComponent struct {

--- a/models/flag.go
+++ b/models/flag.go
@@ -29,15 +29,15 @@ package models
 import "encoding/json"
 
 type Flag struct {
-	Id         string           `json:"id" bson:"_id"`
-	Identifier []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Category   *CodeableConcept `bson:"category,omitempty" json:"category,omitempty"`
-	Status     string           `bson:"status,omitempty" json:"status,omitempty"`
-	Period     *Period          `bson:"period,omitempty" json:"period,omitempty"`
-	Subject    *Reference       `bson:"subject,omitempty" json:"subject,omitempty"`
-	Encounter  *Reference       `bson:"encounter,omitempty" json:"encounter,omitempty"`
-	Author     *Reference       `bson:"author,omitempty" json:"author,omitempty"`
-	Code       *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Category       *CodeableConcept `bson:"category,omitempty" json:"category,omitempty"`
+	Status         string           `bson:"status,omitempty" json:"status,omitempty"`
+	Period         *Period          `bson:"period,omitempty" json:"period,omitempty"`
+	Subject        *Reference       `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter      *Reference       `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Author         *Reference       `bson:"author,omitempty" json:"author,omitempty"`
+	Code           *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -50,4 +50,21 @@ func (resource *Flag) MarshalJSON() ([]byte, error) {
 		Flag:         *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "flag" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type flag Flag
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Flag) UnmarshalJSON(data []byte) (err error) {
+	x2 := flag{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Flag(x2)
+	}
+	return
 }

--- a/models/healthcareservice.go
+++ b/models/healthcareservice.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type HealthcareService struct {
-	Id                     string                                    `json:"id" bson:"_id"`
+	DomainResource         `bson:",inline"`
 	Identifier             []Identifier                              `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	ProvidedBy             *Reference                                `bson:"providedBy,omitempty" json:"providedBy,omitempty"`
 	ServiceCategory        *CodeableConcept                          `bson:"serviceCategory,omitempty" json:"serviceCategory,omitempty"`
@@ -64,6 +64,23 @@ func (resource *HealthcareService) MarshalJSON() ([]byte, error) {
 		HealthcareService: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "healthcareService" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type healthcareService HealthcareService
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *HealthcareService) UnmarshalJSON(data []byte) (err error) {
+	x2 := healthcareService{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = HealthcareService(x2)
+	}
+	return
 }
 
 type HealthcareServiceServiceTypeComponent struct {

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -29,14 +29,14 @@ package models
 import "encoding/json"
 
 type ImagingObjectSelection struct {
-	Id            string                                 `json:"id" bson:"_id"`
-	Uid           string                                 `bson:"uid,omitempty" json:"uid,omitempty"`
-	Patient       *Reference                             `bson:"patient,omitempty" json:"patient,omitempty"`
-	Title         *CodeableConcept                       `bson:"title,omitempty" json:"title,omitempty"`
-	Description   string                                 `bson:"description,omitempty" json:"description,omitempty"`
-	Author        *Reference                             `bson:"author,omitempty" json:"author,omitempty"`
-	AuthoringTime *FHIRDateTime                          `bson:"authoringTime,omitempty" json:"authoringTime,omitempty"`
-	Study         []ImagingObjectSelectionStudyComponent `bson:"study,omitempty" json:"study,omitempty"`
+	DomainResource `bson:",inline"`
+	Uid            string                                 `bson:"uid,omitempty" json:"uid,omitempty"`
+	Patient        *Reference                             `bson:"patient,omitempty" json:"patient,omitempty"`
+	Title          *CodeableConcept                       `bson:"title,omitempty" json:"title,omitempty"`
+	Description    string                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Author         *Reference                             `bson:"author,omitempty" json:"author,omitempty"`
+	AuthoringTime  *FHIRDateTime                          `bson:"authoringTime,omitempty" json:"authoringTime,omitempty"`
+	Study          []ImagingObjectSelectionStudyComponent `bson:"study,omitempty" json:"study,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -49,6 +49,23 @@ func (resource *ImagingObjectSelection) MarshalJSON() ([]byte, error) {
 		ImagingObjectSelection: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "imagingObjectSelection" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type imagingObjectSelection ImagingObjectSelection
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ImagingObjectSelection) UnmarshalJSON(data []byte) (err error) {
+	x2 := imagingObjectSelection{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ImagingObjectSelection(x2)
+	}
+	return
 }
 
 type ImagingObjectSelectionStudyComponent struct {

--- a/models/imagingstudy.go
+++ b/models/imagingstudy.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ImagingStudy struct {
-	Id                string                        `json:"id" bson:"_id"`
+	DomainResource    `bson:",inline"`
 	Started           *FHIRDateTime                 `bson:"started,omitempty" json:"started,omitempty"`
 	Patient           *Reference                    `bson:"patient,omitempty" json:"patient,omitempty"`
 	Uid               string                        `bson:"uid,omitempty" json:"uid,omitempty"`
@@ -58,6 +58,23 @@ func (resource *ImagingStudy) MarshalJSON() ([]byte, error) {
 		ImagingStudy: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "imagingStudy" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type imagingStudy ImagingStudy
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ImagingStudy) UnmarshalJSON(data []byte) (err error) {
+	x2 := imagingStudy{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ImagingStudy(x2)
+	}
+	return
 }
 
 type ImagingStudySeriesComponent struct {

--- a/models/immunization.go
+++ b/models/immunization.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Immunization struct {
-	Id                  string                                     `json:"id" bson:"_id"`
+	DomainResource      `bson:",inline"`
 	Identifier          []Identifier                               `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status              string                                     `bson:"status,omitempty" json:"status,omitempty"`
 	Date                *FHIRDateTime                              `bson:"date,omitempty" json:"date,omitempty"`
@@ -63,6 +63,23 @@ func (resource *Immunization) MarshalJSON() ([]byte, error) {
 		Immunization: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "immunization" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type immunization Immunization
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Immunization) UnmarshalJSON(data []byte) (err error) {
+	x2 := immunization{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Immunization(x2)
+	}
+	return
 }
 
 type ImmunizationExplanationComponent struct {

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ImmunizationRecommendation struct {
-	Id             string                                              `json:"id" bson:"_id"`
+	DomainResource `bson:",inline"`
 	Identifier     []Identifier                                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Patient        *Reference                                          `bson:"patient,omitempty" json:"patient,omitempty"`
 	Recommendation []ImmunizationRecommendationRecommendationComponent `bson:"recommendation,omitempty" json:"recommendation,omitempty"`
@@ -45,6 +45,23 @@ func (resource *ImmunizationRecommendation) MarshalJSON() ([]byte, error) {
 		ImmunizationRecommendation: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "immunizationRecommendation" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type immunizationRecommendation ImmunizationRecommendation
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ImmunizationRecommendation) UnmarshalJSON(data []byte) (err error) {
+	x2 := immunizationRecommendation{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ImmunizationRecommendation(x2)
+	}
+	return
 }
 
 type ImmunizationRecommendationRecommendationComponent struct {

--- a/models/implementationguide.go
+++ b/models/implementationguide.go
@@ -29,24 +29,24 @@ package models
 import "encoding/json"
 
 type ImplementationGuide struct {
-	Id           string                                   `json:"id" bson:"_id"`
-	Url          string                                   `bson:"url,omitempty" json:"url,omitempty"`
-	Version      string                                   `bson:"version,omitempty" json:"version,omitempty"`
-	Name         string                                   `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                                   `bson:"status,omitempty" json:"status,omitempty"`
-	Experimental *bool                                    `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                                   `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []ImplementationGuideContactComponent    `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                            `bson:"date,omitempty" json:"date,omitempty"`
-	Description  string                                   `bson:"description,omitempty" json:"description,omitempty"`
-	UseContext   []CodeableConcept                        `bson:"useContext,omitempty" json:"useContext,omitempty"`
-	Copyright    string                                   `bson:"copyright,omitempty" json:"copyright,omitempty"`
-	FhirVersion  string                                   `bson:"fhirVersion,omitempty" json:"fhirVersion,omitempty"`
-	Dependency   []ImplementationGuideDependencyComponent `bson:"dependency,omitempty" json:"dependency,omitempty"`
-	Package      []ImplementationGuidePackageComponent    `bson:"package,omitempty" json:"package,omitempty"`
-	Global       []ImplementationGuideGlobalComponent     `bson:"global,omitempty" json:"global,omitempty"`
-	Binary       []string                                 `bson:"binary,omitempty" json:"binary,omitempty"`
-	Page         *ImplementationGuidePageComponent        `bson:"page,omitempty" json:"page,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                                   `bson:"url,omitempty" json:"url,omitempty"`
+	Version        string                                   `bson:"version,omitempty" json:"version,omitempty"`
+	Name           string                                   `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                                   `bson:"status,omitempty" json:"status,omitempty"`
+	Experimental   *bool                                    `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                                   `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []ImplementationGuideContactComponent    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                            `bson:"date,omitempty" json:"date,omitempty"`
+	Description    string                                   `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext     []CodeableConcept                        `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Copyright      string                                   `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	FhirVersion    string                                   `bson:"fhirVersion,omitempty" json:"fhirVersion,omitempty"`
+	Dependency     []ImplementationGuideDependencyComponent `bson:"dependency,omitempty" json:"dependency,omitempty"`
+	Package        []ImplementationGuidePackageComponent    `bson:"package,omitempty" json:"package,omitempty"`
+	Global         []ImplementationGuideGlobalComponent     `bson:"global,omitempty" json:"global,omitempty"`
+	Binary         []string                                 `bson:"binary,omitempty" json:"binary,omitempty"`
+	Page           *ImplementationGuidePageComponent        `bson:"page,omitempty" json:"page,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -59,6 +59,23 @@ func (resource *ImplementationGuide) MarshalJSON() ([]byte, error) {
 		ImplementationGuide: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "implementationGuide" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type implementationGuide ImplementationGuide
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ImplementationGuide) UnmarshalJSON(data []byte) (err error) {
+	x2 := implementationGuide{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ImplementationGuide(x2)
+	}
+	return
 }
 
 type ImplementationGuideContactComponent struct {

--- a/models/json_test.go
+++ b/models/json_test.go
@@ -1,0 +1,126 @@
+package models
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"time"
+
+	simple "github.com/bitly/go-simplejson"
+	"github.com/pebbe/util"
+	check "gopkg.in/check.v1"
+)
+
+type JSONSuite struct {
+}
+
+var _ = check.Suite(&JSONSuite{})
+
+func (s *JSONSuite) TestUnmarshalJSON(c *check.C) {
+	file, err := ioutil.ReadFile("../fixtures/loaded_condition.json")
+	util.CheckErr(err)
+
+	r := &Condition{}
+	err = json.Unmarshal(file, r)
+	util.CheckErr(err)
+
+	c.Assert(r.Id, check.Equals, "8664777288161060797")
+	c.Assert(r.Meta, check.NotNil)
+	c.Assert(r.Meta.VersionId, check.Equals, "8664777288161060797-1")
+	c.Assert(r.Meta.LastUpdated.Precision, check.Equals, Precision(Timestamp))
+	c.Assert(r.Meta.LastUpdated.Time.Unix(), check.Equals, int64(1392208200))
+	c.Assert(r.Meta.Tag, check.HasLen, 2)
+	c.Assert(r.Meta.Tag[0].System, check.Equals, "http://intervention-engine.org/tag")
+	c.Assert(r.Meta.Tag[0].Code, check.Equals, "FOO")
+	c.Assert(r.Meta.Tag[1].System, check.Equals, "http://intervention-engine.org/tag")
+	c.Assert(r.Meta.Tag[1].Code, check.Equals, "BAR")
+	c.Assert(r.Text.Status, check.Equals, "additional")
+	c.Assert(r.Text.Div, check.Equals, "<div>HTML in JavaScript.  Wow.</div>")
+	c.Assert(r.Contained, check.HasLen, 1)
+	c.Assert(r.Contained[0], check.FitsTypeOf, &Practitioner{})
+	contained := r.Contained[0].(*Practitioner)
+	c.Assert(contained.Id, check.Equals, "pract1")
+	c.Assert(contained.Name.Family, check.HasLen, 1)
+	c.Assert(contained.Name.Family[0], check.Equals, "Doofenshmirtz")
+	c.Assert(contained.Name.Given, check.HasLen, 1)
+	c.Assert(contained.Name.Given[0], check.Equals, "Heinz")
+	c.Assert(contained.Name.Suffix, check.HasLen, 1)
+	c.Assert(contained.Name.Suffix[0], check.Equals, "MD")
+	c.Assert(r.Patient.Reference, check.Equals, "https://example.com/base/Patient/4954037118555241963")
+	c.Assert(r.Asserter.Reference, check.Equals, "#pract1")
+	c.Assert(r.Code.Coding, check.HasLen, 3)
+	c.Assert(r.Code.MatchesCode("http://snomed.info/sct", "10091002"), check.Equals, true)
+	c.Assert(r.Code.MatchesCode("http://hl7.org/fhir/sid/icd-9", "428.0"), check.Equals, true)
+	c.Assert(r.Code.MatchesCode("http://hl7.org/fhir/sid/icd-10", "I50.1"), check.Equals, true)
+	c.Assert(r.Code.Text, check.Equals, "Heart failure")
+	c.Assert(r.OnsetDateTime.Precision, check.Equals, Precision(Timestamp))
+	c.Assert(r.OnsetDateTime.Time.Unix(), check.Equals, int64(1330603200))
+}
+
+func (s *JSONSuite) TestMarshalJSON(c *check.C) {
+	r := &Condition{}
+	r.Id = "8664777288161060797"
+	r.Meta = &Meta{
+		VersionId:   "8664777288161060797-1",
+		LastUpdated: &FHIRDateTime{Time: time.Date(2014, time.February, 12, 12, 30, 0, 0, time.UTC), Precision: Precision(Timestamp)},
+		Tag: []Coding{
+			{System: "http://intervention-engine.org/tag", Code: "FOO"},
+			{System: "http://intervention-engine.org/tag", Code: "BAR"},
+		},
+	}
+	r.Text = &Narrative{
+		Status: "additional",
+		Div:    "<div>HTML in JavaScript.  Wow.</div>",
+	}
+	r.Contained = make([]interface{}, 1)
+	r.Contained[0] = &Practitioner{
+		DomainResource: DomainResource{Resource: Resource{Id: "pract1"}},
+		Name: &HumanName{
+			Family: []string{"Doofenshmirtz"},
+			Given:  []string{"Heinz"},
+			Suffix: []string{"MD"},
+		},
+	}
+	r.Patient = &Reference{Reference: "https://example.com/base/Patient/4954037118555241963"}
+	r.Asserter = &Reference{Reference: "#pract1"}
+	r.Code = &CodeableConcept{
+		Coding: []Coding{
+			{System: "http://snomed.info/sct", Code: "10091002"},
+			{System: "http://hl7.org/fhir/sid/icd-9", Code: "428.0"},
+			{System: "http://hl7.org/fhir/sid/icd-10", Code: "I50.1"},
+		},
+		Text: "Heart failure",
+	}
+	r.OnsetDateTime = &FHIRDateTime{Time: time.Date(2012, time.March, 01, 12, 0, 0, 0, time.UTC), Precision: Precision(Timestamp)}
+
+	b, err := json.Marshal(r)
+	util.CheckErr(err)
+
+	j, err := simple.NewJson(b)
+	util.CheckErr(err)
+
+	c.Assert(j.Get("resourceType").MustString(), check.Equals, "Condition")
+	c.Assert(j.GetPath("meta", "versionId").MustString(), check.Equals, "8664777288161060797-1")
+	c.Assert(j.GetPath("meta", "lastUpdated").MustString(), check.Equals, "2014-02-12T12:30:00Z")
+	c.Assert(j.GetPath("meta", "tag").GetIndex(0).Get("system").MustString(), check.Equals, "http://intervention-engine.org/tag")
+	c.Assert(j.GetPath("meta", "tag").GetIndex(0).Get("code").MustString(), check.Equals, "FOO")
+	c.Assert(j.GetPath("meta", "tag").GetIndex(1).Get("system").MustString(), check.Equals, "http://intervention-engine.org/tag")
+	c.Assert(j.GetPath("meta", "tag").GetIndex(1).Get("code").MustString(), check.Equals, "BAR")
+	c.Assert(j.GetPath("text", "status").MustString(), check.Equals, "additional")
+	c.Assert(j.GetPath("text", "div").MustString(), check.Equals, "<div>HTML in JavaScript.  Wow.</div>")
+	contained := j.Get("contained").GetIndex(0)
+	c.Assert(contained.Get("resourceType").MustString(), check.Equals, "Practitioner")
+	c.Assert(contained.GetPath("name", "family").GetIndex(0).MustString(), check.Equals, "Doofenshmirtz")
+	c.Assert(contained.GetPath("name", "given").GetIndex(0).MustString(), check.Equals, "Heinz")
+	c.Assert(contained.GetPath("name", "suffix").GetIndex(0).MustString(), check.Equals, "MD")
+	c.Assert(j.GetPath("patient", "reference").MustString(), check.Equals, "https://example.com/base/Patient/4954037118555241963")
+	c.Assert(j.GetPath("asserter", "reference").MustString(), check.Equals, "#pract1")
+	c.Assert(j.GetPath("code", "coding").MustArray(), check.HasLen, 3)
+	c.Assert(j.GetPath("code", "coding").GetIndex(0).Get("system").MustString(), check.Equals, "http://snomed.info/sct")
+	c.Assert(j.GetPath("code", "coding").GetIndex(0).Get("code").MustString(), check.Equals, "10091002")
+	c.Assert(j.GetPath("code", "coding").GetIndex(1).Get("system").MustString(), check.Equals, "http://hl7.org/fhir/sid/icd-9")
+	c.Assert(j.GetPath("code", "coding").GetIndex(1).Get("code").MustString(), check.Equals, "428.0")
+	c.Assert(j.GetPath("code", "coding").GetIndex(2).Get("system").MustString(), check.Equals, "http://hl7.org/fhir/sid/icd-10")
+	c.Assert(j.GetPath("code", "coding").GetIndex(2).Get("code").MustString(), check.Equals, "I50.1")
+	c.Assert(j.GetPath("code", "text").MustString(), check.Equals, "Heart failure")
+	c.Assert(j.Get("onsetDateTime").MustString(), check.Equals, "2012-03-01T12:00:00Z")
+}

--- a/models/list.go
+++ b/models/list.go
@@ -29,20 +29,20 @@ package models
 import "encoding/json"
 
 type List struct {
-	Id          string               `json:"id" bson:"_id"`
-	Identifier  []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Title       string               `bson:"title,omitempty" json:"title,omitempty"`
-	Code        *CodeableConcept     `bson:"code,omitempty" json:"code,omitempty"`
-	Subject     *Reference           `bson:"subject,omitempty" json:"subject,omitempty"`
-	Source      *Reference           `bson:"source,omitempty" json:"source,omitempty"`
-	Encounter   *Reference           `bson:"encounter,omitempty" json:"encounter,omitempty"`
-	Status      string               `bson:"status,omitempty" json:"status,omitempty"`
-	Date        *FHIRDateTime        `bson:"date,omitempty" json:"date,omitempty"`
-	OrderedBy   *CodeableConcept     `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
-	Mode        string               `bson:"mode,omitempty" json:"mode,omitempty"`
-	Note        string               `bson:"note,omitempty" json:"note,omitempty"`
-	Entry       []ListEntryComponent `bson:"entry,omitempty" json:"entry,omitempty"`
-	EmptyReason *CodeableConcept     `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Title          string               `bson:"title,omitempty" json:"title,omitempty"`
+	Code           *CodeableConcept     `bson:"code,omitempty" json:"code,omitempty"`
+	Subject        *Reference           `bson:"subject,omitempty" json:"subject,omitempty"`
+	Source         *Reference           `bson:"source,omitempty" json:"source,omitempty"`
+	Encounter      *Reference           `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Status         string               `bson:"status,omitempty" json:"status,omitempty"`
+	Date           *FHIRDateTime        `bson:"date,omitempty" json:"date,omitempty"`
+	OrderedBy      *CodeableConcept     `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
+	Mode           string               `bson:"mode,omitempty" json:"mode,omitempty"`
+	Note           string               `bson:"note,omitempty" json:"note,omitempty"`
+	Entry          []ListEntryComponent `bson:"entry,omitempty" json:"entry,omitempty"`
+	EmptyReason    *CodeableConcept     `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -55,6 +55,23 @@ func (resource *List) MarshalJSON() ([]byte, error) {
 		List:         *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "list" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type list List
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *List) UnmarshalJSON(data []byte) (err error) {
+	x2 := list{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = List(x2)
+	}
+	return
 }
 
 type ListEntryComponent struct {

--- a/models/location.go
+++ b/models/location.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Location struct {
-	Id                   string                     `json:"id" bson:"_id"`
+	DomainResource       `bson:",inline"`
 	Identifier           []Identifier               `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status               string                     `bson:"status,omitempty" json:"status,omitempty"`
 	Name                 string                     `bson:"name,omitempty" json:"name,omitempty"`
@@ -54,6 +54,23 @@ func (resource *Location) MarshalJSON() ([]byte, error) {
 		Location:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "location" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type location Location
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Location) UnmarshalJSON(data []byte) (err error) {
+	x2 := location{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Location(x2)
+	}
+	return
 }
 
 type LocationPositionComponent struct {

--- a/models/media.go
+++ b/models/media.go
@@ -29,19 +29,19 @@ package models
 import "encoding/json"
 
 type Media struct {
-	Id         string           `json:"id" bson:"_id"`
-	Type       string           `bson:"type,omitempty" json:"type,omitempty"`
-	Subtype    *CodeableConcept `bson:"subtype,omitempty" json:"subtype,omitempty"`
-	Identifier []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Subject    *Reference       `bson:"subject,omitempty" json:"subject,omitempty"`
-	Operator   *Reference       `bson:"operator,omitempty" json:"operator,omitempty"`
-	View       *CodeableConcept `bson:"view,omitempty" json:"view,omitempty"`
-	DeviceName string           `bson:"deviceName,omitempty" json:"deviceName,omitempty"`
-	Height     *uint32          `bson:"height,omitempty" json:"height,omitempty"`
-	Width      *uint32          `bson:"width,omitempty" json:"width,omitempty"`
-	Frames     *uint32          `bson:"frames,omitempty" json:"frames,omitempty"`
-	Duration   *uint32          `bson:"duration,omitempty" json:"duration,omitempty"`
-	Content    *Attachment      `bson:"content,omitempty" json:"content,omitempty"`
+	DomainResource `bson:",inline"`
+	Type           string           `bson:"type,omitempty" json:"type,omitempty"`
+	Subtype        *CodeableConcept `bson:"subtype,omitempty" json:"subtype,omitempty"`
+	Identifier     []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Subject        *Reference       `bson:"subject,omitempty" json:"subject,omitempty"`
+	Operator       *Reference       `bson:"operator,omitempty" json:"operator,omitempty"`
+	View           *CodeableConcept `bson:"view,omitempty" json:"view,omitempty"`
+	DeviceName     string           `bson:"deviceName,omitempty" json:"deviceName,omitempty"`
+	Height         *uint32          `bson:"height,omitempty" json:"height,omitempty"`
+	Width          *uint32          `bson:"width,omitempty" json:"width,omitempty"`
+	Frames         *uint32          `bson:"frames,omitempty" json:"frames,omitempty"`
+	Duration       *uint32          `bson:"duration,omitempty" json:"duration,omitempty"`
+	Content        *Attachment      `bson:"content,omitempty" json:"content,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -54,4 +54,21 @@ func (resource *Media) MarshalJSON() ([]byte, error) {
 		Media:        *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "media" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type media Media
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Media) UnmarshalJSON(data []byte) (err error) {
+	x2 := media{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Media(x2)
+	}
+	return
 }

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type MedicationAdministration struct {
-	Id                        string                                   `json:"id" bson:"_id"`
+	DomainResource            `bson:",inline"`
 	Identifier                []Identifier                             `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status                    string                                   `bson:"status,omitempty" json:"status,omitempty"`
 	Patient                   *Reference                               `bson:"patient,omitempty" json:"patient,omitempty"`
@@ -58,6 +58,23 @@ func (resource *MedicationAdministration) MarshalJSON() ([]byte, error) {
 		MedicationAdministration: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "medicationAdministration" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type medicationAdministration MedicationAdministration
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *MedicationAdministration) UnmarshalJSON(data []byte) (err error) {
+	x2 := medicationAdministration{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = MedicationAdministration(x2)
+	}
+	return
 }
 
 type MedicationAdministrationDosageComponent struct {

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type MedicationDispense struct {
-	Id                        string                                         `json:"id" bson:"_id"`
+	DomainResource            `bson:",inline"`
 	Identifier                *Identifier                                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Status                    string                                         `bson:"status,omitempty" json:"status,omitempty"`
 	Patient                   *Reference                                     `bson:"patient,omitempty" json:"patient,omitempty"`
@@ -59,6 +59,23 @@ func (resource *MedicationDispense) MarshalJSON() ([]byte, error) {
 		MedicationDispense: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "medicationDispense" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type medicationDispense MedicationDispense
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *MedicationDispense) UnmarshalJSON(data []byte) (err error) {
+	x2 := medicationDispense{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = MedicationDispense(x2)
+	}
+	return
 }
 
 type MedicationDispenseDosageInstructionComponent struct {

--- a/models/medicationorder.go
+++ b/models/medicationorder.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type MedicationOrder struct {
-	Id                        string                                      `json:"id" bson:"_id"`
+	DomainResource            `bson:",inline"`
 	Identifier                []Identifier                                `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	DateWritten               *FHIRDateTime                               `bson:"dateWritten,omitempty" json:"dateWritten,omitempty"`
 	Status                    string                                      `bson:"status,omitempty" json:"status,omitempty"`
@@ -59,6 +59,23 @@ func (resource *MedicationOrder) MarshalJSON() ([]byte, error) {
 		MedicationOrder: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "medicationOrder" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type medicationOrder MedicationOrder
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *MedicationOrder) UnmarshalJSON(data []byte) (err error) {
+	x2 := medicationOrder{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = MedicationOrder(x2)
+	}
+	return
 }
 
 type MedicationOrderDosageInstructionComponent struct {

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type MedicationStatement struct {
-	Id                          string                               `json:"id" bson:"_id"`
+	DomainResource              `bson:",inline"`
 	Identifier                  []Identifier                         `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Patient                     *Reference                           `bson:"patient,omitempty" json:"patient,omitempty"`
 	InformationSource           *Reference                           `bson:"informationSource,omitempty" json:"informationSource,omitempty"`
@@ -58,6 +58,23 @@ func (resource *MedicationStatement) MarshalJSON() ([]byte, error) {
 		MedicationStatement: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "medicationStatement" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type medicationStatement MedicationStatement
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *MedicationStatement) UnmarshalJSON(data []byte) (err error) {
+	x2 := medicationStatement{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = MedicationStatement(x2)
+	}
+	return
 }
 
 type MedicationStatementDosageComponent struct {

--- a/models/messageheader.go
+++ b/models/messageheader.go
@@ -29,18 +29,18 @@ package models
 import "encoding/json"
 
 type MessageHeader struct {
-	Id          string                                     `json:"id" bson:"_id"`
-	Timestamp   *FHIRDateTime                              `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
-	Event       *Coding                                    `bson:"event,omitempty" json:"event,omitempty"`
-	Response    *MessageHeaderResponseComponent            `bson:"response,omitempty" json:"response,omitempty"`
-	Source      *MessageHeaderMessageSourceComponent       `bson:"source,omitempty" json:"source,omitempty"`
-	Destination []MessageHeaderMessageDestinationComponent `bson:"destination,omitempty" json:"destination,omitempty"`
-	Enterer     *Reference                                 `bson:"enterer,omitempty" json:"enterer,omitempty"`
-	Author      *Reference                                 `bson:"author,omitempty" json:"author,omitempty"`
-	Receiver    *Reference                                 `bson:"receiver,omitempty" json:"receiver,omitempty"`
-	Responsible *Reference                                 `bson:"responsible,omitempty" json:"responsible,omitempty"`
-	Reason      *CodeableConcept                           `bson:"reason,omitempty" json:"reason,omitempty"`
-	Data        []Reference                                `bson:"data,omitempty" json:"data,omitempty"`
+	DomainResource `bson:",inline"`
+	Timestamp      *FHIRDateTime                              `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
+	Event          *Coding                                    `bson:"event,omitempty" json:"event,omitempty"`
+	Response       *MessageHeaderResponseComponent            `bson:"response,omitempty" json:"response,omitempty"`
+	Source         *MessageHeaderMessageSourceComponent       `bson:"source,omitempty" json:"source,omitempty"`
+	Destination    []MessageHeaderMessageDestinationComponent `bson:"destination,omitempty" json:"destination,omitempty"`
+	Enterer        *Reference                                 `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	Author         *Reference                                 `bson:"author,omitempty" json:"author,omitempty"`
+	Receiver       *Reference                                 `bson:"receiver,omitempty" json:"receiver,omitempty"`
+	Responsible    *Reference                                 `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Reason         *CodeableConcept                           `bson:"reason,omitempty" json:"reason,omitempty"`
+	Data           []Reference                                `bson:"data,omitempty" json:"data,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -53,6 +53,23 @@ func (resource *MessageHeader) MarshalJSON() ([]byte, error) {
 		MessageHeader: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "messageHeader" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type messageHeader MessageHeader
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *MessageHeader) UnmarshalJSON(data []byte) (err error) {
+	x2 := messageHeader{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = MessageHeader(x2)
+	}
+	return
 }
 
 type MessageHeaderResponseComponent struct {

--- a/models/namingsystem.go
+++ b/models/namingsystem.go
@@ -29,20 +29,20 @@ package models
 import "encoding/json"
 
 type NamingSystem struct {
-	Id          string                          `json:"id" bson:"_id"`
-	Name        string                          `bson:"name,omitempty" json:"name,omitempty"`
-	Status      string                          `bson:"status,omitempty" json:"status,omitempty"`
-	Kind        string                          `bson:"kind,omitempty" json:"kind,omitempty"`
-	Publisher   string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact     []NamingSystemContactComponent  `bson:"contact,omitempty" json:"contact,omitempty"`
-	Responsible string                          `bson:"responsible,omitempty" json:"responsible,omitempty"`
-	Date        *FHIRDateTime                   `bson:"date,omitempty" json:"date,omitempty"`
-	Type        *CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
-	Description string                          `bson:"description,omitempty" json:"description,omitempty"`
-	UseContext  []CodeableConcept               `bson:"useContext,omitempty" json:"useContext,omitempty"`
-	Usage       string                          `bson:"usage,omitempty" json:"usage,omitempty"`
-	UniqueId    []NamingSystemUniqueIdComponent `bson:"uniqueId,omitempty" json:"uniqueId,omitempty"`
-	ReplacedBy  *Reference                      `bson:"replacedBy,omitempty" json:"replacedBy,omitempty"`
+	DomainResource `bson:",inline"`
+	Name           string                          `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                          `bson:"status,omitempty" json:"status,omitempty"`
+	Kind           string                          `bson:"kind,omitempty" json:"kind,omitempty"`
+	Publisher      string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []NamingSystemContactComponent  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Responsible    string                          `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Date           *FHIRDateTime                   `bson:"date,omitempty" json:"date,omitempty"`
+	Type           *CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	Description    string                          `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext     []CodeableConcept               `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Usage          string                          `bson:"usage,omitempty" json:"usage,omitempty"`
+	UniqueId       []NamingSystemUniqueIdComponent `bson:"uniqueId,omitempty" json:"uniqueId,omitempty"`
+	ReplacedBy     *Reference                      `bson:"replacedBy,omitempty" json:"replacedBy,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -55,6 +55,23 @@ func (resource *NamingSystem) MarshalJSON() ([]byte, error) {
 		NamingSystem: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "namingSystem" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type namingSystem NamingSystem
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *NamingSystem) UnmarshalJSON(data []byte) (err error) {
+	x2 := namingSystem{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = NamingSystem(x2)
+	}
+	return
 }
 
 type NamingSystemContactComponent struct {

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type NutritionOrder struct {
-	Id                     string                                 `json:"id" bson:"_id"`
+	DomainResource         `bson:",inline"`
 	Patient                *Reference                             `bson:"patient,omitempty" json:"patient,omitempty"`
 	Orderer                *Reference                             `bson:"orderer,omitempty" json:"orderer,omitempty"`
 	Identifier             []Identifier                           `bson:"identifier,omitempty" json:"identifier,omitempty"`
@@ -54,6 +54,23 @@ func (resource *NutritionOrder) MarshalJSON() ([]byte, error) {
 		NutritionOrder: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "nutritionOrder" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type nutritionOrder NutritionOrder
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *NutritionOrder) UnmarshalJSON(data []byte) (err error) {
+	x2 := nutritionOrder{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = NutritionOrder(x2)
+	}
+	return
 }
 
 type NutritionOrderOralDietComponent struct {

--- a/models/operationdefinition.go
+++ b/models/operationdefinition.go
@@ -29,26 +29,26 @@ package models
 import "encoding/json"
 
 type OperationDefinition struct {
-	Id           string                                  `json:"id" bson:"_id"`
-	Url          string                                  `bson:"url,omitempty" json:"url,omitempty"`
-	Version      string                                  `bson:"version,omitempty" json:"version,omitempty"`
-	Name         string                                  `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                                  `bson:"status,omitempty" json:"status,omitempty"`
-	Kind         string                                  `bson:"kind,omitempty" json:"kind,omitempty"`
-	Experimental *bool                                   `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                                  `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []OperationDefinitionContactComponent   `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                           `bson:"date,omitempty" json:"date,omitempty"`
-	Description  string                                  `bson:"description,omitempty" json:"description,omitempty"`
-	Requirements string                                  `bson:"requirements,omitempty" json:"requirements,omitempty"`
-	Idempotent   *bool                                   `bson:"idempotent,omitempty" json:"idempotent,omitempty"`
-	Code         string                                  `bson:"code,omitempty" json:"code,omitempty"`
-	Notes        string                                  `bson:"notes,omitempty" json:"notes,omitempty"`
-	Base         *Reference                              `bson:"base,omitempty" json:"base,omitempty"`
-	System       *bool                                   `bson:"system,omitempty" json:"system,omitempty"`
-	Type         []string                                `bson:"type,omitempty" json:"type,omitempty"`
-	Instance     *bool                                   `bson:"instance,omitempty" json:"instance,omitempty"`
-	Parameter    []OperationDefinitionParameterComponent `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                                  `bson:"url,omitempty" json:"url,omitempty"`
+	Version        string                                  `bson:"version,omitempty" json:"version,omitempty"`
+	Name           string                                  `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                                  `bson:"status,omitempty" json:"status,omitempty"`
+	Kind           string                                  `bson:"kind,omitempty" json:"kind,omitempty"`
+	Experimental   *bool                                   `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                                  `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []OperationDefinitionContactComponent   `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                           `bson:"date,omitempty" json:"date,omitempty"`
+	Description    string                                  `bson:"description,omitempty" json:"description,omitempty"`
+	Requirements   string                                  `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Idempotent     *bool                                   `bson:"idempotent,omitempty" json:"idempotent,omitempty"`
+	Code           string                                  `bson:"code,omitempty" json:"code,omitempty"`
+	Notes          string                                  `bson:"notes,omitempty" json:"notes,omitempty"`
+	Base           *Reference                              `bson:"base,omitempty" json:"base,omitempty"`
+	System         *bool                                   `bson:"system,omitempty" json:"system,omitempty"`
+	Type           []string                                `bson:"type,omitempty" json:"type,omitempty"`
+	Instance       *bool                                   `bson:"instance,omitempty" json:"instance,omitempty"`
+	Parameter      []OperationDefinitionParameterComponent `bson:"parameter,omitempty" json:"parameter,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -61,6 +61,23 @@ func (resource *OperationDefinition) MarshalJSON() ([]byte, error) {
 		OperationDefinition: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "operationDefinition" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type operationDefinition OperationDefinition
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *OperationDefinition) UnmarshalJSON(data []byte) (err error) {
+	x2 := operationDefinition{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = OperationDefinition(x2)
+	}
+	return
 }
 
 type OperationDefinitionContactComponent struct {

--- a/models/order.go
+++ b/models/order.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Order struct {
-	Id                    string              `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Identifier            []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Date                  *FHIRDateTime       `bson:"date,omitempty" json:"date,omitempty"`
 	Subject               *Reference          `bson:"subject,omitempty" json:"subject,omitempty"`
@@ -51,6 +51,23 @@ func (resource *Order) MarshalJSON() ([]byte, error) {
 		Order:        *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "order" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type order Order
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Order) UnmarshalJSON(data []byte) (err error) {
+	x2 := order{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Order(x2)
+	}
+	return
 }
 
 type OrderWhenComponent struct {

--- a/models/orderresponse.go
+++ b/models/orderresponse.go
@@ -29,14 +29,14 @@ package models
 import "encoding/json"
 
 type OrderResponse struct {
-	Id          string        `json:"id" bson:"_id"`
-	Identifier  []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Request     *Reference    `bson:"request,omitempty" json:"request,omitempty"`
-	Date        *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
-	Who         *Reference    `bson:"who,omitempty" json:"who,omitempty"`
-	OrderStatus string        `bson:"orderStatus,omitempty" json:"orderStatus,omitempty"`
-	Description string        `bson:"description,omitempty" json:"description,omitempty"`
-	Fulfillment []Reference   `bson:"fulfillment,omitempty" json:"fulfillment,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Request        *Reference    `bson:"request,omitempty" json:"request,omitempty"`
+	Date           *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
+	Who            *Reference    `bson:"who,omitempty" json:"who,omitempty"`
+	OrderStatus    string        `bson:"orderStatus,omitempty" json:"orderStatus,omitempty"`
+	Description    string        `bson:"description,omitempty" json:"description,omitempty"`
+	Fulfillment    []Reference   `bson:"fulfillment,omitempty" json:"fulfillment,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -49,4 +49,21 @@ func (resource *OrderResponse) MarshalJSON() ([]byte, error) {
 		OrderResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "orderResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type orderResponse OrderResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *OrderResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := orderResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = OrderResponse(x2)
+	}
+	return
 }

--- a/models/organization.go
+++ b/models/organization.go
@@ -29,15 +29,15 @@ package models
 import "encoding/json"
 
 type Organization struct {
-	Id         string                         `json:"id" bson:"_id"`
-	Identifier []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Active     *bool                          `bson:"active,omitempty" json:"active,omitempty"`
-	Type       *CodeableConcept               `bson:"type,omitempty" json:"type,omitempty"`
-	Name       string                         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom    []ContactPoint                 `bson:"telecom,omitempty" json:"telecom,omitempty"`
-	Address    []Address                      `bson:"address,omitempty" json:"address,omitempty"`
-	PartOf     *Reference                     `bson:"partOf,omitempty" json:"partOf,omitempty"`
-	Contact    []OrganizationContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active         *bool                          `bson:"active,omitempty" json:"active,omitempty"`
+	Type           *CodeableConcept               `bson:"type,omitempty" json:"type,omitempty"`
+	Name           string                         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom        []ContactPoint                 `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address        []Address                      `bson:"address,omitempty" json:"address,omitempty"`
+	PartOf         *Reference                     `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Contact        []OrganizationContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -50,6 +50,23 @@ func (resource *Organization) MarshalJSON() ([]byte, error) {
 		Organization: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "organization" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type organization Organization
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Organization) UnmarshalJSON(data []byte) (err error) {
+	x2 := organization{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Organization(x2)
+	}
+	return
 }
 
 type OrganizationContactComponent struct {

--- a/models/parameters.go
+++ b/models/parameters.go
@@ -28,44 +28,34 @@ package models
 
 import "encoding/json"
 
-type OperationOutcome struct {
-	DomainResource `bson:",inline"`
-	Issue          []OperationOutcomeIssueComponent `bson:"issue,omitempty" json:"issue,omitempty"`
+type Parameters struct {
+	Resource  `bson:",inline"`
+	Parameter []ParametersParameterComponent `bson:"parameter,omitempty" json:"parameter,omitempty"`
 }
 
-// Custom marshaller to add the resourceType property, as required by the specification
-func (resource *OperationOutcome) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		OperationOutcome
-	}{
-		ResourceType:     "OperationOutcome",
-		OperationOutcome: *resource,
-	}
-	return json.Marshal(x)
+type ParametersParameterComponent struct {
+	Name                 string                         `bson:"name,omitempty" json:"name,omitempty"`
+	ValueString          string                         `bson:"valueString,omitempty" json:"valueString,omitempty"`
+	ValueInteger         *int32                         `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
+	ValueDateTime        *FHIRDateTime                  `bson:"valueDateTime,omitempty" json:"valueDateTime,omitempty"`
+	ValueBoolean         *bool                          `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
+	ValueCodeableConcept *CodeableConcept               `bson:"valueCodeableConcept,omitempty" json:"valueCodeableConcept,omitempty"`
+	ValueRange           *Range                         `bson:"valueRange,omitempty" json:"valueRange,omitempty"`
+	Resource             interface{}                    `bson:"resource,omitempty" json:"resource,omitempty"`
+	Part                 []ParametersParameterComponent `bson:"part,omitempty" json:"part,omitempty"`
 }
 
-// The "operationOutcome" sub-type is needed to avoid infinite recursion in UnmarshalJSON
-type operationOutcome OperationOutcome
+// The "parametersParameterComponent" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type parametersParameterComponent ParametersParameterComponent
 
 // Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
-func (x *OperationOutcome) UnmarshalJSON(data []byte) (err error) {
-	x2 := operationOutcome{}
+func (x *ParametersParameterComponent) UnmarshalJSON(data []byte) (err error) {
+	x2 := parametersParameterComponent{}
 	if err = json.Unmarshal(data, &x2); err == nil {
-		if x2.Contained != nil {
-			for i := range x2.Contained {
-				x2.Contained[i] = MapToResource(x2.Contained[i], true)
-			}
+		if x2.Resource != nil {
+			x2.Resource = MapToResource(x2.Resource, true)
 		}
-		*x = OperationOutcome(x2)
+		*x = ParametersParameterComponent(x2)
 	}
 	return
-}
-
-type OperationOutcomeIssueComponent struct {
-	Severity    string           `bson:"severity,omitempty" json:"severity,omitempty"`
-	Code        string           `bson:"code,omitempty" json:"code,omitempty"`
-	Details     *CodeableConcept `bson:"details,omitempty" json:"details,omitempty"`
-	Diagnostics string           `bson:"diagnostics,omitempty" json:"diagnostics,omitempty"`
-	Location    []string         `bson:"location,omitempty" json:"location,omitempty"`
 }

--- a/models/patient.go
+++ b/models/patient.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Patient struct {
-	Id                   string                          `json:"id" bson:"_id"`
+	DomainResource       `bson:",inline"`
 	Identifier           []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Active               *bool                           `bson:"active,omitempty" json:"active,omitempty"`
 	Name                 []HumanName                     `bson:"name,omitempty" json:"name,omitempty"`
@@ -61,6 +61,23 @@ func (resource *Patient) MarshalJSON() ([]byte, error) {
 		Patient:      *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "patient" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type patient Patient
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Patient) UnmarshalJSON(data []byte) (err error) {
+	x2 := patient{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Patient(x2)
+	}
+	return
 }
 
 type PatientContactComponent struct {

--- a/models/paymentnotice.go
+++ b/models/paymentnotice.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type PaymentNotice struct {
-	Id              string        `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Identifier      []Identifier  `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Ruleset         *Coding       `bson:"ruleset,omitempty" json:"ruleset,omitempty"`
 	OriginalRuleset *Coding       `bson:"originalRuleset,omitempty" json:"originalRuleset,omitempty"`
@@ -52,4 +52,21 @@ func (resource *PaymentNotice) MarshalJSON() ([]byte, error) {
 		PaymentNotice: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "paymentNotice" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type paymentNotice PaymentNotice
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *PaymentNotice) UnmarshalJSON(data []byte) (err error) {
+	x2 := paymentNotice{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = PaymentNotice(x2)
+	}
+	return
 }

--- a/models/paymentreconciliation.go
+++ b/models/paymentreconciliation.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type PaymentReconciliation struct {
-	Id                  string                                  `json:"id" bson:"_id"`
+	DomainResource      `bson:",inline"`
 	Identifier          []Identifier                            `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Request             *Reference                              `bson:"request,omitempty" json:"request,omitempty"`
 	Outcome             string                                  `bson:"outcome,omitempty" json:"outcome,omitempty"`
@@ -57,6 +57,23 @@ func (resource *PaymentReconciliation) MarshalJSON() ([]byte, error) {
 		PaymentReconciliation: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "paymentReconciliation" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type paymentReconciliation PaymentReconciliation
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *PaymentReconciliation) UnmarshalJSON(data []byte) (err error) {
+	x2 := paymentReconciliation{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = PaymentReconciliation(x2)
+	}
+	return
 }
 
 type PaymentReconciliationDetailsComponent struct {

--- a/models/practitioner.go
+++ b/models/practitioner.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Practitioner struct {
-	Id               string                                  `json:"id" bson:"_id"`
+	DomainResource   `bson:",inline"`
 	Identifier       []Identifier                            `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Active           *bool                                   `bson:"active,omitempty" json:"active,omitempty"`
 	Name             *HumanName                              `bson:"name,omitempty" json:"name,omitempty"`
@@ -53,6 +53,23 @@ func (resource *Practitioner) MarshalJSON() ([]byte, error) {
 		Practitioner: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "practitioner" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type practitioner Practitioner
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Practitioner) UnmarshalJSON(data []byte) (err error) {
+	x2 := practitioner{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Practitioner(x2)
+	}
+	return
 }
 
 type PractitionerPractitionerRoleComponent struct {

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Procedure struct {
-	Id                    string                          `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Identifier            []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Subject               *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
 	Status                string                          `bson:"status,omitempty" json:"status,omitempty"`
@@ -65,6 +65,23 @@ func (resource *Procedure) MarshalJSON() ([]byte, error) {
 		Procedure:    *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "procedure" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type procedure Procedure
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Procedure) UnmarshalJSON(data []byte) (err error) {
+	x2 := procedure{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Procedure(x2)
+	}
+	return
 }
 
 type ProcedurePerformerComponent struct {

--- a/models/procedurerequest.go
+++ b/models/procedurerequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ProcedureRequest struct {
-	Id                      string            `json:"id" bson:"_id"`
+	DomainResource          `bson:",inline"`
 	Identifier              []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Subject                 *Reference        `bson:"subject,omitempty" json:"subject,omitempty"`
 	Code                    *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
@@ -60,4 +60,21 @@ func (resource *ProcedureRequest) MarshalJSON() ([]byte, error) {
 		ProcedureRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "procedureRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type procedureRequest ProcedureRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ProcedureRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := procedureRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ProcedureRequest(x2)
+	}
+	return
 }

--- a/models/processrequest.go
+++ b/models/processrequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ProcessRequest struct {
-	Id              string                         `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Action          string                         `bson:"action,omitempty" json:"action,omitempty"`
 	Identifier      []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Ruleset         *Coding                        `bson:"ruleset,omitempty" json:"ruleset,omitempty"`
@@ -58,6 +58,23 @@ func (resource *ProcessRequest) MarshalJSON() ([]byte, error) {
 		ProcessRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "processRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type processRequest ProcessRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ProcessRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := processRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ProcessRequest(x2)
+	}
+	return
 }
 
 type ProcessRequestItemsComponent struct {

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ProcessResponse struct {
-	Id                  string                          `json:"id" bson:"_id"`
+	DomainResource      `bson:",inline"`
 	Identifier          []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Request             *Reference                      `bson:"request,omitempty" json:"request,omitempty"`
 	Outcome             *Coding                         `bson:"outcome,omitempty" json:"outcome,omitempty"`
@@ -55,6 +55,23 @@ func (resource *ProcessResponse) MarshalJSON() ([]byte, error) {
 		ProcessResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "processResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type processResponse ProcessResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ProcessResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := processResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ProcessResponse(x2)
+	}
+	return
 }
 
 type ProcessResponseNotesComponent struct {

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -29,17 +29,17 @@ package models
 import "encoding/json"
 
 type Provenance struct {
-	Id        string                      `json:"id" bson:"_id"`
-	Target    []Reference                 `bson:"target,omitempty" json:"target,omitempty"`
-	Period    *Period                     `bson:"period,omitempty" json:"period,omitempty"`
-	Recorded  *FHIRDateTime               `bson:"recorded,omitempty" json:"recorded,omitempty"`
-	Reason    []CodeableConcept           `bson:"reason,omitempty" json:"reason,omitempty"`
-	Activity  *CodeableConcept            `bson:"activity,omitempty" json:"activity,omitempty"`
-	Location  *Reference                  `bson:"location,omitempty" json:"location,omitempty"`
-	Policy    []string                    `bson:"policy,omitempty" json:"policy,omitempty"`
-	Agent     []ProvenanceAgentComponent  `bson:"agent,omitempty" json:"agent,omitempty"`
-	Entity    []ProvenanceEntityComponent `bson:"entity,omitempty" json:"entity,omitempty"`
-	Signature []Signature                 `bson:"signature,omitempty" json:"signature,omitempty"`
+	DomainResource `bson:",inline"`
+	Target         []Reference                 `bson:"target,omitempty" json:"target,omitempty"`
+	Period         *Period                     `bson:"period,omitempty" json:"period,omitempty"`
+	Recorded       *FHIRDateTime               `bson:"recorded,omitempty" json:"recorded,omitempty"`
+	Reason         []CodeableConcept           `bson:"reason,omitempty" json:"reason,omitempty"`
+	Activity       *CodeableConcept            `bson:"activity,omitempty" json:"activity,omitempty"`
+	Location       *Reference                  `bson:"location,omitempty" json:"location,omitempty"`
+	Policy         []string                    `bson:"policy,omitempty" json:"policy,omitempty"`
+	Agent          []ProvenanceAgentComponent  `bson:"agent,omitempty" json:"agent,omitempty"`
+	Entity         []ProvenanceEntityComponent `bson:"entity,omitempty" json:"entity,omitempty"`
+	Signature      []Signature                 `bson:"signature,omitempty" json:"signature,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -52,6 +52,23 @@ func (resource *Provenance) MarshalJSON() ([]byte, error) {
 		Provenance:   *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "provenance" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type provenance Provenance
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Provenance) UnmarshalJSON(data []byte) (err error) {
+	x2 := provenance{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Provenance(x2)
+	}
+	return
 }
 
 type ProvenanceAgentComponent struct {

--- a/models/questionnaire.go
+++ b/models/questionnaire.go
@@ -29,15 +29,15 @@ package models
 import "encoding/json"
 
 type Questionnaire struct {
-	Id          string                       `json:"id" bson:"_id"`
-	Identifier  []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Version     string                       `bson:"version,omitempty" json:"version,omitempty"`
-	Status      string                       `bson:"status,omitempty" json:"status,omitempty"`
-	Date        *FHIRDateTime                `bson:"date,omitempty" json:"date,omitempty"`
-	Publisher   string                       `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Telecom     []ContactPoint               `bson:"telecom,omitempty" json:"telecom,omitempty"`
-	SubjectType []string                     `bson:"subjectType,omitempty" json:"subjectType,omitempty"`
-	Group       *QuestionnaireGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version        string                       `bson:"version,omitempty" json:"version,omitempty"`
+	Status         string                       `bson:"status,omitempty" json:"status,omitempty"`
+	Date           *FHIRDateTime                `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher      string                       `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Telecom        []ContactPoint               `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	SubjectType    []string                     `bson:"subjectType,omitempty" json:"subjectType,omitempty"`
+	Group          *QuestionnaireGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -50,6 +50,23 @@ func (resource *Questionnaire) MarshalJSON() ([]byte, error) {
 		Questionnaire: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "questionnaire" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type questionnaire Questionnaire
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Questionnaire) UnmarshalJSON(data []byte) (err error) {
+	x2 := questionnaire{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Questionnaire(x2)
+	}
+	return
 }
 
 type QuestionnaireGroupComponent struct {

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -29,16 +29,16 @@ package models
 import "encoding/json"
 
 type QuestionnaireResponse struct {
-	Id            string                               `json:"id" bson:"_id"`
-	Identifier    *Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Questionnaire *Reference                           `bson:"questionnaire,omitempty" json:"questionnaire,omitempty"`
-	Status        string                               `bson:"status,omitempty" json:"status,omitempty"`
-	Subject       *Reference                           `bson:"subject,omitempty" json:"subject,omitempty"`
-	Author        *Reference                           `bson:"author,omitempty" json:"author,omitempty"`
-	Authored      *FHIRDateTime                        `bson:"authored,omitempty" json:"authored,omitempty"`
-	Source        *Reference                           `bson:"source,omitempty" json:"source,omitempty"`
-	Encounter     *Reference                           `bson:"encounter,omitempty" json:"encounter,omitempty"`
-	Group         *QuestionnaireResponseGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     *Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Questionnaire  *Reference                           `bson:"questionnaire,omitempty" json:"questionnaire,omitempty"`
+	Status         string                               `bson:"status,omitempty" json:"status,omitempty"`
+	Subject        *Reference                           `bson:"subject,omitempty" json:"subject,omitempty"`
+	Author         *Reference                           `bson:"author,omitempty" json:"author,omitempty"`
+	Authored       *FHIRDateTime                        `bson:"authored,omitempty" json:"authored,omitempty"`
+	Source         *Reference                           `bson:"source,omitempty" json:"source,omitempty"`
+	Encounter      *Reference                           `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Group          *QuestionnaireResponseGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -51,6 +51,23 @@ func (resource *QuestionnaireResponse) MarshalJSON() ([]byte, error) {
 		QuestionnaireResponse: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "questionnaireResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type questionnaireResponse QuestionnaireResponse
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *QuestionnaireResponse) UnmarshalJSON(data []byte) (err error) {
+	x2 := questionnaireResponse{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = QuestionnaireResponse(x2)
+	}
+	return
 }
 
 type QuestionnaireResponseGroupComponent struct {

--- a/models/referralrequest.go
+++ b/models/referralrequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type ReferralRequest struct {
-	Id                    string            `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Status                string            `bson:"status,omitempty" json:"status,omitempty"`
 	Identifier            []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Date                  *FHIRDateTime     `bson:"date,omitempty" json:"date,omitempty"`
@@ -58,4 +58,21 @@ func (resource *ReferralRequest) MarshalJSON() ([]byte, error) {
 		ReferralRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "referralRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type referralRequest ReferralRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ReferralRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := referralRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ReferralRequest(x2)
+	}
+	return
 }

--- a/models/relatedperson.go
+++ b/models/relatedperson.go
@@ -29,17 +29,17 @@ package models
 import "encoding/json"
 
 type RelatedPerson struct {
-	Id           string           `json:"id" bson:"_id"`
-	Identifier   []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Patient      *Reference       `bson:"patient,omitempty" json:"patient,omitempty"`
-	Relationship *CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
-	Name         *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom      []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
-	Gender       string           `bson:"gender,omitempty" json:"gender,omitempty"`
-	BirthDate    *FHIRDateTime    `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
-	Address      []Address        `bson:"address,omitempty" json:"address,omitempty"`
-	Photo        []Attachment     `bson:"photo,omitempty" json:"photo,omitempty"`
-	Period       *Period          `bson:"period,omitempty" json:"period,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Patient        *Reference       `bson:"patient,omitempty" json:"patient,omitempty"`
+	Relationship   *CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Name           *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom        []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Gender         string           `bson:"gender,omitempty" json:"gender,omitempty"`
+	BirthDate      *FHIRDateTime    `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
+	Address        []Address        `bson:"address,omitempty" json:"address,omitempty"`
+	Photo          []Attachment     `bson:"photo,omitempty" json:"photo,omitempty"`
+	Period         *Period          `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -52,4 +52,21 @@ func (resource *RelatedPerson) MarshalJSON() ([]byte, error) {
 		RelatedPerson: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "relatedPerson" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type relatedPerson RelatedPerson
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *RelatedPerson) UnmarshalJSON(data []byte) (err error) {
+	x2 := relatedPerson{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = RelatedPerson(x2)
+	}
+	return
 }

--- a/models/resource.go
+++ b/models/resource.go
@@ -26,7 +26,9 @@
 
 package models
 
-type Element struct {
-	Id        string      `bson:"_id,omitempty" json:"id,omitempty"`
-	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+type Resource struct {
+	Id            string `bson:"_id,omitempty" json:"id,omitempty"`
+	Meta          *Meta  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules string `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language      string `bson:"language,omitempty" json:"language,omitempty"`
 }

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -29,17 +29,17 @@ package models
 import "encoding/json"
 
 type RiskAssessment struct {
-	Id         string                              `json:"id" bson:"_id"`
-	Subject    *Reference                          `bson:"subject,omitempty" json:"subject,omitempty"`
-	Date       *FHIRDateTime                       `bson:"date,omitempty" json:"date,omitempty"`
-	Condition  *Reference                          `bson:"condition,omitempty" json:"condition,omitempty"`
-	Encounter  *Reference                          `bson:"encounter,omitempty" json:"encounter,omitempty"`
-	Performer  *Reference                          `bson:"performer,omitempty" json:"performer,omitempty"`
-	Identifier *Identifier                         `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Method     *CodeableConcept                    `bson:"method,omitempty" json:"method,omitempty"`
-	Basis      []Reference                         `bson:"basis,omitempty" json:"basis,omitempty"`
-	Prediction []RiskAssessmentPredictionComponent `bson:"prediction,omitempty" json:"prediction,omitempty"`
-	Mitigation string                              `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
+	DomainResource `bson:",inline"`
+	Subject        *Reference                          `bson:"subject,omitempty" json:"subject,omitempty"`
+	Date           *FHIRDateTime                       `bson:"date,omitempty" json:"date,omitempty"`
+	Condition      *Reference                          `bson:"condition,omitempty" json:"condition,omitempty"`
+	Encounter      *Reference                          `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Performer      *Reference                          `bson:"performer,omitempty" json:"performer,omitempty"`
+	Identifier     *Identifier                         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Method         *CodeableConcept                    `bson:"method,omitempty" json:"method,omitempty"`
+	Basis          []Reference                         `bson:"basis,omitempty" json:"basis,omitempty"`
+	Prediction     []RiskAssessmentPredictionComponent `bson:"prediction,omitempty" json:"prediction,omitempty"`
+	Mitigation     string                              `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -52,6 +52,23 @@ func (resource *RiskAssessment) MarshalJSON() ([]byte, error) {
 		RiskAssessment: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "riskAssessment" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type riskAssessment RiskAssessment
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *RiskAssessment) UnmarshalJSON(data []byte) (err error) {
+	x2 := riskAssessment{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = RiskAssessment(x2)
+	}
+	return
 }
 
 type RiskAssessmentPredictionComponent struct {

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type Schedule struct {
-	Id              string            `json:"id" bson:"_id"`
+	DomainResource  `bson:",inline"`
 	Identifier      []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Type            []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 	Actor           *Reference        `bson:"actor,omitempty" json:"actor,omitempty"`
@@ -47,4 +47,21 @@ func (resource *Schedule) MarshalJSON() ([]byte, error) {
 		Schedule:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "schedule" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type schedule Schedule
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Schedule) UnmarshalJSON(data []byte) (err error) {
+	x2 := schedule{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Schedule(x2)
+	}
+	return
 }

--- a/models/searchparameter.go
+++ b/models/searchparameter.go
@@ -29,22 +29,22 @@ package models
 import "encoding/json"
 
 type SearchParameter struct {
-	Id           string                            `json:"id" bson:"_id"`
-	Url          string                            `bson:"url,omitempty" json:"url,omitempty"`
-	Name         string                            `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                            `bson:"status,omitempty" json:"status,omitempty"`
-	Experimental *bool                             `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                            `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []SearchParameterContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                     `bson:"date,omitempty" json:"date,omitempty"`
-	Requirements string                            `bson:"requirements,omitempty" json:"requirements,omitempty"`
-	Code         string                            `bson:"code,omitempty" json:"code,omitempty"`
-	Base         string                            `bson:"base,omitempty" json:"base,omitempty"`
-	Type         string                            `bson:"type,omitempty" json:"type,omitempty"`
-	Description  string                            `bson:"description,omitempty" json:"description,omitempty"`
-	Xpath        string                            `bson:"xpath,omitempty" json:"xpath,omitempty"`
-	XpathUsage   string                            `bson:"xpathUsage,omitempty" json:"xpathUsage,omitempty"`
-	Target       []string                          `bson:"target,omitempty" json:"target,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                            `bson:"url,omitempty" json:"url,omitempty"`
+	Name           string                            `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                            `bson:"status,omitempty" json:"status,omitempty"`
+	Experimental   *bool                             `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []SearchParameterContactComponent `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                     `bson:"date,omitempty" json:"date,omitempty"`
+	Requirements   string                            `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Code           string                            `bson:"code,omitempty" json:"code,omitempty"`
+	Base           string                            `bson:"base,omitempty" json:"base,omitempty"`
+	Type           string                            `bson:"type,omitempty" json:"type,omitempty"`
+	Description    string                            `bson:"description,omitempty" json:"description,omitempty"`
+	Xpath          string                            `bson:"xpath,omitempty" json:"xpath,omitempty"`
+	XpathUsage     string                            `bson:"xpathUsage,omitempty" json:"xpathUsage,omitempty"`
+	Target         []string                          `bson:"target,omitempty" json:"target,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -57,6 +57,23 @@ func (resource *SearchParameter) MarshalJSON() ([]byte, error) {
 		SearchParameter: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "searchParameter" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type searchParameter SearchParameter
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *SearchParameter) UnmarshalJSON(data []byte) (err error) {
+	x2 := searchParameter{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = SearchParameter(x2)
+	}
+	return
 }
 
 type SearchParameterContactComponent struct {

--- a/models/slot.go
+++ b/models/slot.go
@@ -29,15 +29,15 @@ package models
 import "encoding/json"
 
 type Slot struct {
-	Id           string           `json:"id" bson:"_id"`
-	Identifier   []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Type         *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Schedule     *Reference       `bson:"schedule,omitempty" json:"schedule,omitempty"`
-	FreeBusyType string           `bson:"freeBusyType,omitempty" json:"freeBusyType,omitempty"`
-	Start        *FHIRDateTime    `bson:"start,omitempty" json:"start,omitempty"`
-	End          *FHIRDateTime    `bson:"end,omitempty" json:"end,omitempty"`
-	Overbooked   *bool            `bson:"overbooked,omitempty" json:"overbooked,omitempty"`
-	Comment      string           `bson:"comment,omitempty" json:"comment,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type           *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Schedule       *Reference       `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	FreeBusyType   string           `bson:"freeBusyType,omitempty" json:"freeBusyType,omitempty"`
+	Start          *FHIRDateTime    `bson:"start,omitempty" json:"start,omitempty"`
+	End            *FHIRDateTime    `bson:"end,omitempty" json:"end,omitempty"`
+	Overbooked     *bool            `bson:"overbooked,omitempty" json:"overbooked,omitempty"`
+	Comment        string           `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -50,4 +50,21 @@ func (resource *Slot) MarshalJSON() ([]byte, error) {
 		Slot:         *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "slot" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type slot Slot
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Slot) UnmarshalJSON(data []byte) (err error) {
+	x2 := slot{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Slot(x2)
+	}
+	return
 }

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -29,15 +29,15 @@ package models
 import "encoding/json"
 
 type Subscription struct {
-	Id       string                        `json:"id" bson:"_id"`
-	Criteria string                        `bson:"criteria,omitempty" json:"criteria,omitempty"`
-	Contact  []ContactPoint                `bson:"contact,omitempty" json:"contact,omitempty"`
-	Reason   string                        `bson:"reason,omitempty" json:"reason,omitempty"`
-	Status   string                        `bson:"status,omitempty" json:"status,omitempty"`
-	Error    string                        `bson:"error,omitempty" json:"error,omitempty"`
-	Channel  *SubscriptionChannelComponent `bson:"channel,omitempty" json:"channel,omitempty"`
-	End      *FHIRDateTime                 `bson:"end,omitempty" json:"end,omitempty"`
-	Tag      []Coding                      `bson:"tag,omitempty" json:"tag,omitempty"`
+	DomainResource `bson:",inline"`
+	Criteria       string                        `bson:"criteria,omitempty" json:"criteria,omitempty"`
+	Contact        []ContactPoint                `bson:"contact,omitempty" json:"contact,omitempty"`
+	Reason         string                        `bson:"reason,omitempty" json:"reason,omitempty"`
+	Status         string                        `bson:"status,omitempty" json:"status,omitempty"`
+	Error          string                        `bson:"error,omitempty" json:"error,omitempty"`
+	Channel        *SubscriptionChannelComponent `bson:"channel,omitempty" json:"channel,omitempty"`
+	End            *FHIRDateTime                 `bson:"end,omitempty" json:"end,omitempty"`
+	Tag            []Coding                      `bson:"tag,omitempty" json:"tag,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -50,6 +50,23 @@ func (resource *Subscription) MarshalJSON() ([]byte, error) {
 		Subscription: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "subscription" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type subscription Subscription
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *Subscription) UnmarshalJSON(data []byte) (err error) {
+	x2 := subscription{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = Subscription(x2)
+	}
+	return
 }
 
 type SubscriptionChannelComponent struct {

--- a/models/supplydelivery.go
+++ b/models/supplydelivery.go
@@ -29,18 +29,18 @@ package models
 import "encoding/json"
 
 type SupplyDelivery struct {
-	Id           string           `json:"id" bson:"_id"`
-	Identifier   *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Status       string           `bson:"status,omitempty" json:"status,omitempty"`
-	Patient      *Reference       `bson:"patient,omitempty" json:"patient,omitempty"`
-	Type         *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Quantity     *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
-	SuppliedItem *Reference       `bson:"suppliedItem,omitempty" json:"suppliedItem,omitempty"`
-	Supplier     *Reference       `bson:"supplier,omitempty" json:"supplier,omitempty"`
-	WhenPrepared *Period          `bson:"whenPrepared,omitempty" json:"whenPrepared,omitempty"`
-	Time         *FHIRDateTime    `bson:"time,omitempty" json:"time,omitempty"`
-	Destination  *Reference       `bson:"destination,omitempty" json:"destination,omitempty"`
-	Receiver     []Reference      `bson:"receiver,omitempty" json:"receiver,omitempty"`
+	DomainResource `bson:",inline"`
+	Identifier     *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status         string           `bson:"status,omitempty" json:"status,omitempty"`
+	Patient        *Reference       `bson:"patient,omitempty" json:"patient,omitempty"`
+	Type           *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Quantity       *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	SuppliedItem   *Reference       `bson:"suppliedItem,omitempty" json:"suppliedItem,omitempty"`
+	Supplier       *Reference       `bson:"supplier,omitempty" json:"supplier,omitempty"`
+	WhenPrepared   *Period          `bson:"whenPrepared,omitempty" json:"whenPrepared,omitempty"`
+	Time           *FHIRDateTime    `bson:"time,omitempty" json:"time,omitempty"`
+	Destination    *Reference       `bson:"destination,omitempty" json:"destination,omitempty"`
+	Receiver       []Reference      `bson:"receiver,omitempty" json:"receiver,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -53,4 +53,21 @@ func (resource *SupplyDelivery) MarshalJSON() ([]byte, error) {
 		SupplyDelivery: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "supplyDelivery" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type supplyDelivery SupplyDelivery
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *SupplyDelivery) UnmarshalJSON(data []byte) (err error) {
+	x2 := supplyDelivery{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = SupplyDelivery(x2)
+	}
+	return
 }

--- a/models/supplyrequest.go
+++ b/models/supplyrequest.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type SupplyRequest struct {
-	Id                    string                      `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Patient               *Reference                  `bson:"patient,omitempty" json:"patient,omitempty"`
 	Source                *Reference                  `bson:"source,omitempty" json:"source,omitempty"`
 	Date                  *FHIRDateTime               `bson:"date,omitempty" json:"date,omitempty"`
@@ -53,6 +53,23 @@ func (resource *SupplyRequest) MarshalJSON() ([]byte, error) {
 		SupplyRequest: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "supplyRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type supplyRequest SupplyRequest
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *SupplyRequest) UnmarshalJSON(data []byte) (err error) {
+	x2 := supplyRequest{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = SupplyRequest(x2)
+	}
+	return
 }
 
 type SupplyRequestWhenComponent struct {

--- a/models/testscript.go
+++ b/models/testscript.go
@@ -29,28 +29,28 @@ package models
 import "encoding/json"
 
 type TestScript struct {
-	Id           string                        `json:"id" bson:"_id"`
-	Url          string                        `bson:"url,omitempty" json:"url,omitempty"`
-	Version      string                        `bson:"version,omitempty" json:"version,omitempty"`
-	Name         string                        `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                        `bson:"status,omitempty" json:"status,omitempty"`
-	Identifier   *Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Experimental *bool                         `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []TestScriptContactComponent  `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                 `bson:"date,omitempty" json:"date,omitempty"`
-	Description  string                        `bson:"description,omitempty" json:"description,omitempty"`
-	UseContext   []CodeableConcept             `bson:"useContext,omitempty" json:"useContext,omitempty"`
-	Requirements string                        `bson:"requirements,omitempty" json:"requirements,omitempty"`
-	Copyright    string                        `bson:"copyright,omitempty" json:"copyright,omitempty"`
-	Metadata     *TestScriptMetadataComponent  `bson:"metadata,omitempty" json:"metadata,omitempty"`
-	Multiserver  *bool                         `bson:"multiserver,omitempty" json:"multiserver,omitempty"`
-	Fixture      []TestScriptFixtureComponent  `bson:"fixture,omitempty" json:"fixture,omitempty"`
-	Profile      []Reference                   `bson:"profile,omitempty" json:"profile,omitempty"`
-	Variable     []TestScriptVariableComponent `bson:"variable,omitempty" json:"variable,omitempty"`
-	Setup        *TestScriptSetupComponent     `bson:"setup,omitempty" json:"setup,omitempty"`
-	Test         []TestScriptTestComponent     `bson:"test,omitempty" json:"test,omitempty"`
-	Teardown     *TestScriptTeardownComponent  `bson:"teardown,omitempty" json:"teardown,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                        `bson:"url,omitempty" json:"url,omitempty"`
+	Version        string                        `bson:"version,omitempty" json:"version,omitempty"`
+	Name           string                        `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                        `bson:"status,omitempty" json:"status,omitempty"`
+	Identifier     *Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Experimental   *bool                         `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []TestScriptContactComponent  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                 `bson:"date,omitempty" json:"date,omitempty"`
+	Description    string                        `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext     []CodeableConcept             `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Requirements   string                        `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Copyright      string                        `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Metadata       *TestScriptMetadataComponent  `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Multiserver    *bool                         `bson:"multiserver,omitempty" json:"multiserver,omitempty"`
+	Fixture        []TestScriptFixtureComponent  `bson:"fixture,omitempty" json:"fixture,omitempty"`
+	Profile        []Reference                   `bson:"profile,omitempty" json:"profile,omitempty"`
+	Variable       []TestScriptVariableComponent `bson:"variable,omitempty" json:"variable,omitempty"`
+	Setup          *TestScriptSetupComponent     `bson:"setup,omitempty" json:"setup,omitempty"`
+	Test           []TestScriptTestComponent     `bson:"test,omitempty" json:"test,omitempty"`
+	Teardown       *TestScriptTeardownComponent  `bson:"teardown,omitempty" json:"teardown,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -63,6 +63,23 @@ func (resource *TestScript) MarshalJSON() ([]byte, error) {
 		TestScript:   *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "testScript" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type testScript TestScript
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *TestScript) UnmarshalJSON(data []byte) (err error) {
+	x2 := testScript{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = TestScript(x2)
+	}
+	return
 }
 
 type TestScriptContactComponent struct {

--- a/models/valueset.go
+++ b/models/valueset.go
@@ -29,26 +29,26 @@ package models
 import "encoding/json"
 
 type ValueSet struct {
-	Id           string                       `json:"id" bson:"_id"`
-	Url          string                       `bson:"url,omitempty" json:"url,omitempty"`
-	Identifier   *Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Version      string                       `bson:"version,omitempty" json:"version,omitempty"`
-	Name         string                       `bson:"name,omitempty" json:"name,omitempty"`
-	Status       string                       `bson:"status,omitempty" json:"status,omitempty"`
-	Experimental *bool                        `bson:"experimental,omitempty" json:"experimental,omitempty"`
-	Publisher    string                       `bson:"publisher,omitempty" json:"publisher,omitempty"`
-	Contact      []ValueSetContactComponent   `bson:"contact,omitempty" json:"contact,omitempty"`
-	Date         *FHIRDateTime                `bson:"date,omitempty" json:"date,omitempty"`
-	LockedDate   *FHIRDateTime                `bson:"lockedDate,omitempty" json:"lockedDate,omitempty"`
-	Description  string                       `bson:"description,omitempty" json:"description,omitempty"`
-	UseContext   []CodeableConcept            `bson:"useContext,omitempty" json:"useContext,omitempty"`
-	Immutable    *bool                        `bson:"immutable,omitempty" json:"immutable,omitempty"`
-	Requirements string                       `bson:"requirements,omitempty" json:"requirements,omitempty"`
-	Copyright    string                       `bson:"copyright,omitempty" json:"copyright,omitempty"`
-	Extensible   *bool                        `bson:"extensible,omitempty" json:"extensible,omitempty"`
-	CodeSystem   *ValueSetCodeSystemComponent `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
-	Compose      *ValueSetComposeComponent    `bson:"compose,omitempty" json:"compose,omitempty"`
-	Expansion    *ValueSetExpansionComponent  `bson:"expansion,omitempty" json:"expansion,omitempty"`
+	DomainResource `bson:",inline"`
+	Url            string                       `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier     *Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version        string                       `bson:"version,omitempty" json:"version,omitempty"`
+	Name           string                       `bson:"name,omitempty" json:"name,omitempty"`
+	Status         string                       `bson:"status,omitempty" json:"status,omitempty"`
+	Experimental   *bool                        `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Publisher      string                       `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact        []ValueSetContactComponent   `bson:"contact,omitempty" json:"contact,omitempty"`
+	Date           *FHIRDateTime                `bson:"date,omitempty" json:"date,omitempty"`
+	LockedDate     *FHIRDateTime                `bson:"lockedDate,omitempty" json:"lockedDate,omitempty"`
+	Description    string                       `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext     []CodeableConcept            `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Immutable      *bool                        `bson:"immutable,omitempty" json:"immutable,omitempty"`
+	Requirements   string                       `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Copyright      string                       `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Extensible     *bool                        `bson:"extensible,omitempty" json:"extensible,omitempty"`
+	CodeSystem     *ValueSetCodeSystemComponent `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
+	Compose        *ValueSetComposeComponent    `bson:"compose,omitempty" json:"compose,omitempty"`
+	Expansion      *ValueSetExpansionComponent  `bson:"expansion,omitempty" json:"expansion,omitempty"`
 }
 
 // Custom marshaller to add the resourceType property, as required by the specification
@@ -61,6 +61,23 @@ func (resource *ValueSet) MarshalJSON() ([]byte, error) {
 		ValueSet:     *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "valueSet" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type valueSet ValueSet
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *ValueSet) UnmarshalJSON(data []byte) (err error) {
+	x2 := valueSet{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = ValueSet(x2)
+	}
+	return
 }
 
 type ValueSetContactComponent struct {

--- a/models/visionprescription.go
+++ b/models/visionprescription.go
@@ -29,7 +29,7 @@ package models
 import "encoding/json"
 
 type VisionPrescription struct {
-	Id                    string                                `json:"id" bson:"_id"`
+	DomainResource        `bson:",inline"`
 	Identifier            []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	DateWritten           *FHIRDateTime                         `bson:"dateWritten,omitempty" json:"dateWritten,omitempty"`
 	Patient               *Reference                            `bson:"patient,omitempty" json:"patient,omitempty"`
@@ -50,6 +50,23 @@ func (resource *VisionPrescription) MarshalJSON() ([]byte, error) {
 		VisionPrescription: *resource,
 	}
 	return json.Marshal(x)
+}
+
+// The "visionPrescription" sub-type is needed to avoid infinite recursion in UnmarshalJSON
+type visionPrescription VisionPrescription
+
+// Custom unmarshaller to properly unmarshal embedded resources (represented as interface{})
+func (x *VisionPrescription) UnmarshalJSON(data []byte) (err error) {
+	x2 := visionPrescription{}
+	if err = json.Unmarshal(data, &x2); err == nil {
+		if x2.Contained != nil {
+			for i := range x2.Contained {
+				x2.Contained[i] = MapToResource(x2.Contained[i], true)
+			}
+		}
+		*x = VisionPrescription(x2)
+	}
+	return
 }
 
 type VisionPrescriptionDispenseComponent struct {

--- a/server/batch_controller.go
+++ b/server/batch_controller.go
@@ -57,9 +57,10 @@ func BatchHandler(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc
 			ReferencedID: id.Hex(),
 			External:     new(bool),
 		}
-		// Update the entry with the new FullURL and Id
+		// Update the entry with the new FullURL, Id, and LastUpdated
 		entry.FullUrl = responseURL(r, entry.Request.Url, id.Hex()).String()
 		reflect.ValueOf(entry.Resource).Elem().FieldByName("Id").SetString(id.Hex())
+		UpdateLastUpdatedDate(entry.Resource)
 	}
 	// Update all the references to the entries (to reflect newly assigned IDs)
 	updateAllReferences(entries, refMap)

--- a/server/batch_controller_test.go
+++ b/server/batch_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
@@ -86,6 +87,15 @@ func (s *BatchControllerSuite) TestUploadPatientBundle(c *C) {
 
 		// full URL in response should contain the new ID
 		c.Assert(strings.HasSuffix(resEntry.FullUrl, s.getResourceID(resEntry)), Equals, true)
+
+		// resource should have lastUpdatedTime
+		m := reflect.ValueOf(resEntry.Resource).Elem().FieldByName("Meta").Interface().(*models.Meta)
+		c.Assert(m, NotNil)
+		c.Assert(m.LastUpdated, NotNil)
+		c.Assert(m.LastUpdated.Precision, Equals, models.Precision(models.Timestamp))
+		since := time.Since(m.LastUpdated.Time)
+		c.Assert(since.Hours() < float64(1), Equals, true)
+		c.Assert(since.Minutes() < float64(1), Equals, true)
 
 		// response should not contain the request
 		c.Assert(resEntry.Request, IsNil)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/codegangsta/negroni"
 	"github.com/gorilla/mux"
@@ -232,6 +233,12 @@ func (s *ServerSuite) TestCreatePatient(c *C) {
 	err = patientCollection.Find(bson.M{"_id": createdPatientId}).One(&patient)
 	util.CheckErr(err)
 	c.Assert(patient.Name[0].Family[0], Equals, "Daffy")
+	c.Assert(patient.Meta, NotNil)
+	c.Assert(patient.Meta.LastUpdated, NotNil)
+	c.Assert(patient.Meta.LastUpdated.Precision, Equals, models.Precision(models.Timestamp))
+	since := time.Since(patient.Meta.LastUpdated.Time)
+	c.Assert(since.Hours() < float64(1), Equals, true)
+	c.Assert(since.Minutes() < float64(1), Equals, true)
 }
 
 func (s *ServerSuite) TestUpdatePatient(c *C) {
@@ -249,6 +256,12 @@ func (s *ServerSuite) TestUpdatePatient(c *C) {
 	err = patientCollection.Find(bson.M{"_id": s.FixtureId}).One(&patient)
 	util.CheckErr(err)
 	c.Assert(patient.Name[0].Family[0], Equals, "Darkwing")
+	c.Assert(patient.Meta, NotNil)
+	c.Assert(patient.Meta.LastUpdated, NotNil)
+	c.Assert(patient.Meta.LastUpdated.Precision, Equals, models.Precision(models.Timestamp))
+	since := time.Since(patient.Meta.LastUpdated.Time)
+	c.Assert(since.Hours() < float64(1), Equals, true)
+	c.Assert(since.Minutes() < float64(1), Equals, true)
 }
 
 func (s *ServerSuite) TestDeletePatient(c *C) {

--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -119,7 +119,8 @@ func (s *UploadSuite) TestExternalReferences(c *C) {
 	}))
 	defer ts.Close()
 
-	condition := &models.Condition{Id: "123"}
+	condition := &models.Condition{}
+	condition.Id = "123"
 	condition.Patient = &models.Reference{Reference: "Patient/0"}
 
 	// Upload the resource
@@ -154,8 +155,10 @@ func (s *UploadSuite) TestUnorderedDependencies(c *C) {
 	}))
 	defer ts.Close()
 
-	patient := &models.Patient{Id: "a1"}
-	condition := &models.Condition{Id: "b2"}
+	patient := &models.Patient{}
+	patient.Id = "a1"
+	condition := &models.Condition{}
+	condition.Id = "b2"
 	condition.Patient = &models.Reference{Reference: "cid:a1"}
 
 	// Upload the resources in the wrong order


### PR DESCRIPTION
FHIR resources use an inheritance model to inherit properties from base resources.  Each resource extends `DomainResource`, which itself extends `Resource`.

Previously, our FHIR models ignored these base resources (except that they defined an `Id` property, which is technically inherited from `Resource`).  This Pull Request contains definitions for the base resources, and each resource inherits their properties via composition.  This allows support for useful fields like `meta.lastUpdated`, `meta.tags`, and `contained`.  It also removes the `id` field from the resource struct since it should really be inherited from `Resource` (which does mean that creating struct literals of the resources is a little different now).