### PR TITLE
Add support for including referenced resources in search results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ go:
 - 1.5.3
 services:
 - mongodb
+addons:
+  apt:
+    sources:
+    - mongodb-3.2-precise
+    packages:
+    - mongodb-org-server
 branches:
   only:
   - master

--- a/models/account.go
+++ b/models/account.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Account struct {
 	DomainResource `bson:",inline"`
@@ -70,4 +74,153 @@ func (x *Account) UnmarshalJSON(data []byte) (err error) {
 		*x = Account(x2)
 	}
 	return
+}
+
+type AccountPlus struct {
+	Account             `bson:",inline"`
+	AccountPlusIncludes `bson:",inline"`
+}
+
+type AccountPlusIncludes struct {
+	IncludedOwnerResources                    *[]Organization      `bson:"_includedOwnerResources,omitempty"`
+	IncludedSubjectPractitionerResources      *[]Practitioner      `bson:"_includedSubjectPractitionerResources,omitempty"`
+	IncludedSubjectOrganizationResources      *[]Organization      `bson:"_includedSubjectOrganizationResources,omitempty"`
+	IncludedSubjectDeviceResources            *[]Device            `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources           *[]Patient           `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectHealthcareServiceResources *[]HealthcareService `bson:"_includedSubjectHealthcareServiceResources,omitempty"`
+	IncludedSubjectLocationResources          *[]Location          `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedPatientResources                  *[]Patient           `bson:"_includedPatientResources,omitempty"`
+}
+
+func (a *AccountPlusIncludes) GetIncludedOwnerResource() (organization *Organization, err error) {
+	if a.IncludedOwnerResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*a.IncludedOwnerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedOwnerResources))
+	} else if len(*a.IncludedOwnerResources) == 1 {
+		organization = &(*a.IncludedOwnerResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedSubjectPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedSubjectPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedSubjectPractitionerResources))
+	} else if len(*a.IncludedSubjectPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedSubjectPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
+	if a.IncludedSubjectOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*a.IncludedSubjectOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedSubjectOrganizationResources))
+	} else if len(*a.IncludedSubjectOrganizationResources) == 1 {
+		organization = &(*a.IncludedSubjectOrganizationResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if a.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*a.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedSubjectDeviceResources))
+	} else if len(*a.IncludedSubjectDeviceResources) == 1 {
+		device = &(*a.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if a.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedSubjectPatientResources))
+	} else if len(*a.IncludedSubjectPatientResources) == 1 {
+		patient = &(*a.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
+	if a.IncludedSubjectHealthcareServiceResources == nil {
+		err = errors.New("Included healthcareservices not requested")
+	} else if len(*a.IncludedSubjectHealthcareServiceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedSubjectHealthcareServiceResources))
+	} else if len(*a.IncludedSubjectHealthcareServiceResources) == 1 {
+		healthcareService = &(*a.IncludedSubjectHealthcareServiceResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if a.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*a.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedSubjectLocationResources))
+	} else if len(*a.IncludedSubjectLocationResources) == 1 {
+		location = &(*a.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if a.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
+	} else if len(*a.IncludedPatientResources) == 1 {
+		patient = &(*a.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (a *AccountPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedOwnerResources != nil {
+		for _, r := range *a.IncludedOwnerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectPractitionerResources != nil {
+		for _, r := range *a.IncludedSubjectPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectOrganizationResources != nil {
+		for _, r := range *a.IncludedSubjectOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectDeviceResources != nil {
+		for _, r := range *a.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectPatientResources != nil {
+		for _, r := range *a.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectHealthcareServiceResources != nil {
+		for _, r := range *a.IncludedSubjectHealthcareServiceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedSubjectLocationResources != nil {
+		for _, r := range *a.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResources != nil {
+		for _, r := range *a.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type AllergyIntolerance struct {
 	DomainResource `bson:",inline"`
@@ -84,4 +88,119 @@ type AllergyIntoleranceReactionComponent struct {
 	Severity      string            `bson:"severity,omitempty" json:"severity,omitempty"`
 	ExposureRoute *CodeableConcept  `bson:"exposureRoute,omitempty" json:"exposureRoute,omitempty"`
 	Note          *Annotation       `bson:"note,omitempty" json:"note,omitempty"`
+}
+
+type AllergyIntolerancePlus struct {
+	AllergyIntolerance             `bson:",inline"`
+	AllergyIntolerancePlusIncludes `bson:",inline"`
+}
+
+type AllergyIntolerancePlusIncludes struct {
+	IncludedRecorderPractitionerResources  *[]Practitioner  `bson:"_includedRecorderPractitionerResources,omitempty"`
+	IncludedRecorderPatientResources       *[]Patient       `bson:"_includedRecorderPatientResources,omitempty"`
+	IncludedReporterPractitionerResources  *[]Practitioner  `bson:"_includedReporterPractitionerResources,omitempty"`
+	IncludedReporterPatientResources       *[]Patient       `bson:"_includedReporterPatientResources,omitempty"`
+	IncludedReporterRelatedPersonResources *[]RelatedPerson `bson:"_includedReporterRelatedPersonResources,omitempty"`
+	IncludedPatientResources               *[]Patient       `bson:"_includedPatientResources,omitempty"`
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedRecorderPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedRecorderPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedRecorderPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedRecorderPractitionerResources))
+	} else if len(*a.IncludedRecorderPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedRecorderPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedRecorderPatientResource() (patient *Patient, err error) {
+	if a.IncludedRecorderPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedRecorderPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedRecorderPatientResources))
+	} else if len(*a.IncludedRecorderPatientResources) == 1 {
+		patient = &(*a.IncludedRecorderPatientResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedReporterPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedReporterPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedReporterPractitionerResources))
+	} else if len(*a.IncludedReporterPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedReporterPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterPatientResource() (patient *Patient, err error) {
+	if a.IncludedReporterPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedReporterPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedReporterPatientResources))
+	} else if len(*a.IncludedReporterPatientResources) == 1 {
+		patient = &(*a.IncludedReporterPatientResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedReporterRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*a.IncludedReporterRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedReporterRelatedPersonResources))
+	} else if len(*a.IncludedReporterRelatedPersonResources) == 1 {
+		relatedPerson = &(*a.IncludedReporterRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if a.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
+	} else if len(*a.IncludedPatientResources) == 1 {
+		patient = &(*a.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedRecorderPractitionerResources != nil {
+		for _, r := range *a.IncludedRecorderPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedRecorderPatientResources != nil {
+		for _, r := range *a.IncludedRecorderPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedReporterPractitionerResources != nil {
+		for _, r := range *a.IncludedReporterPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedReporterPatientResources != nil {
+		for _, r := range *a.IncludedReporterPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedReporterRelatedPersonResources != nil {
+		for _, r := range *a.IncludedReporterRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResources != nil {
+		for _, r := range *a.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/appointment.go
+++ b/models/appointment.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Appointment struct {
 	DomainResource  `bson:",inline"`
@@ -78,4 +82,170 @@ type AppointmentParticipantComponent struct {
 	Actor    *Reference        `bson:"actor,omitempty" json:"actor,omitempty"`
 	Required string            `bson:"required,omitempty" json:"required,omitempty"`
 	Status   string            `bson:"status,omitempty" json:"status,omitempty"`
+}
+
+type AppointmentPlus struct {
+	Appointment             `bson:",inline"`
+	AppointmentPlusIncludes `bson:",inline"`
+}
+
+type AppointmentPlusIncludes struct {
+	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
+	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
+	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
+	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
+	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
+	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
+	IncludedPractitionerResources           *[]Practitioner      `bson:"_includedPractitionerResources,omitempty"`
+	IncludedPatientResources                *[]Patient           `bson:"_includedPatientResources,omitempty"`
+	IncludedLocationResources               *[]Location          `bson:"_includedLocationResources,omitempty"`
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedActorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedActorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedActorPractitionerResources))
+	} else if len(*a.IncludedActorPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedActorPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
+	if a.IncludedActorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*a.IncludedActorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedActorDeviceResources))
+	} else if len(*a.IncludedActorDeviceResources) == 1 {
+		device = &(*a.IncludedActorDeviceResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
+	if a.IncludedActorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedActorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedActorPatientResources))
+	} else if len(*a.IncludedActorPatientResources) == 1 {
+		patient = &(*a.IncludedActorPatientResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
+	if a.IncludedActorHealthcareServiceResources == nil {
+		err = errors.New("Included healthcareservices not requested")
+	} else if len(*a.IncludedActorHealthcareServiceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedActorHealthcareServiceResources))
+	} else if len(*a.IncludedActorHealthcareServiceResources) == 1 {
+		healthcareService = &(*a.IncludedActorHealthcareServiceResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedActorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*a.IncludedActorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedActorRelatedPersonResources))
+	} else if len(*a.IncludedActorRelatedPersonResources) == 1 {
+		relatedPerson = &(*a.IncludedActorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
+	if a.IncludedActorLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*a.IncludedActorLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedActorLocationResources))
+	} else if len(*a.IncludedActorLocationResources) == 1 {
+		location = &(*a.IncludedActorLocationResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResources))
+	} else if len(*a.IncludedPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if a.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
+	} else if len(*a.IncludedPatientResources) == 1 {
+		patient = &(*a.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if a.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*a.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResources))
+	} else if len(*a.IncludedLocationResources) == 1 {
+		location = &(*a.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedActorPractitionerResources != nil {
+		for _, r := range *a.IncludedActorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorDeviceResources != nil {
+		for _, r := range *a.IncludedActorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorPatientResources != nil {
+		for _, r := range *a.IncludedActorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorHealthcareServiceResources != nil {
+		for _, r := range *a.IncludedActorHealthcareServiceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorRelatedPersonResources != nil {
+		for _, r := range *a.IncludedActorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorLocationResources != nil {
+		for _, r := range *a.IncludedActorLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResources != nil {
+		for _, r := range *a.IncludedPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResources != nil {
+		for _, r := range *a.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResources != nil {
+		for _, r := range *a.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/appointmentresponse.go
+++ b/models/appointmentresponse.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type AppointmentResponse struct {
 	DomainResource    `bson:",inline"`
@@ -67,4 +71,187 @@ func (x *AppointmentResponse) UnmarshalJSON(data []byte) (err error) {
 		*x = AppointmentResponse(x2)
 	}
 	return
+}
+
+type AppointmentResponsePlus struct {
+	AppointmentResponse             `bson:",inline"`
+	AppointmentResponsePlusIncludes `bson:",inline"`
+}
+
+type AppointmentResponsePlusIncludes struct {
+	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
+	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
+	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
+	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
+	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
+	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
+	IncludedPractitionerResources           *[]Practitioner      `bson:"_includedPractitionerResources,omitempty"`
+	IncludedPatientResources                *[]Patient           `bson:"_includedPatientResources,omitempty"`
+	IncludedAppointmentResources            *[]Appointment       `bson:"_includedAppointmentResources,omitempty"`
+	IncludedLocationResources               *[]Location          `bson:"_includedLocationResources,omitempty"`
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedActorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedActorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedActorPractitionerResources))
+	} else if len(*a.IncludedActorPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedActorPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
+	if a.IncludedActorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*a.IncludedActorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedActorDeviceResources))
+	} else if len(*a.IncludedActorDeviceResources) == 1 {
+		device = &(*a.IncludedActorDeviceResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
+	if a.IncludedActorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedActorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedActorPatientResources))
+	} else if len(*a.IncludedActorPatientResources) == 1 {
+		patient = &(*a.IncludedActorPatientResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
+	if a.IncludedActorHealthcareServiceResources == nil {
+		err = errors.New("Included healthcareservices not requested")
+	} else if len(*a.IncludedActorHealthcareServiceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedActorHealthcareServiceResources))
+	} else if len(*a.IncludedActorHealthcareServiceResources) == 1 {
+		healthcareService = &(*a.IncludedActorHealthcareServiceResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedActorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*a.IncludedActorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedActorRelatedPersonResources))
+	} else if len(*a.IncludedActorRelatedPersonResources) == 1 {
+		relatedPerson = &(*a.IncludedActorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
+	if a.IncludedActorLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*a.IncludedActorLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedActorLocationResources))
+	} else if len(*a.IncludedActorLocationResources) == 1 {
+		location = &(*a.IncludedActorLocationResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResources))
+	} else if len(*a.IncludedPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if a.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
+	} else if len(*a.IncludedPatientResources) == 1 {
+		patient = &(*a.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedAppointmentResource() (appointment *Appointment, err error) {
+	if a.IncludedAppointmentResources == nil {
+		err = errors.New("Included appointments not requested")
+	} else if len(*a.IncludedAppointmentResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*a.IncludedAppointmentResources))
+	} else if len(*a.IncludedAppointmentResources) == 1 {
+		appointment = &(*a.IncludedAppointmentResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if a.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*a.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResources))
+	} else if len(*a.IncludedLocationResources) == 1 {
+		location = &(*a.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedActorPractitionerResources != nil {
+		for _, r := range *a.IncludedActorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorDeviceResources != nil {
+		for _, r := range *a.IncludedActorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorPatientResources != nil {
+		for _, r := range *a.IncludedActorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorHealthcareServiceResources != nil {
+		for _, r := range *a.IncludedActorHealthcareServiceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorRelatedPersonResources != nil {
+		for _, r := range *a.IncludedActorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedActorLocationResources != nil {
+		for _, r := range *a.IncludedActorLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResources != nil {
+		for _, r := range *a.IncludedPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResources != nil {
+		for _, r := range *a.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedAppointmentResources != nil {
+		for _, r := range *a.IncludedAppointmentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResources != nil {
+		for _, r := range *a.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/auditevent.go
+++ b/models/auditevent.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type AuditEvent struct {
 	DomainResource `bson:",inline"`
@@ -116,4 +120,136 @@ type AuditEventObjectComponent struct {
 type AuditEventObjectDetailComponent struct {
 	Type  string `bson:"type,omitempty" json:"type,omitempty"`
 	Value string `bson:"value,omitempty" json:"value,omitempty"`
+}
+
+type AuditEventPlus struct {
+	AuditEvent             `bson:",inline"`
+	AuditEventPlusIncludes `bson:",inline"`
+}
+
+type AuditEventPlusIncludes struct {
+	IncludedParticipantPractitionerResources  *[]Practitioner  `bson:"_includedParticipantPractitionerResources,omitempty"`
+	IncludedParticipantOrganizationResources  *[]Organization  `bson:"_includedParticipantOrganizationResources,omitempty"`
+	IncludedParticipantDeviceResources        *[]Device        `bson:"_includedParticipantDeviceResources,omitempty"`
+	IncludedParticipantPatientResources       *[]Patient       `bson:"_includedParticipantPatientResources,omitempty"`
+	IncludedParticipantRelatedPersonResources *[]RelatedPerson `bson:"_includedParticipantRelatedPersonResources,omitempty"`
+	IncludedPatientPath1Resources             *[]Patient       `bson:"_includedPatientPath1Resources,omitempty"`
+	IncludedPatientPath2Resources             *[]Patient       `bson:"_includedPatientPath2Resources,omitempty"`
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
+	if a.IncludedParticipantPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*a.IncludedParticipantPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedParticipantPractitionerResources))
+	} else if len(*a.IncludedParticipantPractitionerResources) == 1 {
+		practitioner = &(*a.IncludedParticipantPractitionerResources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedParticipantOrganizationResource() (organization *Organization, err error) {
+	if a.IncludedParticipantOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*a.IncludedParticipantOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedParticipantOrganizationResources))
+	} else if len(*a.IncludedParticipantOrganizationResources) == 1 {
+		organization = &(*a.IncludedParticipantOrganizationResources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedParticipantDeviceResource() (device *Device, err error) {
+	if a.IncludedParticipantDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*a.IncludedParticipantDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedParticipantDeviceResources))
+	} else if len(*a.IncludedParticipantDeviceResources) == 1 {
+		device = &(*a.IncludedParticipantDeviceResources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedParticipantPatientResource() (patient *Patient, err error) {
+	if a.IncludedParticipantPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedParticipantPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedParticipantPatientResources))
+	} else if len(*a.IncludedParticipantPatientResources) == 1 {
+		patient = &(*a.IncludedParticipantPatientResources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedParticipantRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*a.IncludedParticipantRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedParticipantRelatedPersonResources))
+	} else if len(*a.IncludedParticipantRelatedPersonResources) == 1 {
+		relatedPerson = &(*a.IncludedParticipantRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedPatientPath1Resource() (patient *Patient, err error) {
+	if a.IncludedPatientPath1Resources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientPath1Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientPath1Resources))
+	} else if len(*a.IncludedPatientPath1Resources) == 1 {
+		patient = &(*a.IncludedPatientPath1Resources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedPatientPath2Resource() (patient *Patient, err error) {
+	if a.IncludedPatientPath2Resources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*a.IncludedPatientPath2Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientPath2Resources))
+	} else if len(*a.IncludedPatientPath2Resources) == 1 {
+		patient = &(*a.IncludedPatientPath2Resources)[0]
+	}
+	return
+}
+
+func (a *AuditEventPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedParticipantPractitionerResources != nil {
+		for _, r := range *a.IncludedParticipantPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedParticipantOrganizationResources != nil {
+		for _, r := range *a.IncludedParticipantOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedParticipantDeviceResources != nil {
+		for _, r := range *a.IncludedParticipantDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedParticipantPatientResources != nil {
+		for _, r := range *a.IncludedParticipantPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedParticipantRelatedPersonResources != nil {
+		for _, r := range *a.IncludedParticipantRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientPath1Resources != nil {
+		for _, r := range *a.IncludedPatientPath1Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientPath2Resources != nil {
+		for _, r := range *a.IncludedPatientPath2Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/basic.go
+++ b/models/basic.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Basic struct {
 	DomainResource `bson:",inline"`
@@ -64,4 +68,85 @@ func (x *Basic) UnmarshalJSON(data []byte) (err error) {
 		*x = Basic(x2)
 	}
 	return
+}
+
+type BasicPlus struct {
+	Basic             `bson:",inline"`
+	BasicPlusIncludes `bson:",inline"`
+}
+
+type BasicPlusIncludes struct {
+	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+}
+
+func (b *BasicPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if b.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*b.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResources))
+	} else if len(*b.IncludedPatientResources) == 1 {
+		patient = &(*b.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (b *BasicPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
+	if b.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*b.IncludedAuthorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*b.IncludedAuthorPractitionerResources))
+	} else if len(*b.IncludedAuthorPractitionerResources) == 1 {
+		practitioner = &(*b.IncludedAuthorPractitionerResources)[0]
+	}
+	return
+}
+
+func (b *BasicPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
+	if b.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*b.IncludedAuthorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedAuthorPatientResources))
+	} else if len(*b.IncludedAuthorPatientResources) == 1 {
+		patient = &(*b.IncludedAuthorPatientResources)[0]
+	}
+	return
+}
+
+func (b *BasicPlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if b.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*b.IncludedAuthorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*b.IncludedAuthorRelatedPersonResources))
+	} else if len(*b.IncludedAuthorRelatedPersonResources) == 1 {
+		relatedPerson = &(*b.IncludedAuthorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (b *BasicPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.IncludedPatientResources != nil {
+		for _, r := range *b.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *b.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedAuthorPatientResources != nil {
+		for _, r := range *b.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *b.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/binary.go
+++ b/models/binary.go
@@ -45,3 +45,16 @@ func (resource *Binary) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(x)
 }
+
+type BinaryPlus struct {
+	Binary             `bson:",inline"`
+	BinaryPlusIncludes `bson:",inline"`
+}
+
+type BinaryPlusIncludes struct {
+}
+
+func (b *BinaryPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/careplan.go
+++ b/models/careplan.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type CarePlan struct {
 	DomainResource `bson:",inline"`
@@ -113,4 +117,447 @@ type CarePlanActivityDetailComponent struct {
 	DailyAmount            *Quantity         `bson:"dailyAmount,omitempty" json:"dailyAmount,omitempty"`
 	Quantity               *Quantity         `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	Description            string            `bson:"description,omitempty" json:"description,omitempty"`
+}
+
+type CarePlanPlus struct {
+	CarePlan             `bson:",inline"`
+	CarePlanPlusIncludes `bson:",inline"`
+}
+
+type CarePlanPlusIncludes struct {
+	IncludedActivityreferenceAppointmentResources          *[]Appointment          `bson:"_includedActivityreferenceAppointmentResources,omitempty"`
+	IncludedActivityreferenceOrderResources                *[]Order                `bson:"_includedActivityreferenceOrderResources,omitempty"`
+	IncludedActivityreferenceReferralRequestResources      *[]ReferralRequest      `bson:"_includedActivityreferenceReferralRequestResources,omitempty"`
+	IncludedActivityreferenceProcessRequestResources       *[]ProcessRequest       `bson:"_includedActivityreferenceProcessRequestResources,omitempty"`
+	IncludedActivityreferenceNutritionOrderResources       *[]NutritionOrder       `bson:"_includedActivityreferenceNutritionOrderResources,omitempty"`
+	IncludedActivityreferenceVisionPrescriptionResources   *[]VisionPrescription   `bson:"_includedActivityreferenceVisionPrescriptionResources,omitempty"`
+	IncludedActivityreferenceDiagnosticOrderResources      *[]DiagnosticOrder      `bson:"_includedActivityreferenceDiagnosticOrderResources,omitempty"`
+	IncludedActivityreferenceProcedureRequestResources     *[]ProcedureRequest     `bson:"_includedActivityreferenceProcedureRequestResources,omitempty"`
+	IncludedActivityreferenceDeviceUseRequestResources     *[]DeviceUseRequest     `bson:"_includedActivityreferenceDeviceUseRequestResources,omitempty"`
+	IncludedActivityreferenceMedicationOrderResources      *[]MedicationOrder      `bson:"_includedActivityreferenceMedicationOrderResources,omitempty"`
+	IncludedActivityreferenceCommunicationRequestResources *[]CommunicationRequest `bson:"_includedActivityreferenceCommunicationRequestResources,omitempty"`
+	IncludedActivityreferenceSupplyRequestResources        *[]SupplyRequest        `bson:"_includedActivityreferenceSupplyRequestResources,omitempty"`
+	IncludedPerformerPractitionerResources                 *[]Practitioner         `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerOrganizationResources                 *[]Organization         `bson:"_includedPerformerOrganizationResources,omitempty"`
+	IncludedPerformerPatientResources                      *[]Patient              `bson:"_includedPerformerPatientResources,omitempty"`
+	IncludedPerformerRelatedPersonResources                *[]RelatedPerson        `bson:"_includedPerformerRelatedPersonResources,omitempty"`
+	IncludedGoalResources                                  *[]Goal                 `bson:"_includedGoalResources,omitempty"`
+	IncludedSubjectGroupResources                          *[]Group                `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectPatientResources                        *[]Patient              `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedParticipantPractitionerResources               *[]Practitioner         `bson:"_includedParticipantPractitionerResources,omitempty"`
+	IncludedParticipantOrganizationResources               *[]Organization         `bson:"_includedParticipantOrganizationResources,omitempty"`
+	IncludedParticipantPatientResources                    *[]Patient              `bson:"_includedParticipantPatientResources,omitempty"`
+	IncludedParticipantRelatedPersonResources              *[]RelatedPerson        `bson:"_includedParticipantRelatedPersonResources,omitempty"`
+	IncludedRelatedplanResources                           *[]CarePlan             `bson:"_includedRelatedplanResources,omitempty"`
+	IncludedConditionResources                             *[]Condition            `bson:"_includedConditionResources,omitempty"`
+	IncludedPatientResources                               *[]Patient              `bson:"_includedPatientResources,omitempty"`
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceAppointmentResource() (appointment *Appointment, err error) {
+	if c.IncludedActivityreferenceAppointmentResources == nil {
+		err = errors.New("Included appointments not requested")
+	} else if len(*c.IncludedActivityreferenceAppointmentResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*c.IncludedActivityreferenceAppointmentResources))
+	} else if len(*c.IncludedActivityreferenceAppointmentResources) == 1 {
+		appointment = &(*c.IncludedActivityreferenceAppointmentResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceOrderResource() (order *Order, err error) {
+	if c.IncludedActivityreferenceOrderResources == nil {
+		err = errors.New("Included orders not requested")
+	} else if len(*c.IncludedActivityreferenceOrderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*c.IncludedActivityreferenceOrderResources))
+	} else if len(*c.IncludedActivityreferenceOrderResources) == 1 {
+		order = &(*c.IncludedActivityreferenceOrderResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceReferralRequestResource() (referralRequest *ReferralRequest, err error) {
+	if c.IncludedActivityreferenceReferralRequestResources == nil {
+		err = errors.New("Included referralrequests not requested")
+	} else if len(*c.IncludedActivityreferenceReferralRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 referralRequest, but found %d", len(*c.IncludedActivityreferenceReferralRequestResources))
+	} else if len(*c.IncludedActivityreferenceReferralRequestResources) == 1 {
+		referralRequest = &(*c.IncludedActivityreferenceReferralRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceProcessRequestResource() (processRequest *ProcessRequest, err error) {
+	if c.IncludedActivityreferenceProcessRequestResources == nil {
+		err = errors.New("Included processrequests not requested")
+	} else if len(*c.IncludedActivityreferenceProcessRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 processRequest, but found %d", len(*c.IncludedActivityreferenceProcessRequestResources))
+	} else if len(*c.IncludedActivityreferenceProcessRequestResources) == 1 {
+		processRequest = &(*c.IncludedActivityreferenceProcessRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceNutritionOrderResource() (nutritionOrder *NutritionOrder, err error) {
+	if c.IncludedActivityreferenceNutritionOrderResources == nil {
+		err = errors.New("Included nutritionorders not requested")
+	} else if len(*c.IncludedActivityreferenceNutritionOrderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 nutritionOrder, but found %d", len(*c.IncludedActivityreferenceNutritionOrderResources))
+	} else if len(*c.IncludedActivityreferenceNutritionOrderResources) == 1 {
+		nutritionOrder = &(*c.IncludedActivityreferenceNutritionOrderResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceVisionPrescriptionResource() (visionPrescription *VisionPrescription, err error) {
+	if c.IncludedActivityreferenceVisionPrescriptionResources == nil {
+		err = errors.New("Included visionprescriptions not requested")
+	} else if len(*c.IncludedActivityreferenceVisionPrescriptionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 visionPrescription, but found %d", len(*c.IncludedActivityreferenceVisionPrescriptionResources))
+	} else if len(*c.IncludedActivityreferenceVisionPrescriptionResources) == 1 {
+		visionPrescription = &(*c.IncludedActivityreferenceVisionPrescriptionResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceDiagnosticOrderResource() (diagnosticOrder *DiagnosticOrder, err error) {
+	if c.IncludedActivityreferenceDiagnosticOrderResources == nil {
+		err = errors.New("Included diagnosticorders not requested")
+	} else if len(*c.IncludedActivityreferenceDiagnosticOrderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 diagnosticOrder, but found %d", len(*c.IncludedActivityreferenceDiagnosticOrderResources))
+	} else if len(*c.IncludedActivityreferenceDiagnosticOrderResources) == 1 {
+		diagnosticOrder = &(*c.IncludedActivityreferenceDiagnosticOrderResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceProcedureRequestResource() (procedureRequest *ProcedureRequest, err error) {
+	if c.IncludedActivityreferenceProcedureRequestResources == nil {
+		err = errors.New("Included procedurerequests not requested")
+	} else if len(*c.IncludedActivityreferenceProcedureRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 procedureRequest, but found %d", len(*c.IncludedActivityreferenceProcedureRequestResources))
+	} else if len(*c.IncludedActivityreferenceProcedureRequestResources) == 1 {
+		procedureRequest = &(*c.IncludedActivityreferenceProcedureRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceDeviceUseRequestResource() (deviceUseRequest *DeviceUseRequest, err error) {
+	if c.IncludedActivityreferenceDeviceUseRequestResources == nil {
+		err = errors.New("Included deviceuserequests not requested")
+	} else if len(*c.IncludedActivityreferenceDeviceUseRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceUseRequest, but found %d", len(*c.IncludedActivityreferenceDeviceUseRequestResources))
+	} else if len(*c.IncludedActivityreferenceDeviceUseRequestResources) == 1 {
+		deviceUseRequest = &(*c.IncludedActivityreferenceDeviceUseRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceMedicationOrderResource() (medicationOrder *MedicationOrder, err error) {
+	if c.IncludedActivityreferenceMedicationOrderResources == nil {
+		err = errors.New("Included medicationorders not requested")
+	} else if len(*c.IncludedActivityreferenceMedicationOrderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*c.IncludedActivityreferenceMedicationOrderResources))
+	} else if len(*c.IncludedActivityreferenceMedicationOrderResources) == 1 {
+		medicationOrder = &(*c.IncludedActivityreferenceMedicationOrderResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceCommunicationRequestResource() (communicationRequest *CommunicationRequest, err error) {
+	if c.IncludedActivityreferenceCommunicationRequestResources == nil {
+		err = errors.New("Included communicationrequests not requested")
+	} else if len(*c.IncludedActivityreferenceCommunicationRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedActivityreferenceCommunicationRequestResources))
+	} else if len(*c.IncludedActivityreferenceCommunicationRequestResources) == 1 {
+		communicationRequest = &(*c.IncludedActivityreferenceCommunicationRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceSupplyRequestResource() (supplyRequest *SupplyRequest, err error) {
+	if c.IncludedActivityreferenceSupplyRequestResources == nil {
+		err = errors.New("Included supplyrequests not requested")
+	} else if len(*c.IncludedActivityreferenceSupplyRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 supplyRequest, but found %d", len(*c.IncludedActivityreferenceSupplyRequestResources))
+	} else if len(*c.IncludedActivityreferenceSupplyRequestResources) == 1 {
+		supplyRequest = &(*c.IncludedActivityreferenceSupplyRequestResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedPerformerPractitionerResources() (practitioners []Practitioner, err error) {
+	if c.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *c.IncludedPerformerPractitionerResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedPerformerOrganizationResources() (organizations []Organization, err error) {
+	if c.IncludedPerformerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *c.IncludedPerformerOrganizationResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedPerformerPatientResources() (patients []Patient, err error) {
+	if c.IncludedPerformerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedPerformerPatientResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedPerformerRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedPerformerRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *c.IncludedPerformerRelatedPersonResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedGoalResources() (goals []Goal, err error) {
+	if c.IncludedGoalResources == nil {
+		err = errors.New("Included goals not requested")
+	} else {
+		goals = *c.IncludedGoalResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if c.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*c.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedSubjectGroupResources))
+	} else if len(*c.IncludedSubjectGroupResources) == 1 {
+		group = &(*c.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if c.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectPatientResources))
+	} else if len(*c.IncludedSubjectPatientResources) == 1 {
+		patient = &(*c.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedParticipantPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedParticipantPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedParticipantPractitionerResources))
+	} else if len(*c.IncludedParticipantPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedParticipantPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedParticipantOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedParticipantOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedParticipantOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedParticipantOrganizationResources))
+	} else if len(*c.IncludedParticipantOrganizationResources) == 1 {
+		organization = &(*c.IncludedParticipantOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedParticipantPatientResource() (patient *Patient, err error) {
+	if c.IncludedParticipantPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedParticipantPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedParticipantPatientResources))
+	} else if len(*c.IncludedParticipantPatientResources) == 1 {
+		patient = &(*c.IncludedParticipantPatientResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedParticipantRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedParticipantRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedParticipantRelatedPersonResources))
+	} else if len(*c.IncludedParticipantRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedParticipantRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedRelatedplanResource() (carePlan *CarePlan, err error) {
+	if c.IncludedRelatedplanResources == nil {
+		err = errors.New("Included careplans not requested")
+	} else if len(*c.IncludedRelatedplanResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 carePlan, but found %d", len(*c.IncludedRelatedplanResources))
+	} else if len(*c.IncludedRelatedplanResources) == 1 {
+		carePlan = &(*c.IncludedRelatedplanResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
+	if c.IncludedConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else {
+		conditions = *c.IncludedConditionResources
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *CarePlanPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedActivityreferenceAppointmentResources != nil {
+		for _, r := range *c.IncludedActivityreferenceAppointmentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceOrderResources != nil {
+		for _, r := range *c.IncludedActivityreferenceOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceReferralRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceReferralRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceProcessRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceProcessRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceNutritionOrderResources != nil {
+		for _, r := range *c.IncludedActivityreferenceNutritionOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceVisionPrescriptionResources != nil {
+		for _, r := range *c.IncludedActivityreferenceVisionPrescriptionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceDiagnosticOrderResources != nil {
+		for _, r := range *c.IncludedActivityreferenceDiagnosticOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceProcedureRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceProcedureRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceDeviceUseRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceDeviceUseRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceMedicationOrderResources != nil {
+		for _, r := range *c.IncludedActivityreferenceMedicationOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceCommunicationRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceCommunicationRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActivityreferenceSupplyRequestResources != nil {
+		for _, r := range *c.IncludedActivityreferenceSupplyRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *c.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPerformerOrganizationResources != nil {
+		for _, r := range *c.IncludedPerformerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPerformerPatientResources != nil {
+		for _, r := range *c.IncludedPerformerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPerformerRelatedPersonResources != nil {
+		for _, r := range *c.IncludedPerformerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedGoalResources != nil {
+		for _, r := range *c.IncludedGoalResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubjectGroupResources != nil {
+		for _, r := range *c.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubjectPatientResources != nil {
+		for _, r := range *c.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedParticipantPractitionerResources != nil {
+		for _, r := range *c.IncludedParticipantPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedParticipantOrganizationResources != nil {
+		for _, r := range *c.IncludedParticipantOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedParticipantPatientResources != nil {
+		for _, r := range *c.IncludedParticipantPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedParticipantRelatedPersonResources != nil {
+		for _, r := range *c.IncludedParticipantRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedplanResources != nil {
+		for _, r := range *c.IncludedRelatedplanResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedConditionResources != nil {
+		for _, r := range *c.IncludedConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -173,3 +173,16 @@ type ClaimResponseCoverageComponent struct {
 	ClaimResponse       *Reference `bson:"claimResponse,omitempty" json:"claimResponse,omitempty"`
 	OriginalRuleset     *Coding    `bson:"originalRuleset,omitempty" json:"originalRuleset,omitempty"`
 }
+
+type ClaimResponsePlus struct {
+	ClaimResponse             `bson:",inline"`
+	ClaimResponsePlusIncludes `bson:",inline"`
+}
+
+type ClaimResponsePlusIncludes struct {
+}
+
+func (c *ClaimResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ClinicalImpression struct {
 	DomainResource         `bson:",inline"`
@@ -92,4 +96,473 @@ type ClinicalImpressionFindingComponent struct {
 type ClinicalImpressionRuledOutComponent struct {
 	Item   *CodeableConcept `bson:"item,omitempty" json:"item,omitempty"`
 	Reason string           `bson:"reason,omitempty" json:"reason,omitempty"`
+}
+
+type ClinicalImpressionPlus struct {
+	ClinicalImpression             `bson:",inline"`
+	ClinicalImpressionPlusIncludes `bson:",inline"`
+}
+
+type ClinicalImpressionPlusIncludes struct {
+	IncludedPreviousResources                           *[]ClinicalImpression    `bson:"_includedPreviousResources,omitempty"`
+	IncludedAssessorResources                           *[]Practitioner          `bson:"_includedAssessorResources,omitempty"`
+	IncludedProblemConditionResources                   *[]Condition             `bson:"_includedProblemConditionResources,omitempty"`
+	IncludedProblemAllergyIntoleranceResources          *[]AllergyIntolerance    `bson:"_includedProblemAllergyIntoleranceResources,omitempty"`
+	IncludedPatientResources                            *[]Patient               `bson:"_includedPatientResources,omitempty"`
+	IncludedInvestigationFamilyMemberHistoryResources   *[]FamilyMemberHistory   `bson:"_includedInvestigationFamilyMemberHistoryResources,omitempty"`
+	IncludedInvestigationObservationResources           *[]Observation           `bson:"_includedInvestigationObservationResources,omitempty"`
+	IncludedInvestigationDiagnosticReportResources      *[]DiagnosticReport      `bson:"_includedInvestigationDiagnosticReportResources,omitempty"`
+	IncludedInvestigationQuestionnaireResponseResources *[]QuestionnaireResponse `bson:"_includedInvestigationQuestionnaireResponseResources,omitempty"`
+	IncludedActionAppointmentResources                  *[]Appointment           `bson:"_includedActionAppointmentResources,omitempty"`
+	IncludedActionReferralRequestResources              *[]ReferralRequest       `bson:"_includedActionReferralRequestResources,omitempty"`
+	IncludedActionNutritionOrderResources               *[]NutritionOrder        `bson:"_includedActionNutritionOrderResources,omitempty"`
+	IncludedActionProcedureRequestResources             *[]ProcedureRequest      `bson:"_includedActionProcedureRequestResources,omitempty"`
+	IncludedActionProcedureResources                    *[]Procedure             `bson:"_includedActionProcedureResources,omitempty"`
+	IncludedActionDiagnosticOrderResources              *[]DiagnosticOrder       `bson:"_includedActionDiagnosticOrderResources,omitempty"`
+	IncludedActionMedicationOrderResources              *[]MedicationOrder       `bson:"_includedActionMedicationOrderResources,omitempty"`
+	IncludedActionSupplyRequestResources                *[]SupplyRequest         `bson:"_includedActionSupplyRequestResources,omitempty"`
+	IncludedPlanAppointmentResources                    *[]Appointment           `bson:"_includedPlanAppointmentResources,omitempty"`
+	IncludedPlanOrderResources                          *[]Order                 `bson:"_includedPlanOrderResources,omitempty"`
+	IncludedPlanReferralRequestResources                *[]ReferralRequest       `bson:"_includedPlanReferralRequestResources,omitempty"`
+	IncludedPlanProcessRequestResources                 *[]ProcessRequest        `bson:"_includedPlanProcessRequestResources,omitempty"`
+	IncludedPlanVisionPrescriptionResources             *[]VisionPrescription    `bson:"_includedPlanVisionPrescriptionResources,omitempty"`
+	IncludedPlanDiagnosticOrderResources                *[]DiagnosticOrder       `bson:"_includedPlanDiagnosticOrderResources,omitempty"`
+	IncludedPlanProcedureRequestResources               *[]ProcedureRequest      `bson:"_includedPlanProcedureRequestResources,omitempty"`
+	IncludedPlanDeviceUseRequestResources               *[]DeviceUseRequest      `bson:"_includedPlanDeviceUseRequestResources,omitempty"`
+	IncludedPlanSupplyRequestResources                  *[]SupplyRequest         `bson:"_includedPlanSupplyRequestResources,omitempty"`
+	IncludedPlanCarePlanResources                       *[]CarePlan              `bson:"_includedPlanCarePlanResources,omitempty"`
+	IncludedPlanNutritionOrderResources                 *[]NutritionOrder        `bson:"_includedPlanNutritionOrderResources,omitempty"`
+	IncludedPlanMedicationOrderResources                *[]MedicationOrder       `bson:"_includedPlanMedicationOrderResources,omitempty"`
+	IncludedPlanCommunicationRequestResources           *[]CommunicationRequest  `bson:"_includedPlanCommunicationRequestResources,omitempty"`
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPreviousResource() (clinicalImpression *ClinicalImpression, err error) {
+	if c.IncludedPreviousResources == nil {
+		err = errors.New("Included clinicalimpressions not requested")
+	} else if len(*c.IncludedPreviousResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 clinicalImpression, but found %d", len(*c.IncludedPreviousResources))
+	} else if len(*c.IncludedPreviousResources) == 1 {
+		clinicalImpression = &(*c.IncludedPreviousResources)[0]
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedAssessorResource() (practitioner *Practitioner, err error) {
+	if c.IncludedAssessorResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedAssessorResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAssessorResources))
+	} else if len(*c.IncludedAssessorResources) == 1 {
+		practitioner = &(*c.IncludedAssessorResources)[0]
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedProblemConditionResources() (conditions []Condition, err error) {
+	if c.IncludedProblemConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else {
+		conditions = *c.IncludedProblemConditionResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedProblemAllergyIntoleranceResources() (allergyIntolerances []AllergyIntolerance, err error) {
+	if c.IncludedProblemAllergyIntoleranceResources == nil {
+		err = errors.New("Included allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *c.IncludedProblemAllergyIntoleranceResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationFamilyMemberHistoryResources() (familyMemberHistories []FamilyMemberHistory, err error) {
+	if c.IncludedInvestigationFamilyMemberHistoryResources == nil {
+		err = errors.New("Included familyMemberHistories not requested")
+	} else {
+		familyMemberHistories = *c.IncludedInvestigationFamilyMemberHistoryResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationObservationResources() (observations []Observation, err error) {
+	if c.IncludedInvestigationObservationResources == nil {
+		err = errors.New("Included observations not requested")
+	} else {
+		observations = *c.IncludedInvestigationObservationResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationDiagnosticReportResources() (diagnosticReports []DiagnosticReport, err error) {
+	if c.IncludedInvestigationDiagnosticReportResources == nil {
+		err = errors.New("Included diagnosticReports not requested")
+	} else {
+		diagnosticReports = *c.IncludedInvestigationDiagnosticReportResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationQuestionnaireResponseResources() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.IncludedInvestigationQuestionnaireResponseResources == nil {
+		err = errors.New("Included questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.IncludedInvestigationQuestionnaireResponseResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionAppointmentResources() (appointments []Appointment, err error) {
+	if c.IncludedActionAppointmentResources == nil {
+		err = errors.New("Included appointments not requested")
+	} else {
+		appointments = *c.IncludedActionAppointmentResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionReferralRequestResources() (referralRequests []ReferralRequest, err error) {
+	if c.IncludedActionReferralRequestResources == nil {
+		err = errors.New("Included referralRequests not requested")
+	} else {
+		referralRequests = *c.IncludedActionReferralRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionNutritionOrderResources() (nutritionOrders []NutritionOrder, err error) {
+	if c.IncludedActionNutritionOrderResources == nil {
+		err = errors.New("Included nutritionOrders not requested")
+	} else {
+		nutritionOrders = *c.IncludedActionNutritionOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
+	if c.IncludedActionProcedureRequestResources == nil {
+		err = errors.New("Included procedureRequests not requested")
+	} else {
+		procedureRequests = *c.IncludedActionProcedureRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionProcedureResources() (procedures []Procedure, err error) {
+	if c.IncludedActionProcedureResources == nil {
+		err = errors.New("Included procedures not requested")
+	} else {
+		procedures = *c.IncludedActionProcedureResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
+	if c.IncludedActionDiagnosticOrderResources == nil {
+		err = errors.New("Included diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *c.IncludedActionDiagnosticOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionMedicationOrderResources() (medicationOrders []MedicationOrder, err error) {
+	if c.IncludedActionMedicationOrderResources == nil {
+		err = errors.New("Included medicationOrders not requested")
+	} else {
+		medicationOrders = *c.IncludedActionMedicationOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedActionSupplyRequestResources() (supplyRequests []SupplyRequest, err error) {
+	if c.IncludedActionSupplyRequestResources == nil {
+		err = errors.New("Included supplyRequests not requested")
+	} else {
+		supplyRequests = *c.IncludedActionSupplyRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanAppointmentResources() (appointments []Appointment, err error) {
+	if c.IncludedPlanAppointmentResources == nil {
+		err = errors.New("Included appointments not requested")
+	} else {
+		appointments = *c.IncludedPlanAppointmentResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanOrderResources() (orders []Order, err error) {
+	if c.IncludedPlanOrderResources == nil {
+		err = errors.New("Included orders not requested")
+	} else {
+		orders = *c.IncludedPlanOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanReferralRequestResources() (referralRequests []ReferralRequest, err error) {
+	if c.IncludedPlanReferralRequestResources == nil {
+		err = errors.New("Included referralRequests not requested")
+	} else {
+		referralRequests = *c.IncludedPlanReferralRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanProcessRequestResources() (processRequests []ProcessRequest, err error) {
+	if c.IncludedPlanProcessRequestResources == nil {
+		err = errors.New("Included processRequests not requested")
+	} else {
+		processRequests = *c.IncludedPlanProcessRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanVisionPrescriptionResources() (visionPrescriptions []VisionPrescription, err error) {
+	if c.IncludedPlanVisionPrescriptionResources == nil {
+		err = errors.New("Included visionPrescriptions not requested")
+	} else {
+		visionPrescriptions = *c.IncludedPlanVisionPrescriptionResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
+	if c.IncludedPlanDiagnosticOrderResources == nil {
+		err = errors.New("Included diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *c.IncludedPlanDiagnosticOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
+	if c.IncludedPlanProcedureRequestResources == nil {
+		err = errors.New("Included procedureRequests not requested")
+	} else {
+		procedureRequests = *c.IncludedPlanProcedureRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanDeviceUseRequestResources() (deviceUseRequests []DeviceUseRequest, err error) {
+	if c.IncludedPlanDeviceUseRequestResources == nil {
+		err = errors.New("Included deviceUseRequests not requested")
+	} else {
+		deviceUseRequests = *c.IncludedPlanDeviceUseRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanSupplyRequestResources() (supplyRequests []SupplyRequest, err error) {
+	if c.IncludedPlanSupplyRequestResources == nil {
+		err = errors.New("Included supplyRequests not requested")
+	} else {
+		supplyRequests = *c.IncludedPlanSupplyRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanCarePlanResources() (carePlans []CarePlan, err error) {
+	if c.IncludedPlanCarePlanResources == nil {
+		err = errors.New("Included carePlans not requested")
+	} else {
+		carePlans = *c.IncludedPlanCarePlanResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanNutritionOrderResources() (nutritionOrders []NutritionOrder, err error) {
+	if c.IncludedPlanNutritionOrderResources == nil {
+		err = errors.New("Included nutritionOrders not requested")
+	} else {
+		nutritionOrders = *c.IncludedPlanNutritionOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanMedicationOrderResources() (medicationOrders []MedicationOrder, err error) {
+	if c.IncludedPlanMedicationOrderResources == nil {
+		err = errors.New("Included medicationOrders not requested")
+	} else {
+		medicationOrders = *c.IncludedPlanMedicationOrderResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanCommunicationRequestResources() (communicationRequests []CommunicationRequest, err error) {
+	if c.IncludedPlanCommunicationRequestResources == nil {
+		err = errors.New("Included communicationRequests not requested")
+	} else {
+		communicationRequests = *c.IncludedPlanCommunicationRequestResources
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedPreviousResources != nil {
+		for _, r := range *c.IncludedPreviousResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAssessorResources != nil {
+		for _, r := range *c.IncludedAssessorResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProblemConditionResources != nil {
+		for _, r := range *c.IncludedProblemConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProblemAllergyIntoleranceResources != nil {
+		for _, r := range *c.IncludedProblemAllergyIntoleranceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedInvestigationFamilyMemberHistoryResources != nil {
+		for _, r := range *c.IncludedInvestigationFamilyMemberHistoryResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedInvestigationObservationResources != nil {
+		for _, r := range *c.IncludedInvestigationObservationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedInvestigationDiagnosticReportResources != nil {
+		for _, r := range *c.IncludedInvestigationDiagnosticReportResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedInvestigationQuestionnaireResponseResources != nil {
+		for _, r := range *c.IncludedInvestigationQuestionnaireResponseResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionAppointmentResources != nil {
+		for _, r := range *c.IncludedActionAppointmentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionReferralRequestResources != nil {
+		for _, r := range *c.IncludedActionReferralRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionNutritionOrderResources != nil {
+		for _, r := range *c.IncludedActionNutritionOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionProcedureRequestResources != nil {
+		for _, r := range *c.IncludedActionProcedureRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionProcedureResources != nil {
+		for _, r := range *c.IncludedActionProcedureResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionDiagnosticOrderResources != nil {
+		for _, r := range *c.IncludedActionDiagnosticOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionMedicationOrderResources != nil {
+		for _, r := range *c.IncludedActionMedicationOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActionSupplyRequestResources != nil {
+		for _, r := range *c.IncludedActionSupplyRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanAppointmentResources != nil {
+		for _, r := range *c.IncludedPlanAppointmentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanOrderResources != nil {
+		for _, r := range *c.IncludedPlanOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanReferralRequestResources != nil {
+		for _, r := range *c.IncludedPlanReferralRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanProcessRequestResources != nil {
+		for _, r := range *c.IncludedPlanProcessRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanVisionPrescriptionResources != nil {
+		for _, r := range *c.IncludedPlanVisionPrescriptionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanDiagnosticOrderResources != nil {
+		for _, r := range *c.IncludedPlanDiagnosticOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanProcedureRequestResources != nil {
+		for _, r := range *c.IncludedPlanProcedureRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanDeviceUseRequestResources != nil {
+		for _, r := range *c.IncludedPlanDeviceUseRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanSupplyRequestResources != nil {
+		for _, r := range *c.IncludedPlanSupplyRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanCarePlanResources != nil {
+		for _, r := range *c.IncludedPlanCarePlanResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanNutritionOrderResources != nil {
+		for _, r := range *c.IncludedPlanNutritionOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanMedicationOrderResources != nil {
+		for _, r := range *c.IncludedPlanMedicationOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPlanCommunicationRequestResources != nil {
+		for _, r := range *c.IncludedPlanCommunicationRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/communication.go
+++ b/models/communication.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Communication struct {
 	DomainResource `bson:",inline"`
@@ -78,4 +82,260 @@ type CommunicationPayloadComponent struct {
 	ContentString     string      `bson:"contentString,omitempty" json:"contentString,omitempty"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
+}
+
+type CommunicationPlus struct {
+	Communication             `bson:",inline"`
+	CommunicationPlusIncludes `bson:",inline"`
+}
+
+type CommunicationPlusIncludes struct {
+	IncludedRequestResources                *[]CommunicationRequest `bson:"_includedRequestResources,omitempty"`
+	IncludedSenderPractitionerResources     *[]Practitioner         `bson:"_includedSenderPractitionerResources,omitempty"`
+	IncludedSenderOrganizationResources     *[]Organization         `bson:"_includedSenderOrganizationResources,omitempty"`
+	IncludedSenderDeviceResources           *[]Device               `bson:"_includedSenderDeviceResources,omitempty"`
+	IncludedSenderPatientResources          *[]Patient              `bson:"_includedSenderPatientResources,omitempty"`
+	IncludedSenderRelatedPersonResources    *[]RelatedPerson        `bson:"_includedSenderRelatedPersonResources,omitempty"`
+	IncludedSubjectResources                *[]Patient              `bson:"_includedSubjectResources,omitempty"`
+	IncludedPatientResources                *[]Patient              `bson:"_includedPatientResources,omitempty"`
+	IncludedRecipientPractitionerResources  *[]Practitioner         `bson:"_includedRecipientPractitionerResources,omitempty"`
+	IncludedRecipientGroupResources         *[]Group                `bson:"_includedRecipientGroupResources,omitempty"`
+	IncludedRecipientOrganizationResources  *[]Organization         `bson:"_includedRecipientOrganizationResources,omitempty"`
+	IncludedRecipientDeviceResources        *[]Device               `bson:"_includedRecipientDeviceResources,omitempty"`
+	IncludedRecipientPatientResources       *[]Patient              `bson:"_includedRecipientPatientResources,omitempty"`
+	IncludedRecipientRelatedPersonResources *[]RelatedPerson        `bson:"_includedRecipientRelatedPersonResources,omitempty"`
+	IncludedEncounterResources              *[]Encounter            `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRequestResource() (communicationRequest *CommunicationRequest, err error) {
+	if c.IncludedRequestResources == nil {
+		err = errors.New("Included communicationrequests not requested")
+	} else if len(*c.IncludedRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedRequestResources))
+	} else if len(*c.IncludedRequestResources) == 1 {
+		communicationRequest = &(*c.IncludedRequestResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSenderPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedSenderPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedSenderPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSenderPractitionerResources))
+	} else if len(*c.IncludedSenderPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedSenderPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSenderOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedSenderOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedSenderOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSenderOrganizationResources))
+	} else if len(*c.IncludedSenderOrganizationResources) == 1 {
+		organization = &(*c.IncludedSenderOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSenderDeviceResource() (device *Device, err error) {
+	if c.IncludedSenderDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*c.IncludedSenderDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedSenderDeviceResources))
+	} else if len(*c.IncludedSenderDeviceResources) == 1 {
+		device = &(*c.IncludedSenderDeviceResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSenderPatientResource() (patient *Patient, err error) {
+	if c.IncludedSenderPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSenderPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSenderPatientResources))
+	} else if len(*c.IncludedSenderPatientResources) == 1 {
+		patient = &(*c.IncludedSenderPatientResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSenderRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedSenderRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedSenderRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSenderRelatedPersonResources))
+	} else if len(*c.IncludedSenderRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedSenderRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
+	if c.IncludedSubjectResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSubjectResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectResources))
+	} else if len(*c.IncludedSubjectResources) == 1 {
+		patient = &(*c.IncludedSubjectResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
+	if c.IncludedRecipientPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *c.IncludedRecipientPractitionerResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientGroupResources() (groups []Group, err error) {
+	if c.IncludedRecipientGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else {
+		groups = *c.IncludedRecipientGroupResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
+	if c.IncludedRecipientOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *c.IncludedRecipientOrganizationResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientDeviceResources() (devices []Device, err error) {
+	if c.IncludedRecipientDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *c.IncludedRecipientDeviceResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
+	if c.IncludedRecipientPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedRecipientPatientResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRecipientRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *c.IncludedRecipientRelatedPersonResources
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*c.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
+	} else if len(*c.IncludedEncounterResources) == 1 {
+		encounter = &(*c.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedRequestResources != nil {
+		for _, r := range *c.IncludedRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderPractitionerResources != nil {
+		for _, r := range *c.IncludedSenderPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderOrganizationResources != nil {
+		for _, r := range *c.IncludedSenderOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderDeviceResources != nil {
+		for _, r := range *c.IncludedSenderDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderPatientResources != nil {
+		for _, r := range *c.IncludedSenderPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderRelatedPersonResources != nil {
+		for _, r := range *c.IncludedSenderRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubjectResources != nil {
+		for _, r := range *c.IncludedSubjectResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientPractitionerResources != nil {
+		for _, r := range *c.IncludedRecipientPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientGroupResources != nil {
+		for _, r := range *c.IncludedRecipientGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientOrganizationResources != nil {
+		for _, r := range *c.IncludedRecipientOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientDeviceResources != nil {
+		for _, r := range *c.IncludedRecipientDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientPatientResources != nil {
+		for _, r := range *c.IncludedRecipientPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientRelatedPersonResources != nil {
+		for _, r := range *c.IncludedRecipientRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResources != nil {
+		for _, r := range *c.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/communicationrequest.go
+++ b/models/communicationrequest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type CommunicationRequest struct {
 	DomainResource    `bson:",inline"`
@@ -80,4 +84,279 @@ type CommunicationRequestPayloadComponent struct {
 	ContentString     string      `bson:"contentString,omitempty" json:"contentString,omitempty"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
+}
+
+type CommunicationRequestPlus struct {
+	CommunicationRequest             `bson:",inline"`
+	CommunicationRequestPlusIncludes `bson:",inline"`
+}
+
+type CommunicationRequestPlusIncludes struct {
+	IncludedRequesterPractitionerResources  *[]Practitioner  `bson:"_includedRequesterPractitionerResources,omitempty"`
+	IncludedRequesterPatientResources       *[]Patient       `bson:"_includedRequesterPatientResources,omitempty"`
+	IncludedRequesterRelatedPersonResources *[]RelatedPerson `bson:"_includedRequesterRelatedPersonResources,omitempty"`
+	IncludedSubjectResources                *[]Patient       `bson:"_includedSubjectResources,omitempty"`
+	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+	IncludedSenderPractitionerResources     *[]Practitioner  `bson:"_includedSenderPractitionerResources,omitempty"`
+	IncludedSenderOrganizationResources     *[]Organization  `bson:"_includedSenderOrganizationResources,omitempty"`
+	IncludedSenderDeviceResources           *[]Device        `bson:"_includedSenderDeviceResources,omitempty"`
+	IncludedSenderPatientResources          *[]Patient       `bson:"_includedSenderPatientResources,omitempty"`
+	IncludedSenderRelatedPersonResources    *[]RelatedPerson `bson:"_includedSenderRelatedPersonResources,omitempty"`
+	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedRecipientPractitionerResources  *[]Practitioner  `bson:"_includedRecipientPractitionerResources,omitempty"`
+	IncludedRecipientOrganizationResources  *[]Organization  `bson:"_includedRecipientOrganizationResources,omitempty"`
+	IncludedRecipientDeviceResources        *[]Device        `bson:"_includedRecipientDeviceResources,omitempty"`
+	IncludedRecipientPatientResources       *[]Patient       `bson:"_includedRecipientPatientResources,omitempty"`
+	IncludedRecipientRelatedPersonResources *[]RelatedPerson `bson:"_includedRecipientRelatedPersonResources,omitempty"`
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedRequesterPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedRequesterPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedRequesterPractitionerResources))
+	} else if len(*c.IncludedRequesterPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedRequesterPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterPatientResource() (patient *Patient, err error) {
+	if c.IncludedRequesterPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedRequesterPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedRequesterPatientResources))
+	} else if len(*c.IncludedRequesterPatientResources) == 1 {
+		patient = &(*c.IncludedRequesterPatientResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRequesterRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedRequesterRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRequesterRelatedPersonResources))
+	} else if len(*c.IncludedRequesterRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedRequesterRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
+	if c.IncludedSubjectResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSubjectResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectResources))
+	} else if len(*c.IncludedSubjectResources) == 1 {
+		patient = &(*c.IncludedSubjectResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*c.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
+	} else if len(*c.IncludedEncounterResources) == 1 {
+		encounter = &(*c.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSenderPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedSenderPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedSenderPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSenderPractitionerResources))
+	} else if len(*c.IncludedSenderPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedSenderPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSenderOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedSenderOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedSenderOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSenderOrganizationResources))
+	} else if len(*c.IncludedSenderOrganizationResources) == 1 {
+		organization = &(*c.IncludedSenderOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSenderDeviceResource() (device *Device, err error) {
+	if c.IncludedSenderDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*c.IncludedSenderDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedSenderDeviceResources))
+	} else if len(*c.IncludedSenderDeviceResources) == 1 {
+		device = &(*c.IncludedSenderDeviceResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSenderPatientResource() (patient *Patient, err error) {
+	if c.IncludedSenderPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSenderPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSenderPatientResources))
+	} else if len(*c.IncludedSenderPatientResources) == 1 {
+		patient = &(*c.IncludedSenderPatientResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedSenderRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedSenderRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedSenderRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSenderRelatedPersonResources))
+	} else if len(*c.IncludedSenderRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedSenderRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
+	if c.IncludedRecipientPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *c.IncludedRecipientPractitionerResources
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
+	if c.IncludedRecipientOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *c.IncludedRecipientOrganizationResources
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientDeviceResources() (devices []Device, err error) {
+	if c.IncludedRecipientDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *c.IncludedRecipientDeviceResources
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
+	if c.IncludedRecipientPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedRecipientPatientResources
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRecipientRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *c.IncludedRecipientRelatedPersonResources
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedRequesterPractitionerResources != nil {
+		for _, r := range *c.IncludedRequesterPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRequesterPatientResources != nil {
+		for _, r := range *c.IncludedRequesterPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRequesterRelatedPersonResources != nil {
+		for _, r := range *c.IncludedRequesterRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubjectResources != nil {
+		for _, r := range *c.IncludedSubjectResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResources != nil {
+		for _, r := range *c.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderPractitionerResources != nil {
+		for _, r := range *c.IncludedSenderPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderOrganizationResources != nil {
+		for _, r := range *c.IncludedSenderOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderDeviceResources != nil {
+		for _, r := range *c.IncludedSenderDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderPatientResources != nil {
+		for _, r := range *c.IncludedSenderPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSenderRelatedPersonResources != nil {
+		for _, r := range *c.IncludedSenderRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientPractitionerResources != nil {
+		for _, r := range *c.IncludedRecipientPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientOrganizationResources != nil {
+		for _, r := range *c.IncludedRecipientOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientDeviceResources != nil {
+		for _, r := range *c.IncludedRecipientDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientPatientResources != nil {
+		for _, r := range *c.IncludedRecipientPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRecipientRelatedPersonResources != nil {
+		for _, r := range *c.IncludedRecipientRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/composition.go
+++ b/models/composition.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Composition struct {
 	DomainResource  `bson:",inline"`
@@ -96,4 +100,162 @@ type CompositionSectionComponent struct {
 	Entry       []Reference                   `bson:"entry,omitempty" json:"entry,omitempty"`
 	EmptyReason *CodeableConcept              `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
 	Section     []CompositionSectionComponent `bson:"section,omitempty" json:"section,omitempty"`
+}
+
+type CompositionPlus struct {
+	Composition             `bson:",inline"`
+	CompositionPlusIncludes `bson:",inline"`
+}
+
+type CompositionPlusIncludes struct {
+	IncludedAuthorPractitionerResources   *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorDeviceResources         *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources        *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources  *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+	IncludedEncounterResources            *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+	IncludedAttesterPractitionerResources *[]Practitioner  `bson:"_includedAttesterPractitionerResources,omitempty"`
+	IncludedAttesterOrganizationResources *[]Organization  `bson:"_includedAttesterOrganizationResources,omitempty"`
+	IncludedAttesterPatientResources      *[]Patient       `bson:"_includedAttesterPatientResources,omitempty"`
+	IncludedPatientResources              *[]Patient       `bson:"_includedPatientResources,omitempty"`
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
+	if c.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *c.IncludedAuthorPractitionerResources
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
+	if c.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *c.IncludedAuthorDeviceResources
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
+	if c.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedAuthorPatientResources
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *c.IncludedAuthorRelatedPersonResources
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*c.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
+	} else if len(*c.IncludedEncounterResources) == 1 {
+		encounter = &(*c.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAttesterPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedAttesterPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedAttesterPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAttesterPractitionerResources))
+	} else if len(*c.IncludedAttesterPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedAttesterPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAttesterOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedAttesterOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedAttesterOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedAttesterOrganizationResources))
+	} else if len(*c.IncludedAttesterOrganizationResources) == 1 {
+		organization = &(*c.IncludedAttesterOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedAttesterPatientResource() (patient *Patient, err error) {
+	if c.IncludedAttesterPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedAttesterPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedAttesterPatientResources))
+	} else if len(*c.IncludedAttesterPatientResources) == 1 {
+		patient = &(*c.IncludedAttesterPatientResources)[0]
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *CompositionPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *c.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAuthorDeviceResources != nil {
+		for _, r := range *c.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAuthorPatientResources != nil {
+		for _, r := range *c.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *c.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResources != nil {
+		for _, r := range *c.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAttesterPractitionerResources != nil {
+		for _, r := range *c.IncludedAttesterPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAttesterOrganizationResources != nil {
+		for _, r := range *c.IncludedAttesterOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAttesterPatientResources != nil {
+		for _, r := range *c.IncludedAttesterPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/conceptmap.go
+++ b/models/conceptmap.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ConceptMap struct {
 	DomainResource  `bson:",inline"`
@@ -103,4 +107,119 @@ type ConceptMapOtherElementComponent struct {
 	Element    string `bson:"element,omitempty" json:"element,omitempty"`
 	CodeSystem string `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
 	Code       string `bson:"code,omitempty" json:"code,omitempty"`
+}
+
+type ConceptMapPlus struct {
+	ConceptMap             `bson:",inline"`
+	ConceptMapPlusIncludes `bson:",inline"`
+}
+
+type ConceptMapPlusIncludes struct {
+	IncludedSourceStructureDefinitionResources    *[]StructureDefinition `bson:"_includedSourceStructureDefinitionResources,omitempty"`
+	IncludedSourceValueSetResources               *[]ValueSet            `bson:"_includedSourceValueSetResources,omitempty"`
+	IncludedTargetStructureDefinitionResources    *[]StructureDefinition `bson:"_includedTargetStructureDefinitionResources,omitempty"`
+	IncludedTargetValueSetResources               *[]ValueSet            `bson:"_includedTargetValueSetResources,omitempty"`
+	IncludedSourceuriStructureDefinitionResources *[]StructureDefinition `bson:"_includedSourceuriStructureDefinitionResources,omitempty"`
+	IncludedSourceuriValueSetResources            *[]ValueSet            `bson:"_includedSourceuriValueSetResources,omitempty"`
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedSourceStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedSourceStructureDefinitionResources == nil {
+		err = errors.New("Included structuredefinitions not requested")
+	} else if len(*c.IncludedSourceStructureDefinitionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedSourceStructureDefinitionResources))
+	} else if len(*c.IncludedSourceStructureDefinitionResources) == 1 {
+		structureDefinition = &(*c.IncludedSourceStructureDefinitionResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedSourceValueSetResource() (valueSet *ValueSet, err error) {
+	if c.IncludedSourceValueSetResources == nil {
+		err = errors.New("Included valuesets not requested")
+	} else if len(*c.IncludedSourceValueSetResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedSourceValueSetResources))
+	} else if len(*c.IncludedSourceValueSetResources) == 1 {
+		valueSet = &(*c.IncludedSourceValueSetResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedTargetStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedTargetStructureDefinitionResources == nil {
+		err = errors.New("Included structuredefinitions not requested")
+	} else if len(*c.IncludedTargetStructureDefinitionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedTargetStructureDefinitionResources))
+	} else if len(*c.IncludedTargetStructureDefinitionResources) == 1 {
+		structureDefinition = &(*c.IncludedTargetStructureDefinitionResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedTargetValueSetResource() (valueSet *ValueSet, err error) {
+	if c.IncludedTargetValueSetResources == nil {
+		err = errors.New("Included valuesets not requested")
+	} else if len(*c.IncludedTargetValueSetResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedTargetValueSetResources))
+	} else if len(*c.IncludedTargetValueSetResources) == 1 {
+		valueSet = &(*c.IncludedTargetValueSetResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedSourceuriStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedSourceuriStructureDefinitionResources == nil {
+		err = errors.New("Included structuredefinitions not requested")
+	} else if len(*c.IncludedSourceuriStructureDefinitionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedSourceuriStructureDefinitionResources))
+	} else if len(*c.IncludedSourceuriStructureDefinitionResources) == 1 {
+		structureDefinition = &(*c.IncludedSourceuriStructureDefinitionResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedSourceuriValueSetResource() (valueSet *ValueSet, err error) {
+	if c.IncludedSourceuriValueSetResources == nil {
+		err = errors.New("Included valuesets not requested")
+	} else if len(*c.IncludedSourceuriValueSetResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedSourceuriValueSetResources))
+	} else if len(*c.IncludedSourceuriValueSetResources) == 1 {
+		valueSet = &(*c.IncludedSourceuriValueSetResources)[0]
+	}
+	return
+}
+
+func (c *ConceptMapPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedSourceStructureDefinitionResources != nil {
+		for _, r := range *c.IncludedSourceStructureDefinitionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSourceValueSetResources != nil {
+		for _, r := range *c.IncludedSourceValueSetResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedTargetStructureDefinitionResources != nil {
+		for _, r := range *c.IncludedTargetStructureDefinitionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedTargetValueSetResources != nil {
+		for _, r := range *c.IncludedTargetValueSetResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSourceuriStructureDefinitionResources != nil {
+		for _, r := range *c.IncludedSourceuriStructureDefinitionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSourceuriValueSetResources != nil {
+		for _, r := range *c.IncludedSourceuriValueSetResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/condition.go
+++ b/models/condition.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Condition struct {
 	DomainResource     `bson:",inline"`
@@ -94,4 +98,85 @@ type ConditionStageComponent struct {
 type ConditionEvidenceComponent struct {
 	Code   *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 	Detail []Reference      `bson:"detail,omitempty" json:"detail,omitempty"`
+}
+
+type ConditionPlus struct {
+	Condition             `bson:",inline"`
+	ConditionPlusIncludes `bson:",inline"`
+}
+
+type ConditionPlusIncludes struct {
+	IncludedEncounterResources            *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+	IncludedAsserterPractitionerResources *[]Practitioner `bson:"_includedAsserterPractitionerResources,omitempty"`
+	IncludedAsserterPatientResources      *[]Patient      `bson:"_includedAsserterPatientResources,omitempty"`
+	IncludedPatientResources              *[]Patient      `bson:"_includedPatientResources,omitempty"`
+}
+
+func (c *ConditionPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*c.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
+	} else if len(*c.IncludedEncounterResources) == 1 {
+		encounter = &(*c.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (c *ConditionPlusIncludes) GetIncludedAsserterPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedAsserterPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedAsserterPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAsserterPractitionerResources))
+	} else if len(*c.IncludedAsserterPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedAsserterPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *ConditionPlusIncludes) GetIncludedAsserterPatientResource() (patient *Patient, err error) {
+	if c.IncludedAsserterPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedAsserterPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedAsserterPatientResources))
+	} else if len(*c.IncludedAsserterPatientResources) == 1 {
+		patient = &(*c.IncludedAsserterPatientResources)[0]
+	}
+	return
+}
+
+func (c *ConditionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
+	} else if len(*c.IncludedPatientResources) == 1 {
+		patient = &(*c.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (c *ConditionPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedEncounterResources != nil {
+		for _, r := range *c.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAsserterPractitionerResources != nil {
+		for _, r := range *c.IncludedAsserterPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAsserterPatientResources != nil {
+		for _, r := range *c.IncludedAsserterPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/contract.go
+++ b/models/contract.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Contract struct {
 	DomainResource    `bson:",inline"`
@@ -148,4 +152,268 @@ type ContractLegalLanguageComponent struct {
 type ContractComputableLanguageComponent struct {
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
+}
+
+type ContractPlus struct {
+	Contract             `bson:",inline"`
+	ContractPlusIncludes `bson:",inline"`
+}
+
+type ContractPlusIncludes struct {
+	IncludedActorPractitionerResources   *[]Practitioner  `bson:"_includedActorPractitionerResources,omitempty"`
+	IncludedActorGroupResources          *[]Group         `bson:"_includedActorGroupResources,omitempty"`
+	IncludedActorOrganizationResources   *[]Organization  `bson:"_includedActorOrganizationResources,omitempty"`
+	IncludedActorDeviceResources         *[]Device        `bson:"_includedActorDeviceResources,omitempty"`
+	IncludedActorPatientResources        *[]Patient       `bson:"_includedActorPatientResources,omitempty"`
+	IncludedActorSubstanceResources      *[]Substance     `bson:"_includedActorSubstanceResources,omitempty"`
+	IncludedActorContractResources       *[]Contract      `bson:"_includedActorContractResources,omitempty"`
+	IncludedActorRelatedPersonResources  *[]RelatedPerson `bson:"_includedActorRelatedPersonResources,omitempty"`
+	IncludedActorLocationResources       *[]Location      `bson:"_includedActorLocationResources,omitempty"`
+	IncludedSubjectResources             *[]Patient       `bson:"_includedSubjectResources,omitempty"`
+	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedSignerPractitionerResources  *[]Practitioner  `bson:"_includedSignerPractitionerResources,omitempty"`
+	IncludedSignerOrganizationResources  *[]Organization  `bson:"_includedSignerOrganizationResources,omitempty"`
+	IncludedSignerPatientResources       *[]Patient       `bson:"_includedSignerPatientResources,omitempty"`
+	IncludedSignerRelatedPersonResources *[]RelatedPerson `bson:"_includedSignerRelatedPersonResources,omitempty"`
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedActorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedActorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedActorPractitionerResources))
+	} else if len(*c.IncludedActorPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedActorPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorGroupResource() (group *Group, err error) {
+	if c.IncludedActorGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*c.IncludedActorGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedActorGroupResources))
+	} else if len(*c.IncludedActorGroupResources) == 1 {
+		group = &(*c.IncludedActorGroupResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedActorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedActorOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedActorOrganizationResources))
+	} else if len(*c.IncludedActorOrganizationResources) == 1 {
+		organization = &(*c.IncludedActorOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
+	if c.IncludedActorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*c.IncludedActorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedActorDeviceResources))
+	} else if len(*c.IncludedActorDeviceResources) == 1 {
+		device = &(*c.IncludedActorDeviceResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
+	if c.IncludedActorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedActorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedActorPatientResources))
+	} else if len(*c.IncludedActorPatientResources) == 1 {
+		patient = &(*c.IncludedActorPatientResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorSubstanceResource() (substance *Substance, err error) {
+	if c.IncludedActorSubstanceResources == nil {
+		err = errors.New("Included substances not requested")
+	} else if len(*c.IncludedActorSubstanceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*c.IncludedActorSubstanceResources))
+	} else if len(*c.IncludedActorSubstanceResources) == 1 {
+		substance = &(*c.IncludedActorSubstanceResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorContractResource() (contract *Contract, err error) {
+	if c.IncludedActorContractResources == nil {
+		err = errors.New("Included contracts not requested")
+	} else if len(*c.IncludedActorContractResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 contract, but found %d", len(*c.IncludedActorContractResources))
+	} else if len(*c.IncludedActorContractResources) == 1 {
+		contract = &(*c.IncludedActorContractResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedActorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedActorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedActorRelatedPersonResources))
+	} else if len(*c.IncludedActorRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedActorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
+	if c.IncludedActorLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*c.IncludedActorLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*c.IncludedActorLocationResources))
+	} else if len(*c.IncludedActorLocationResources) == 1 {
+		location = &(*c.IncludedActorLocationResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedSubjectResources() (patients []Patient, err error) {
+	if c.IncludedSubjectResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedSubjectResources
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedPatientResources() (patients []Patient, err error) {
+	if c.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *c.IncludedPatientResources
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedSignerPractitionerResource() (practitioner *Practitioner, err error) {
+	if c.IncludedSignerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*c.IncludedSignerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSignerPractitionerResources))
+	} else if len(*c.IncludedSignerPractitionerResources) == 1 {
+		practitioner = &(*c.IncludedSignerPractitionerResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedSignerOrganizationResource() (organization *Organization, err error) {
+	if c.IncludedSignerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*c.IncludedSignerOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSignerOrganizationResources))
+	} else if len(*c.IncludedSignerOrganizationResources) == 1 {
+		organization = &(*c.IncludedSignerOrganizationResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedSignerPatientResource() (patient *Patient, err error) {
+	if c.IncludedSignerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*c.IncludedSignerPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSignerPatientResources))
+	} else if len(*c.IncludedSignerPatientResources) == 1 {
+		patient = &(*c.IncludedSignerPatientResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedSignerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedSignerRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*c.IncludedSignerRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSignerRelatedPersonResources))
+	} else if len(*c.IncludedSignerRelatedPersonResources) == 1 {
+		relatedPerson = &(*c.IncludedSignerRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (c *ContractPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedActorPractitionerResources != nil {
+		for _, r := range *c.IncludedActorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorGroupResources != nil {
+		for _, r := range *c.IncludedActorGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorOrganizationResources != nil {
+		for _, r := range *c.IncludedActorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorDeviceResources != nil {
+		for _, r := range *c.IncludedActorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorPatientResources != nil {
+		for _, r := range *c.IncludedActorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorSubstanceResources != nil {
+		for _, r := range *c.IncludedActorSubstanceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorContractResources != nil {
+		for _, r := range *c.IncludedActorContractResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorRelatedPersonResources != nil {
+		for _, r := range *c.IncludedActorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedActorLocationResources != nil {
+		for _, r := range *c.IncludedActorLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubjectResources != nil {
+		for _, r := range *c.IncludedSubjectResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResources != nil {
+		for _, r := range *c.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSignerPractitionerResources != nil {
+		for _, r := range *c.IncludedSignerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSignerOrganizationResources != nil {
+		for _, r := range *c.IncludedSignerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSignerPatientResources != nil {
+		for _, r := range *c.IncludedSignerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSignerRelatedPersonResources != nil {
+		for _, r := range *c.IncludedSignerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/dataelement.go
+++ b/models/dataelement.go
@@ -86,3 +86,16 @@ type DataElementMappingComponent struct {
 	Name     string `bson:"name,omitempty" json:"name,omitempty"`
 	Comments string `bson:"comments,omitempty" json:"comments,omitempty"`
 }
+
+type DataElementPlus struct {
+	DataElement             `bson:",inline"`
+	DataElementPlusIncludes `bson:",inline"`
+}
+
+type DataElementPlusIncludes struct {
+}
+
+func (d *DataElementPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/device.go
+++ b/models/device.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Device struct {
 	DomainResource  `bson:",inline"`
@@ -75,4 +79,68 @@ func (x *Device) UnmarshalJSON(data []byte) (err error) {
 		*x = Device(x2)
 	}
 	return
+}
+
+type DevicePlus struct {
+	Device             `bson:",inline"`
+	DevicePlusIncludes `bson:",inline"`
+}
+
+type DevicePlusIncludes struct {
+	IncludedPatientResources      *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
+	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+}
+
+func (d *DevicePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DevicePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
+	if d.IncludedOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*d.IncludedOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResources))
+	} else if len(*d.IncludedOrganizationResources) == 1 {
+		organization = &(*d.IncludedOrganizationResources)[0]
+	}
+	return
+}
+
+func (d *DevicePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if d.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*d.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedLocationResources))
+	} else if len(*d.IncludedLocationResources) == 1 {
+		location = &(*d.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (d *DevicePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResources != nil {
+		for _, r := range *d.IncludedOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedLocationResources != nil {
+		for _, r := range *d.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/devicemetric.go
+++ b/models/devicemetric.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DeviceMetric struct {
 	DomainResource    `bson:",inline"`
@@ -75,4 +79,51 @@ type DeviceMetricCalibrationComponent struct {
 	Type  string        `bson:"type,omitempty" json:"type,omitempty"`
 	State string        `bson:"state,omitempty" json:"state,omitempty"`
 	Time  *FHIRDateTime `bson:"time,omitempty" json:"time,omitempty"`
+}
+
+type DeviceMetricPlus struct {
+	DeviceMetric             `bson:",inline"`
+	DeviceMetricPlusIncludes `bson:",inline"`
+}
+
+type DeviceMetricPlusIncludes struct {
+	IncludedParentResources *[]DeviceComponent `bson:"_includedParentResources,omitempty"`
+	IncludedSourceResources *[]Device          `bson:"_includedSourceResources,omitempty"`
+}
+
+func (d *DeviceMetricPlusIncludes) GetIncludedParentResource() (deviceComponent *DeviceComponent, err error) {
+	if d.IncludedParentResources == nil {
+		err = errors.New("Included devicecomponents not requested")
+	} else if len(*d.IncludedParentResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceComponent, but found %d", len(*d.IncludedParentResources))
+	} else if len(*d.IncludedParentResources) == 1 {
+		deviceComponent = &(*d.IncludedParentResources)[0]
+	}
+	return
+}
+
+func (d *DeviceMetricPlusIncludes) GetIncludedSourceResource() (device *Device, err error) {
+	if d.IncludedSourceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedSourceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSourceResources))
+	} else if len(*d.IncludedSourceResources) == 1 {
+		device = &(*d.IncludedSourceResources)[0]
+	}
+	return
+}
+
+func (d *DeviceMetricPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedParentResources != nil {
+		for _, r := range *d.IncludedParentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSourceResources != nil {
+		for _, r := range *d.IncludedSourceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/deviceuserequest.go
+++ b/models/deviceuserequest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DeviceUseRequest struct {
 	DomainResource          `bson:",inline"`
@@ -75,4 +79,68 @@ func (x *DeviceUseRequest) UnmarshalJSON(data []byte) (err error) {
 		*x = DeviceUseRequest(x2)
 	}
 	return
+}
+
+type DeviceUseRequestPlus struct {
+	DeviceUseRequest             `bson:",inline"`
+	DeviceUseRequestPlusIncludes `bson:",inline"`
+}
+
+type DeviceUseRequestPlusIncludes struct {
+	IncludedSubjectResources *[]Patient `bson:"_includedSubjectResources,omitempty"`
+	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+	IncludedDeviceResources  *[]Device  `bson:"_includedDeviceResources,omitempty"`
+}
+
+func (d *DeviceUseRequestPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
+	if d.IncludedSubjectResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectResources))
+	} else if len(*d.IncludedSubjectResources) == 1 {
+		patient = &(*d.IncludedSubjectResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusIncludes) GetIncludedDeviceResource() (device *Device, err error) {
+	if d.IncludedDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResources))
+	} else if len(*d.IncludedDeviceResources) == 1 {
+		device = &(*d.IncludedDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedSubjectResources != nil {
+		for _, r := range *d.IncludedSubjectResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResources != nil {
+		for _, r := range *d.IncludedDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/deviceusestatement.go
+++ b/models/deviceusestatement.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DeviceUseStatement struct {
 	DomainResource          `bson:",inline"`
@@ -71,4 +75,68 @@ func (x *DeviceUseStatement) UnmarshalJSON(data []byte) (err error) {
 		*x = DeviceUseStatement(x2)
 	}
 	return
+}
+
+type DeviceUseStatementPlus struct {
+	DeviceUseStatement             `bson:",inline"`
+	DeviceUseStatementPlusIncludes `bson:",inline"`
+}
+
+type DeviceUseStatementPlusIncludes struct {
+	IncludedSubjectResources *[]Patient `bson:"_includedSubjectResources,omitempty"`
+	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+	IncludedDeviceResources  *[]Device  `bson:"_includedDeviceResources,omitempty"`
+}
+
+func (d *DeviceUseStatementPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
+	if d.IncludedSubjectResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectResources))
+	} else if len(*d.IncludedSubjectResources) == 1 {
+		patient = &(*d.IncludedSubjectResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusIncludes) GetIncludedDeviceResource() (device *Device, err error) {
+	if d.IncludedDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResources))
+	} else if len(*d.IncludedDeviceResources) == 1 {
+		device = &(*d.IncludedDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedSubjectResources != nil {
+		for _, r := range *d.IncludedSubjectResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResources != nil {
+		for _, r := range *d.IncludedDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DiagnosticOrder struct {
 	DomainResource        `bson:",inline"`
@@ -86,4 +90,234 @@ type DiagnosticOrderItemComponent struct {
 	BodySite *CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
 	Status   string                          `bson:"status,omitempty" json:"status,omitempty"`
 	Event    []DiagnosticOrderEventComponent `bson:"event,omitempty" json:"event,omitempty"`
+}
+
+type DiagnosticOrderPlus struct {
+	DiagnosticOrder             `bson:",inline"`
+	DiagnosticOrderPlusIncludes `bson:",inline"`
+}
+
+type DiagnosticOrderPlusIncludes struct {
+	IncludedSubjectGroupResources           *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources          *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources         *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectLocationResources        *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedEncounterResources              *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+	IncludedActorPractitionerPath1Resources *[]Practitioner `bson:"_includedActorPractitionerPath1Resources,omitempty"`
+	IncludedActorPractitionerPath2Resources *[]Practitioner `bson:"_includedActorPractitionerPath2Resources,omitempty"`
+	IncludedActorDevicePath1Resources       *[]Device       `bson:"_includedActorDevicePath1Resources,omitempty"`
+	IncludedActorDevicePath2Resources       *[]Device       `bson:"_includedActorDevicePath2Resources,omitempty"`
+	IncludedPatientResources                *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedOrdererResources                *[]Practitioner `bson:"_includedOrdererResources,omitempty"`
+	IncludedSpecimenPath1Resources          *[]Specimen     `bson:"_includedSpecimenPath1Resources,omitempty"`
+	IncludedSpecimenPath2Resources          *[]Specimen     `bson:"_includedSpecimenPath2Resources,omitempty"`
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if d.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*d.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
+	} else if len(*d.IncludedSubjectGroupResources) == 1 {
+		group = &(*d.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if d.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
+	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
+		device = &(*d.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if d.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
+	} else if len(*d.IncludedSubjectPatientResources) == 1 {
+		patient = &(*d.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if d.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*d.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedSubjectLocationResources))
+	} else if len(*d.IncludedSubjectLocationResources) == 1 {
+		location = &(*d.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*d.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
+	} else if len(*d.IncludedEncounterResources) == 1 {
+		encounter = &(*d.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedActorPractitionerPath1Resource() (practitioner *Practitioner, err error) {
+	if d.IncludedActorPractitionerPath1Resources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedActorPractitionerPath1Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedActorPractitionerPath1Resources))
+	} else if len(*d.IncludedActorPractitionerPath1Resources) == 1 {
+		practitioner = &(*d.IncludedActorPractitionerPath1Resources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedActorPractitionerPath2Resource() (practitioner *Practitioner, err error) {
+	if d.IncludedActorPractitionerPath2Resources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedActorPractitionerPath2Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedActorPractitionerPath2Resources))
+	} else if len(*d.IncludedActorPractitionerPath2Resources) == 1 {
+		practitioner = &(*d.IncludedActorPractitionerPath2Resources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedActorDevicePath1Resource() (device *Device, err error) {
+	if d.IncludedActorDevicePath1Resources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedActorDevicePath1Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedActorDevicePath1Resources))
+	} else if len(*d.IncludedActorDevicePath1Resources) == 1 {
+		device = &(*d.IncludedActorDevicePath1Resources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedActorDevicePath2Resource() (device *Device, err error) {
+	if d.IncludedActorDevicePath2Resources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedActorDevicePath2Resources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedActorDevicePath2Resources))
+	} else if len(*d.IncludedActorDevicePath2Resources) == 1 {
+		device = &(*d.IncludedActorDevicePath2Resources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedOrdererResource() (practitioner *Practitioner, err error) {
+	if d.IncludedOrdererResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedOrdererResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedOrdererResources))
+	} else if len(*d.IncludedOrdererResources) == 1 {
+		practitioner = &(*d.IncludedOrdererResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSpecimenPath1Resources() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenPath1Resources == nil {
+		err = errors.New("Included specimen not requested")
+	} else {
+		specimen = *d.IncludedSpecimenPath1Resources
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedSpecimenPath2Resources() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenPath2Resources == nil {
+		err = errors.New("Included specimen not requested")
+	} else {
+		specimen = *d.IncludedSpecimenPath2Resources
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedSubjectGroupResources != nil {
+		for _, r := range *d.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectDeviceResources != nil {
+		for _, r := range *d.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectPatientResources != nil {
+		for _, r := range *d.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectLocationResources != nil {
+		for _, r := range *d.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResources != nil {
+		for _, r := range *d.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedActorPractitionerPath1Resources != nil {
+		for _, r := range *d.IncludedActorPractitionerPath1Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedActorPractitionerPath2Resources != nil {
+		for _, r := range *d.IncludedActorPractitionerPath2Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedActorDevicePath1Resources != nil {
+		for _, r := range *d.IncludedActorDevicePath1Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedActorDevicePath2Resources != nil {
+		for _, r := range *d.IncludedActorDevicePath2Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrdererResources != nil {
+		for _, r := range *d.IncludedOrdererResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenPath1Resources != nil {
+		for _, r := range *d.IncludedSpecimenPath1Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenPath2Resources != nil {
+		for _, r := range *d.IncludedSpecimenPath2Resources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/diagnosticreport.go
+++ b/models/diagnosticreport.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DiagnosticReport struct {
 	DomainResource    `bson:",inline"`
@@ -82,4 +86,245 @@ func (x *DiagnosticReport) UnmarshalJSON(data []byte) (err error) {
 type DiagnosticReportImageComponent struct {
 	Comment string     `bson:"comment,omitempty" json:"comment,omitempty"`
 	Link    *Reference `bson:"link,omitempty" json:"link,omitempty"`
+}
+
+type DiagnosticReportPlus struct {
+	DiagnosticReport             `bson:",inline"`
+	DiagnosticReportPlusIncludes `bson:",inline"`
+}
+
+type DiagnosticReportPlusIncludes struct {
+	IncludedImageResources                   *[]Media            `bson:"_includedImageResources,omitempty"`
+	IncludedRequestReferralRequestResources  *[]ReferralRequest  `bson:"_includedRequestReferralRequestResources,omitempty"`
+	IncludedRequestDiagnosticOrderResources  *[]DiagnosticOrder  `bson:"_includedRequestDiagnosticOrderResources,omitempty"`
+	IncludedRequestProcedureRequestResources *[]ProcedureRequest `bson:"_includedRequestProcedureRequestResources,omitempty"`
+	IncludedPerformerPractitionerResources   *[]Practitioner     `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerOrganizationResources   *[]Organization     `bson:"_includedPerformerOrganizationResources,omitempty"`
+	IncludedSubjectGroupResources            *[]Group            `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources           *[]Device           `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources          *[]Patient          `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectLocationResources         *[]Location         `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedEncounterResources               *[]Encounter        `bson:"_includedEncounterResources,omitempty"`
+	IncludedResultResources                  *[]Observation      `bson:"_includedResultResources,omitempty"`
+	IncludedPatientResources                 *[]Patient          `bson:"_includedPatientResources,omitempty"`
+	IncludedSpecimenResources                *[]Specimen         `bson:"_includedSpecimenResources,omitempty"`
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedImageResource() (media *Media, err error) {
+	if d.IncludedImageResources == nil {
+		err = errors.New("Included media not requested")
+	} else if len(*d.IncludedImageResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 media, but found %d", len(*d.IncludedImageResources))
+	} else if len(*d.IncludedImageResources) == 1 {
+		media = &(*d.IncludedImageResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedRequestReferralRequestResources() (referralRequests []ReferralRequest, err error) {
+	if d.IncludedRequestReferralRequestResources == nil {
+		err = errors.New("Included referralRequests not requested")
+	} else {
+		referralRequests = *d.IncludedRequestReferralRequestResources
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedRequestDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
+	if d.IncludedRequestDiagnosticOrderResources == nil {
+		err = errors.New("Included diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *d.IncludedRequestDiagnosticOrderResources
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedRequestProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
+	if d.IncludedRequestProcedureRequestResources == nil {
+		err = errors.New("Included procedureRequests not requested")
+	} else {
+		procedureRequests = *d.IncludedRequestProcedureRequestResources
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
+	if d.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedPerformerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPerformerPractitionerResources))
+	} else if len(*d.IncludedPerformerPractitionerResources) == 1 {
+		practitioner = &(*d.IncludedPerformerPractitionerResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
+	if d.IncludedPerformerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*d.IncludedPerformerOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedPerformerOrganizationResources))
+	} else if len(*d.IncludedPerformerOrganizationResources) == 1 {
+		organization = &(*d.IncludedPerformerOrganizationResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if d.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*d.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
+	} else if len(*d.IncludedSubjectGroupResources) == 1 {
+		group = &(*d.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if d.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
+	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
+		device = &(*d.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if d.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
+	} else if len(*d.IncludedSubjectPatientResources) == 1 {
+		patient = &(*d.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if d.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*d.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedSubjectLocationResources))
+	} else if len(*d.IncludedSubjectLocationResources) == 1 {
+		location = &(*d.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*d.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
+	} else if len(*d.IncludedEncounterResources) == 1 {
+		encounter = &(*d.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedResultResources() (observations []Observation, err error) {
+	if d.IncludedResultResources == nil {
+		err = errors.New("Included observations not requested")
+	} else {
+		observations = *d.IncludedResultResources
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedSpecimenResources() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenResources == nil {
+		err = errors.New("Included specimen not requested")
+	} else {
+		specimen = *d.IncludedSpecimenResources
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedImageResources != nil {
+		for _, r := range *d.IncludedImageResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRequestReferralRequestResources != nil {
+		for _, r := range *d.IncludedRequestReferralRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRequestDiagnosticOrderResources != nil {
+		for _, r := range *d.IncludedRequestDiagnosticOrderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRequestProcedureRequestResources != nil {
+		for _, r := range *d.IncludedRequestProcedureRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *d.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPerformerOrganizationResources != nil {
+		for _, r := range *d.IncludedPerformerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectGroupResources != nil {
+		for _, r := range *d.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectDeviceResources != nil {
+		for _, r := range *d.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectPatientResources != nil {
+		for _, r := range *d.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectLocationResources != nil {
+		for _, r := range *d.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResources != nil {
+		for _, r := range *d.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedResultResources != nil {
+		for _, r := range *d.IncludedResultResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenResources != nil {
+		for _, r := range *d.IncludedSpecimenResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/documentmanifest.go
+++ b/models/documentmanifest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DocumentManifest struct {
 	DomainResource   `bson:",inline"`
@@ -81,4 +85,237 @@ type DocumentManifestContentComponent struct {
 type DocumentManifestRelatedComponent struct {
 	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Ref        *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
+}
+
+type DocumentManifestPlus struct {
+	DocumentManifest             `bson:",inline"`
+	DocumentManifestPlusIncludes `bson:",inline"`
+}
+
+type DocumentManifestPlusIncludes struct {
+	IncludedSubjectPractitionerResources    *[]Practitioner  `bson:"_includedSubjectPractitionerResources,omitempty"`
+	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources          *[]Device        `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedAuthorPractitionerResources     *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorOrganizationResources     *[]Organization  `bson:"_includedAuthorOrganizationResources,omitempty"`
+	IncludedAuthorDeviceResources           *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources          *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources    *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedRecipientPractitionerResources  *[]Practitioner  `bson:"_includedRecipientPractitionerResources,omitempty"`
+	IncludedRecipientOrganizationResources  *[]Organization  `bson:"_includedRecipientOrganizationResources,omitempty"`
+	IncludedRecipientPatientResources       *[]Patient       `bson:"_includedRecipientPatientResources,omitempty"`
+	IncludedRecipientRelatedPersonResources *[]RelatedPerson `bson:"_includedRecipientRelatedPersonResources,omitempty"`
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
+	if d.IncludedSubjectPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedSubjectPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedSubjectPractitionerResources))
+	} else if len(*d.IncludedSubjectPractitionerResources) == 1 {
+		practitioner = &(*d.IncludedSubjectPractitionerResources)[0]
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if d.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*d.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
+	} else if len(*d.IncludedSubjectGroupResources) == 1 {
+		group = &(*d.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if d.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
+	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
+		device = &(*d.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if d.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
+	} else if len(*d.IncludedSubjectPatientResources) == 1 {
+		patient = &(*d.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
+	if d.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *d.IncludedAuthorPractitionerResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedAuthorOrganizationResources() (organizations []Organization, err error) {
+	if d.IncludedAuthorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *d.IncludedAuthorOrganizationResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
+	if d.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *d.IncludedAuthorDeviceResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
+	if d.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *d.IncludedAuthorPatientResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *d.IncludedAuthorRelatedPersonResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
+	if d.IncludedRecipientPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *d.IncludedRecipientPractitionerResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
+	if d.IncludedRecipientOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *d.IncludedRecipientOrganizationResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
+	if d.IncludedRecipientPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *d.IncludedRecipientPatientResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedRecipientRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *d.IncludedRecipientRelatedPersonResources
+	}
+	return
+}
+
+func (d *DocumentManifestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedSubjectPractitionerResources != nil {
+		for _, r := range *d.IncludedSubjectPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectGroupResources != nil {
+		for _, r := range *d.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectDeviceResources != nil {
+		for _, r := range *d.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectPatientResources != nil {
+		for _, r := range *d.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *d.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorOrganizationResources != nil {
+		for _, r := range *d.IncludedAuthorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorDeviceResources != nil {
+		for _, r := range *d.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorPatientResources != nil {
+		for _, r := range *d.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *d.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRecipientPractitionerResources != nil {
+		for _, r := range *d.IncludedRecipientPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRecipientOrganizationResources != nil {
+		for _, r := range *d.IncludedRecipientOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRecipientPatientResources != nil {
+		for _, r := range *d.IncludedRecipientPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRecipientRelatedPersonResources != nil {
+		for _, r := range *d.IncludedRecipientRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type DocumentReference struct {
 	DomainResource   `bson:",inline"`
@@ -101,4 +105,262 @@ type DocumentReferenceContextComponent struct {
 type DocumentReferenceContextRelatedComponent struct {
 	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Ref        *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
+}
+
+type DocumentReferencePlus struct {
+	DocumentReference             `bson:",inline"`
+	DocumentReferencePlusIncludes `bson:",inline"`
+}
+
+type DocumentReferencePlusIncludes struct {
+	IncludedSubjectPractitionerResources       *[]Practitioner      `bson:"_includedSubjectPractitionerResources,omitempty"`
+	IncludedSubjectGroupResources              *[]Group             `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources             *[]Device            `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources            *[]Patient           `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedPatientResources                   *[]Patient           `bson:"_includedPatientResources,omitempty"`
+	IncludedAuthenticatorPractitionerResources *[]Practitioner      `bson:"_includedAuthenticatorPractitionerResources,omitempty"`
+	IncludedAuthenticatorOrganizationResources *[]Organization      `bson:"_includedAuthenticatorOrganizationResources,omitempty"`
+	IncludedCustodianResources                 *[]Organization      `bson:"_includedCustodianResources,omitempty"`
+	IncludedAuthorPractitionerResources        *[]Practitioner      `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorOrganizationResources        *[]Organization      `bson:"_includedAuthorOrganizationResources,omitempty"`
+	IncludedAuthorDeviceResources              *[]Device            `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources             *[]Patient           `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources       *[]RelatedPerson     `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+	IncludedEncounterResources                 *[]Encounter         `bson:"_includedEncounterResources,omitempty"`
+	IncludedRelatestoResources                 *[]DocumentReference `bson:"_includedRelatestoResources,omitempty"`
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
+	if d.IncludedSubjectPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedSubjectPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedSubjectPractitionerResources))
+	} else if len(*d.IncludedSubjectPractitionerResources) == 1 {
+		practitioner = &(*d.IncludedSubjectPractitionerResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if d.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*d.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
+	} else if len(*d.IncludedSubjectGroupResources) == 1 {
+		group = &(*d.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if d.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
+	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
+		device = &(*d.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if d.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
+	} else if len(*d.IncludedSubjectPatientResources) == 1 {
+		patient = &(*d.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if d.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*d.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
+	} else if len(*d.IncludedPatientResources) == 1 {
+		patient = &(*d.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthenticatorPractitionerResource() (practitioner *Practitioner, err error) {
+	if d.IncludedAuthenticatorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*d.IncludedAuthenticatorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedAuthenticatorPractitionerResources))
+	} else if len(*d.IncludedAuthenticatorPractitionerResources) == 1 {
+		practitioner = &(*d.IncludedAuthenticatorPractitionerResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthenticatorOrganizationResource() (organization *Organization, err error) {
+	if d.IncludedAuthenticatorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*d.IncludedAuthenticatorOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedAuthenticatorOrganizationResources))
+	} else if len(*d.IncludedAuthenticatorOrganizationResources) == 1 {
+		organization = &(*d.IncludedAuthenticatorOrganizationResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedCustodianResource() (organization *Organization, err error) {
+	if d.IncludedCustodianResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*d.IncludedCustodianResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedCustodianResources))
+	} else if len(*d.IncludedCustodianResources) == 1 {
+		organization = &(*d.IncludedCustodianResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
+	if d.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *d.IncludedAuthorPractitionerResources
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthorOrganizationResources() (organizations []Organization, err error) {
+	if d.IncludedAuthorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *d.IncludedAuthorOrganizationResources
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
+	if d.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *d.IncludedAuthorDeviceResources
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
+	if d.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *d.IncludedAuthorPatientResources
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *d.IncludedAuthorRelatedPersonResources
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*d.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
+	} else if len(*d.IncludedEncounterResources) == 1 {
+		encounter = &(*d.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedRelatestoResource() (documentReference *DocumentReference, err error) {
+	if d.IncludedRelatestoResources == nil {
+		err = errors.New("Included documentreferences not requested")
+	} else if len(*d.IncludedRelatestoResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 documentReference, but found %d", len(*d.IncludedRelatestoResources))
+	} else if len(*d.IncludedRelatestoResources) == 1 {
+		documentReference = &(*d.IncludedRelatestoResources)[0]
+	}
+	return
+}
+
+func (d *DocumentReferencePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedSubjectPractitionerResources != nil {
+		for _, r := range *d.IncludedSubjectPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectGroupResources != nil {
+		for _, r := range *d.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectDeviceResources != nil {
+		for _, r := range *d.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSubjectPatientResources != nil {
+		for _, r := range *d.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResources != nil {
+		for _, r := range *d.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthenticatorPractitionerResources != nil {
+		for _, r := range *d.IncludedAuthenticatorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthenticatorOrganizationResources != nil {
+		for _, r := range *d.IncludedAuthenticatorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedCustodianResources != nil {
+		for _, r := range *d.IncludedCustodianResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *d.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorOrganizationResources != nil {
+		for _, r := range *d.IncludedAuthorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorDeviceResources != nil {
+		for _, r := range *d.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorPatientResources != nil {
+		for _, r := range *d.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *d.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResources != nil {
+		for _, r := range *d.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRelatestoResources != nil {
+		for _, r := range *d.IncludedRelatestoResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/eligibilityrequest.go
+++ b/models/eligibilityrequest.go
@@ -67,3 +67,16 @@ func (x *EligibilityRequest) UnmarshalJSON(data []byte) (err error) {
 	}
 	return
 }
+
+type EligibilityRequestPlus struct {
+	EligibilityRequest             `bson:",inline"`
+	EligibilityRequestPlusIncludes `bson:",inline"`
+}
+
+type EligibilityRequestPlusIncludes struct {
+}
+
+func (e *EligibilityRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/eligibilityresponse.go
+++ b/models/eligibilityresponse.go
@@ -70,3 +70,16 @@ func (x *EligibilityResponse) UnmarshalJSON(data []byte) (err error) {
 	}
 	return
 }
+
+type EligibilityResponsePlus struct {
+	EligibilityResponse             `bson:",inline"`
+	EligibilityResponsePlusIncludes `bson:",inline"`
+}
+
+type EligibilityResponsePlusIncludes struct {
+}
+
+func (e *EligibilityResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Encounter struct {
 	DomainResource   `bson:",inline"`
@@ -109,4 +113,226 @@ type EncounterLocationComponent struct {
 	Location *Reference `bson:"location,omitempty" json:"location,omitempty"`
 	Status   string     `bson:"status,omitempty" json:"status,omitempty"`
 	Period   *Period    `bson:"period,omitempty" json:"period,omitempty"`
+}
+
+type EncounterPlus struct {
+	Encounter             `bson:",inline"`
+	EncounterPlusIncludes `bson:",inline"`
+}
+
+type EncounterPlusIncludes struct {
+	IncludedEpisodeofcareResources            *[]EpisodeOfCare   `bson:"_includedEpisodeofcareResources,omitempty"`
+	IncludedIncomingreferralResources         *[]ReferralRequest `bson:"_includedIncomingreferralResources,omitempty"`
+	IncludedPractitionerResources             *[]Practitioner    `bson:"_includedPractitionerResources,omitempty"`
+	IncludedAppointmentResources              *[]Appointment     `bson:"_includedAppointmentResources,omitempty"`
+	IncludedPartofResources                   *[]Encounter       `bson:"_includedPartofResources,omitempty"`
+	IncludedProcedureResources                *[]Procedure       `bson:"_includedProcedureResources,omitempty"`
+	IncludedParticipantPractitionerResources  *[]Practitioner    `bson:"_includedParticipantPractitionerResources,omitempty"`
+	IncludedParticipantRelatedPersonResources *[]RelatedPerson   `bson:"_includedParticipantRelatedPersonResources,omitempty"`
+	IncludedConditionResources                *[]Condition       `bson:"_includedConditionResources,omitempty"`
+	IncludedPatientResources                  *[]Patient         `bson:"_includedPatientResources,omitempty"`
+	IncludedLocationResources                 *[]Location        `bson:"_includedLocationResources,omitempty"`
+	IncludedIndicationConditionResources      *[]Condition       `bson:"_includedIndicationConditionResources,omitempty"`
+	IncludedIndicationProcedureResources      *[]Procedure       `bson:"_includedIndicationProcedureResources,omitempty"`
+}
+
+func (e *EncounterPlusIncludes) GetIncludedEpisodeofcareResources() (episodeOfCares []EpisodeOfCare, err error) {
+	if e.IncludedEpisodeofcareResources == nil {
+		err = errors.New("Included episodeOfCares not requested")
+	} else {
+		episodeOfCares = *e.IncludedEpisodeofcareResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedIncomingreferralResources() (referralRequests []ReferralRequest, err error) {
+	if e.IncludedIncomingreferralResources == nil {
+		err = errors.New("Included referralRequests not requested")
+	} else {
+		referralRequests = *e.IncludedIncomingreferralResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
+	if e.IncludedPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*e.IncludedPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResources))
+	} else if len(*e.IncludedPractitionerResources) == 1 {
+		practitioner = &(*e.IncludedPractitionerResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedAppointmentResource() (appointment *Appointment, err error) {
+	if e.IncludedAppointmentResources == nil {
+		err = errors.New("Included appointments not requested")
+	} else if len(*e.IncludedAppointmentResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*e.IncludedAppointmentResources))
+	} else if len(*e.IncludedAppointmentResources) == 1 {
+		appointment = &(*e.IncludedAppointmentResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedPartofResource() (encounter *Encounter, err error) {
+	if e.IncludedPartofResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*e.IncludedPartofResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*e.IncludedPartofResources))
+	} else if len(*e.IncludedPartofResources) == 1 {
+		encounter = &(*e.IncludedPartofResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedProcedureResources() (procedures []Procedure, err error) {
+	if e.IncludedProcedureResources == nil {
+		err = errors.New("Included procedures not requested")
+	} else {
+		procedures = *e.IncludedProcedureResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
+	if e.IncludedParticipantPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*e.IncludedParticipantPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedParticipantPractitionerResources))
+	} else if len(*e.IncludedParticipantPractitionerResources) == 1 {
+		practitioner = &(*e.IncludedParticipantPractitionerResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if e.IncludedParticipantRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*e.IncludedParticipantRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*e.IncludedParticipantRelatedPersonResources))
+	} else if len(*e.IncludedParticipantRelatedPersonResources) == 1 {
+		relatedPerson = &(*e.IncludedParticipantRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
+	if e.IncludedConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else {
+		conditions = *e.IncludedConditionResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if e.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*e.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResources))
+	} else if len(*e.IncludedPatientResources) == 1 {
+		patient = &(*e.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if e.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*e.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*e.IncludedLocationResources))
+	} else if len(*e.IncludedLocationResources) == 1 {
+		location = &(*e.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedIndicationConditionResources() (conditions []Condition, err error) {
+	if e.IncludedIndicationConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else {
+		conditions = *e.IncludedIndicationConditionResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedIndicationProcedureResources() (procedures []Procedure, err error) {
+	if e.IncludedIndicationProcedureResources == nil {
+		err = errors.New("Included procedures not requested")
+	} else {
+		procedures = *e.IncludedIndicationProcedureResources
+	}
+	return
+}
+
+func (e *EncounterPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.IncludedEpisodeofcareResources != nil {
+		for _, r := range *e.IncludedEpisodeofcareResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedIncomingreferralResources != nil {
+		for _, r := range *e.IncludedIncomingreferralResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPractitionerResources != nil {
+		for _, r := range *e.IncludedPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedAppointmentResources != nil {
+		for _, r := range *e.IncludedAppointmentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPartofResources != nil {
+		for _, r := range *e.IncludedPartofResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedProcedureResources != nil {
+		for _, r := range *e.IncludedProcedureResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedParticipantPractitionerResources != nil {
+		for _, r := range *e.IncludedParticipantPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedParticipantRelatedPersonResources != nil {
+		for _, r := range *e.IncludedParticipantRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedConditionResources != nil {
+		for _, r := range *e.IncludedConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPatientResources != nil {
+		for _, r := range *e.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedLocationResources != nil {
+		for _, r := range *e.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedIndicationConditionResources != nil {
+		for _, r := range *e.IncludedIndicationConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedIndicationProcedureResources != nil {
+		for _, r := range *e.IncludedIndicationProcedureResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/enrollmentresponse.go
+++ b/models/enrollmentresponse.go
@@ -70,3 +70,16 @@ func (x *EnrollmentResponse) UnmarshalJSON(data []byte) (err error) {
 	}
 	return
 }
+
+type EnrollmentResponsePlus struct {
+	EnrollmentResponse             `bson:",inline"`
+	EnrollmentResponsePlusIncludes `bson:",inline"`
+}
+
+type EnrollmentResponsePlusIncludes struct {
+}
+
+func (e *EnrollmentResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type EpisodeOfCare struct {
 	DomainResource       `bson:",inline"`
@@ -81,4 +85,132 @@ type EpisodeOfCareCareTeamComponent struct {
 	Role   []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
 	Period *Period           `bson:"period,omitempty" json:"period,omitempty"`
 	Member *Reference        `bson:"member,omitempty" json:"member,omitempty"`
+}
+
+type EpisodeOfCarePlus struct {
+	EpisodeOfCare             `bson:",inline"`
+	EpisodeOfCarePlusIncludes `bson:",inline"`
+}
+
+type EpisodeOfCarePlusIncludes struct {
+	IncludedConditionResources              *[]Condition       `bson:"_includedConditionResources,omitempty"`
+	IncludedIncomingreferralResources       *[]ReferralRequest `bson:"_includedIncomingreferralResources,omitempty"`
+	IncludedPatientResources                *[]Patient         `bson:"_includedPatientResources,omitempty"`
+	IncludedOrganizationResources           *[]Organization    `bson:"_includedOrganizationResources,omitempty"`
+	IncludedTeammemberPractitionerResources *[]Practitioner    `bson:"_includedTeammemberPractitionerResources,omitempty"`
+	IncludedTeammemberOrganizationResources *[]Organization    `bson:"_includedTeammemberOrganizationResources,omitempty"`
+	IncludedCaremanagerResources            *[]Practitioner    `bson:"_includedCaremanagerResources,omitempty"`
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
+	if e.IncludedConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else {
+		conditions = *e.IncludedConditionResources
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedIncomingreferralResources() (referralRequests []ReferralRequest, err error) {
+	if e.IncludedIncomingreferralResources == nil {
+		err = errors.New("Included referralRequests not requested")
+	} else {
+		referralRequests = *e.IncludedIncomingreferralResources
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if e.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*e.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResources))
+	} else if len(*e.IncludedPatientResources) == 1 {
+		patient = &(*e.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
+	if e.IncludedOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*e.IncludedOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedOrganizationResources))
+	} else if len(*e.IncludedOrganizationResources) == 1 {
+		organization = &(*e.IncludedOrganizationResources)[0]
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedTeammemberPractitionerResource() (practitioner *Practitioner, err error) {
+	if e.IncludedTeammemberPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*e.IncludedTeammemberPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedTeammemberPractitionerResources))
+	} else if len(*e.IncludedTeammemberPractitionerResources) == 1 {
+		practitioner = &(*e.IncludedTeammemberPractitionerResources)[0]
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedTeammemberOrganizationResource() (organization *Organization, err error) {
+	if e.IncludedTeammemberOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*e.IncludedTeammemberOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedTeammemberOrganizationResources))
+	} else if len(*e.IncludedTeammemberOrganizationResources) == 1 {
+		organization = &(*e.IncludedTeammemberOrganizationResources)[0]
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedCaremanagerResource() (practitioner *Practitioner, err error) {
+	if e.IncludedCaremanagerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*e.IncludedCaremanagerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedCaremanagerResources))
+	} else if len(*e.IncludedCaremanagerResources) == 1 {
+		practitioner = &(*e.IncludedCaremanagerResources)[0]
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.IncludedConditionResources != nil {
+		for _, r := range *e.IncludedConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedIncomingreferralResources != nil {
+		for _, r := range *e.IncludedIncomingreferralResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPatientResources != nil {
+		for _, r := range *e.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedOrganizationResources != nil {
+		for _, r := range *e.IncludedOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedTeammemberPractitionerResources != nil {
+		for _, r := range *e.IncludedTeammemberPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedTeammemberOrganizationResources != nil {
+		for _, r := range *e.IncludedTeammemberOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedCaremanagerResources != nil {
+		for _, r := range *e.IncludedCaremanagerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/explanationofbenefit.go
+++ b/models/explanationofbenefit.go
@@ -70,3 +70,16 @@ func (x *ExplanationOfBenefit) UnmarshalJSON(data []byte) (err error) {
 	}
 	return
 }
+
+type ExplanationOfBenefitPlus struct {
+	ExplanationOfBenefit             `bson:",inline"`
+	ExplanationOfBenefitPlusIncludes `bson:",inline"`
+}
+
+type ExplanationOfBenefitPlusIncludes struct {
+}
+
+func (e *ExplanationOfBenefitPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/flag.go
+++ b/models/flag.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Flag struct {
 	DomainResource `bson:",inline"`
@@ -67,4 +71,204 @@ func (x *Flag) UnmarshalJSON(data []byte) (err error) {
 		*x = Flag(x2)
 	}
 	return
+}
+
+type FlagPlus struct {
+	Flag             `bson:",inline"`
+	FlagPlusIncludes `bson:",inline"`
+}
+
+type FlagPlusIncludes struct {
+	IncludedSubjectPractitionerResources *[]Practitioner `bson:"_includedSubjectPractitionerResources,omitempty"`
+	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectOrganizationResources *[]Organization `bson:"_includedSubjectOrganizationResources,omitempty"`
+	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectLocationResources     *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedAuthorPractitionerResources  *[]Practitioner `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorOrganizationResources  *[]Organization `bson:"_includedAuthorOrganizationResources,omitempty"`
+	IncludedAuthorDeviceResources        *[]Device       `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources       *[]Patient      `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedEncounterResources           *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (f *FlagPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
+	if f.IncludedSubjectPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*f.IncludedSubjectPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedSubjectPractitionerResources))
+	} else if len(*f.IncludedSubjectPractitionerResources) == 1 {
+		practitioner = &(*f.IncludedSubjectPractitionerResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if f.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*f.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*f.IncludedSubjectGroupResources))
+	} else if len(*f.IncludedSubjectGroupResources) == 1 {
+		group = &(*f.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
+	if f.IncludedSubjectOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*f.IncludedSubjectOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedSubjectOrganizationResources))
+	} else if len(*f.IncludedSubjectOrganizationResources) == 1 {
+		organization = &(*f.IncludedSubjectOrganizationResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if f.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*f.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedSubjectPatientResources))
+	} else if len(*f.IncludedSubjectPatientResources) == 1 {
+		patient = &(*f.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if f.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*f.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*f.IncludedSubjectLocationResources))
+	} else if len(*f.IncludedSubjectLocationResources) == 1 {
+		location = &(*f.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if f.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*f.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResources))
+	} else if len(*f.IncludedPatientResources) == 1 {
+		patient = &(*f.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
+	if f.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*f.IncludedAuthorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedAuthorPractitionerResources))
+	} else if len(*f.IncludedAuthorPractitionerResources) == 1 {
+		practitioner = &(*f.IncludedAuthorPractitionerResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedAuthorOrganizationResource() (organization *Organization, err error) {
+	if f.IncludedAuthorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*f.IncludedAuthorOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedAuthorOrganizationResources))
+	} else if len(*f.IncludedAuthorOrganizationResources) == 1 {
+		organization = &(*f.IncludedAuthorOrganizationResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
+	if f.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*f.IncludedAuthorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*f.IncludedAuthorDeviceResources))
+	} else if len(*f.IncludedAuthorDeviceResources) == 1 {
+		device = &(*f.IncludedAuthorDeviceResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
+	if f.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*f.IncludedAuthorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedAuthorPatientResources))
+	} else if len(*f.IncludedAuthorPatientResources) == 1 {
+		patient = &(*f.IncludedAuthorPatientResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if f.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*f.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*f.IncludedEncounterResources))
+	} else if len(*f.IncludedEncounterResources) == 1 {
+		encounter = &(*f.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (f *FlagPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if f.IncludedSubjectPractitionerResources != nil {
+		for _, r := range *f.IncludedSubjectPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedSubjectGroupResources != nil {
+		for _, r := range *f.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedSubjectOrganizationResources != nil {
+		for _, r := range *f.IncludedSubjectOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedSubjectPatientResources != nil {
+		for _, r := range *f.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedSubjectLocationResources != nil {
+		for _, r := range *f.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedPatientResources != nil {
+		for _, r := range *f.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *f.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedAuthorOrganizationResources != nil {
+		for _, r := range *f.IncludedAuthorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedAuthorDeviceResources != nil {
+		for _, r := range *f.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedAuthorPatientResources != nil {
+		for _, r := range *f.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedEncounterResources != nil {
+		for _, r := range *f.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/goal.go
+++ b/models/goal.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Goal struct {
 	DomainResource       `bson:",inline"`
@@ -80,4 +84,85 @@ func (x *Goal) UnmarshalJSON(data []byte) (err error) {
 type GoalOutcomeComponent struct {
 	ResultCodeableConcept *CodeableConcept `bson:"resultCodeableConcept,omitempty" json:"resultCodeableConcept,omitempty"`
 	ResultReference       *Reference       `bson:"resultReference,omitempty" json:"resultReference,omitempty"`
+}
+
+type GoalPlus struct {
+	Goal             `bson:",inline"`
+	GoalPlusIncludes `bson:",inline"`
+}
+
+type GoalPlusIncludes struct {
+	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectOrganizationResources *[]Organization `bson:"_includedSubjectOrganizationResources,omitempty"`
+	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+}
+
+func (g *GoalPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if g.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*g.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedPatientResources))
+	} else if len(*g.IncludedPatientResources) == 1 {
+		patient = &(*g.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (g *GoalPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if g.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*g.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*g.IncludedSubjectGroupResources))
+	} else if len(*g.IncludedSubjectGroupResources) == 1 {
+		group = &(*g.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (g *GoalPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
+	if g.IncludedSubjectOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*g.IncludedSubjectOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*g.IncludedSubjectOrganizationResources))
+	} else if len(*g.IncludedSubjectOrganizationResources) == 1 {
+		organization = &(*g.IncludedSubjectOrganizationResources)[0]
+	}
+	return
+}
+
+func (g *GoalPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if g.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*g.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedSubjectPatientResources))
+	} else if len(*g.IncludedSubjectPatientResources) == 1 {
+		patient = &(*g.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (g *GoalPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.IncludedPatientResources != nil {
+		for _, r := range *g.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedSubjectGroupResources != nil {
+		for _, r := range *g.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedSubjectOrganizationResources != nil {
+		for _, r := range *g.IncludedSubjectOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedSubjectPatientResources != nil {
+		for _, r := range *g.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/group.go
+++ b/models/group.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Group struct {
 	DomainResource `bson:",inline"`
@@ -83,4 +87,102 @@ type GroupMemberComponent struct {
 	Entity   *Reference `bson:"entity,omitempty" json:"entity,omitempty"`
 	Period   *Period    `bson:"period,omitempty" json:"period,omitempty"`
 	Inactive *bool      `bson:"inactive,omitempty" json:"inactive,omitempty"`
+}
+
+type GroupPlus struct {
+	Group             `bson:",inline"`
+	GroupPlusIncludes `bson:",inline"`
+}
+
+type GroupPlusIncludes struct {
+	IncludedMemberPractitionerResources *[]Practitioner `bson:"_includedMemberPractitionerResources,omitempty"`
+	IncludedMemberDeviceResources       *[]Device       `bson:"_includedMemberDeviceResources,omitempty"`
+	IncludedMemberMedicationResources   *[]Medication   `bson:"_includedMemberMedicationResources,omitempty"`
+	IncludedMemberPatientResources      *[]Patient      `bson:"_includedMemberPatientResources,omitempty"`
+	IncludedMemberSubstanceResources    *[]Substance    `bson:"_includedMemberSubstanceResources,omitempty"`
+}
+
+func (g *GroupPlusIncludes) GetIncludedMemberPractitionerResource() (practitioner *Practitioner, err error) {
+	if g.IncludedMemberPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*g.IncludedMemberPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*g.IncludedMemberPractitionerResources))
+	} else if len(*g.IncludedMemberPractitionerResources) == 1 {
+		practitioner = &(*g.IncludedMemberPractitionerResources)[0]
+	}
+	return
+}
+
+func (g *GroupPlusIncludes) GetIncludedMemberDeviceResource() (device *Device, err error) {
+	if g.IncludedMemberDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*g.IncludedMemberDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*g.IncludedMemberDeviceResources))
+	} else if len(*g.IncludedMemberDeviceResources) == 1 {
+		device = &(*g.IncludedMemberDeviceResources)[0]
+	}
+	return
+}
+
+func (g *GroupPlusIncludes) GetIncludedMemberMedicationResource() (medication *Medication, err error) {
+	if g.IncludedMemberMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*g.IncludedMemberMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*g.IncludedMemberMedicationResources))
+	} else if len(*g.IncludedMemberMedicationResources) == 1 {
+		medication = &(*g.IncludedMemberMedicationResources)[0]
+	}
+	return
+}
+
+func (g *GroupPlusIncludes) GetIncludedMemberPatientResource() (patient *Patient, err error) {
+	if g.IncludedMemberPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*g.IncludedMemberPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedMemberPatientResources))
+	} else if len(*g.IncludedMemberPatientResources) == 1 {
+		patient = &(*g.IncludedMemberPatientResources)[0]
+	}
+	return
+}
+
+func (g *GroupPlusIncludes) GetIncludedMemberSubstanceResource() (substance *Substance, err error) {
+	if g.IncludedMemberSubstanceResources == nil {
+		err = errors.New("Included substances not requested")
+	} else if len(*g.IncludedMemberSubstanceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*g.IncludedMemberSubstanceResources))
+	} else if len(*g.IncludedMemberSubstanceResources) == 1 {
+		substance = &(*g.IncludedMemberSubstanceResources)[0]
+	}
+	return
+}
+
+func (g *GroupPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.IncludedMemberPractitionerResources != nil {
+		for _, r := range *g.IncludedMemberPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedMemberDeviceResources != nil {
+		for _, r := range *g.IncludedMemberDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedMemberMedicationResources != nil {
+		for _, r := range *g.IncludedMemberMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedMemberPatientResources != nil {
+		for _, r := range *g.IncludedMemberPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedMemberSubstanceResources != nil {
+		for _, r := range *g.IncludedMemberSubstanceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ImagingObjectSelection struct {
 	DomainResource `bson:",inline"`
@@ -91,4 +95,119 @@ type ImagingObjectSelectionInstanceComponent struct {
 type ImagingObjectSelectionFramesComponent struct {
 	FrameNumbers []uint32 `bson:"frameNumbers,omitempty" json:"frameNumbers,omitempty"`
 	Url          string   `bson:"url,omitempty" json:"url,omitempty"`
+}
+
+type ImagingObjectSelectionPlus struct {
+	ImagingObjectSelection             `bson:",inline"`
+	ImagingObjectSelectionPlusIncludes `bson:",inline"`
+}
+
+type ImagingObjectSelectionPlusIncludes struct {
+	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorOrganizationResources  *[]Organization  `bson:"_includedAuthorOrganizationResources,omitempty"`
+	IncludedAuthorDeviceResources        *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
+	if i.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*i.IncludedAuthorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedAuthorPractitionerResources))
+	} else if len(*i.IncludedAuthorPractitionerResources) == 1 {
+		practitioner = &(*i.IncludedAuthorPractitionerResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorOrganizationResource() (organization *Organization, err error) {
+	if i.IncludedAuthorOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*i.IncludedAuthorOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedAuthorOrganizationResources))
+	} else if len(*i.IncludedAuthorOrganizationResources) == 1 {
+		organization = &(*i.IncludedAuthorOrganizationResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
+	if i.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*i.IncludedAuthorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*i.IncludedAuthorDeviceResources))
+	} else if len(*i.IncludedAuthorDeviceResources) == 1 {
+		device = &(*i.IncludedAuthorDeviceResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
+	if i.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*i.IncludedAuthorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedAuthorPatientResources))
+	} else if len(*i.IncludedAuthorPatientResources) == 1 {
+		patient = &(*i.IncludedAuthorPatientResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if i.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*i.IncludedAuthorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*i.IncludedAuthorRelatedPersonResources))
+	} else if len(*i.IncludedAuthorRelatedPersonResources) == 1 {
+		relatedPerson = &(*i.IncludedAuthorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if i.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*i.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
+	} else if len(*i.IncludedPatientResources) == 1 {
+		patient = &(*i.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *i.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedAuthorOrganizationResources != nil {
+		for _, r := range *i.IncludedAuthorOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedAuthorDeviceResources != nil {
+		for _, r := range *i.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedAuthorPatientResources != nil {
+		for _, r := range *i.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *i.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPatientResources != nil {
+		for _, r := range *i.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/immunization.go
+++ b/models/immunization.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Immunization struct {
 	DomainResource      `bson:",inline"`
@@ -102,4 +106,119 @@ type ImmunizationVaccinationProtocolComponent struct {
 	TargetDisease    []CodeableConcept `bson:"targetDisease,omitempty" json:"targetDisease,omitempty"`
 	DoseStatus       *CodeableConcept  `bson:"doseStatus,omitempty" json:"doseStatus,omitempty"`
 	DoseStatusReason *CodeableConcept  `bson:"doseStatusReason,omitempty" json:"doseStatusReason,omitempty"`
+}
+
+type ImmunizationPlus struct {
+	Immunization             `bson:",inline"`
+	ImmunizationPlusIncludes `bson:",inline"`
+}
+
+type ImmunizationPlusIncludes struct {
+	IncludedRequesterResources    *[]Practitioner `bson:"_includedRequesterResources,omitempty"`
+	IncludedPerformerResources    *[]Practitioner `bson:"_includedPerformerResources,omitempty"`
+	IncludedReactionResources     *[]Observation  `bson:"_includedReactionResources,omitempty"`
+	IncludedManufacturerResources *[]Organization `bson:"_includedManufacturerResources,omitempty"`
+	IncludedPatientResources      *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedRequesterResource() (practitioner *Practitioner, err error) {
+	if i.IncludedRequesterResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*i.IncludedRequesterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedRequesterResources))
+	} else if len(*i.IncludedRequesterResources) == 1 {
+		practitioner = &(*i.IncludedRequesterResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedPerformerResource() (practitioner *Practitioner, err error) {
+	if i.IncludedPerformerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*i.IncludedPerformerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedPerformerResources))
+	} else if len(*i.IncludedPerformerResources) == 1 {
+		practitioner = &(*i.IncludedPerformerResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedReactionResource() (observation *Observation, err error) {
+	if i.IncludedReactionResources == nil {
+		err = errors.New("Included observations not requested")
+	} else if len(*i.IncludedReactionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*i.IncludedReactionResources))
+	} else if len(*i.IncludedReactionResources) == 1 {
+		observation = &(*i.IncludedReactionResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedManufacturerResource() (organization *Organization, err error) {
+	if i.IncludedManufacturerResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*i.IncludedManufacturerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedManufacturerResources))
+	} else if len(*i.IncludedManufacturerResources) == 1 {
+		organization = &(*i.IncludedManufacturerResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if i.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*i.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
+	} else if len(*i.IncludedPatientResources) == 1 {
+		patient = &(*i.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if i.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*i.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*i.IncludedLocationResources))
+	} else if len(*i.IncludedLocationResources) == 1 {
+		location = &(*i.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedRequesterResources != nil {
+		for _, r := range *i.IncludedRequesterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPerformerResources != nil {
+		for _, r := range *i.IncludedPerformerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedReactionResources != nil {
+		for _, r := range *i.IncludedReactionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedManufacturerResources != nil {
+		for _, r := range *i.IncludedManufacturerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPatientResources != nil {
+		for _, r := range *i.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedLocationResources != nil {
+		for _, r := range *i.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ImmunizationRecommendation struct {
 	DomainResource `bson:",inline"`
@@ -85,4 +89,79 @@ type ImmunizationRecommendationRecommendationProtocolComponent struct {
 	Description  string     `bson:"description,omitempty" json:"description,omitempty"`
 	Authority    *Reference `bson:"authority,omitempty" json:"authority,omitempty"`
 	Series       string     `bson:"series,omitempty" json:"series,omitempty"`
+}
+
+type ImmunizationRecommendationPlus struct {
+	ImmunizationRecommendation             `bson:",inline"`
+	ImmunizationRecommendationPlusIncludes `bson:",inline"`
+}
+
+type ImmunizationRecommendationPlusIncludes struct {
+	IncludedPatientResources                       *[]Patient            `bson:"_includedPatientResources,omitempty"`
+	IncludedInformationAllergyIntoleranceResources *[]AllergyIntolerance `bson:"_includedInformationAllergyIntoleranceResources,omitempty"`
+	IncludedInformationObservationResources        *[]Observation        `bson:"_includedInformationObservationResources,omitempty"`
+	IncludedSupportResources                       *[]Immunization       `bson:"_includedSupportResources,omitempty"`
+}
+
+func (i *ImmunizationRecommendationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if i.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*i.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
+	} else if len(*i.IncludedPatientResources) == 1 {
+		patient = &(*i.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusIncludes) GetIncludedInformationAllergyIntoleranceResources() (allergyIntolerances []AllergyIntolerance, err error) {
+	if i.IncludedInformationAllergyIntoleranceResources == nil {
+		err = errors.New("Included allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *i.IncludedInformationAllergyIntoleranceResources
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusIncludes) GetIncludedInformationObservationResources() (observations []Observation, err error) {
+	if i.IncludedInformationObservationResources == nil {
+		err = errors.New("Included observations not requested")
+	} else {
+		observations = *i.IncludedInformationObservationResources
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusIncludes) GetIncludedSupportResources() (immunizations []Immunization, err error) {
+	if i.IncludedSupportResources == nil {
+		err = errors.New("Included immunizations not requested")
+	} else {
+		immunizations = *i.IncludedSupportResources
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedPatientResources != nil {
+		for _, r := range *i.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedInformationAllergyIntoleranceResources != nil {
+		for _, r := range *i.IncludedInformationAllergyIntoleranceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedInformationObservationResources != nil {
+		for _, r := range *i.IncludedInformationObservationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedSupportResources != nil {
+		for _, r := range *i.IncludedSupportResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/implementationguide.go
+++ b/models/implementationguide.go
@@ -118,3 +118,16 @@ type ImplementationGuidePageComponent struct {
 	Format  string                             `bson:"format,omitempty" json:"format,omitempty"`
 	Page    []ImplementationGuidePageComponent `bson:"page,omitempty" json:"page,omitempty"`
 }
+
+type ImplementationGuidePlus struct {
+	ImplementationGuide             `bson:",inline"`
+	ImplementationGuidePlusIncludes `bson:",inline"`
+}
+
+type ImplementationGuidePlusIncludes struct {
+}
+
+func (i *ImplementationGuidePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/list.go
+++ b/models/list.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type List struct {
 	DomainResource `bson:",inline"`
@@ -79,4 +83,170 @@ type ListEntryComponent struct {
 	Deleted *bool            `bson:"deleted,omitempty" json:"deleted,omitempty"`
 	Date    *FHIRDateTime    `bson:"date,omitempty" json:"date,omitempty"`
 	Item    *Reference       `bson:"item,omitempty" json:"item,omitempty"`
+}
+
+type ListPlus struct {
+	List             `bson:",inline"`
+	ListPlusIncludes `bson:",inline"`
+}
+
+type ListPlusIncludes struct {
+	IncludedSubjectGroupResources       *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources      *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources     *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectLocationResources    *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
+	IncludedSourceDeviceResources       *[]Device       `bson:"_includedSourceDeviceResources,omitempty"`
+	IncludedSourcePatientResources      *[]Patient      `bson:"_includedSourcePatientResources,omitempty"`
+	IncludedEncounterResources          *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (l *ListPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if l.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*l.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*l.IncludedSubjectGroupResources))
+	} else if len(*l.IncludedSubjectGroupResources) == 1 {
+		group = &(*l.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if l.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*l.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedSubjectDeviceResources))
+	} else if len(*l.IncludedSubjectDeviceResources) == 1 {
+		device = &(*l.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if l.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*l.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedSubjectPatientResources))
+	} else if len(*l.IncludedSubjectPatientResources) == 1 {
+		patient = &(*l.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if l.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*l.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*l.IncludedSubjectLocationResources))
+	} else if len(*l.IncludedSubjectLocationResources) == 1 {
+		location = &(*l.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if l.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*l.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedPatientResources))
+	} else if len(*l.IncludedPatientResources) == 1 {
+		patient = &(*l.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
+	if l.IncludedSourcePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*l.IncludedSourcePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*l.IncludedSourcePractitionerResources))
+	} else if len(*l.IncludedSourcePractitionerResources) == 1 {
+		practitioner = &(*l.IncludedSourcePractitionerResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSourceDeviceResource() (device *Device, err error) {
+	if l.IncludedSourceDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*l.IncludedSourceDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedSourceDeviceResources))
+	} else if len(*l.IncludedSourceDeviceResources) == 1 {
+		device = &(*l.IncludedSourceDeviceResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
+	if l.IncludedSourcePatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*l.IncludedSourcePatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedSourcePatientResources))
+	} else if len(*l.IncludedSourcePatientResources) == 1 {
+		patient = &(*l.IncludedSourcePatientResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if l.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*l.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*l.IncludedEncounterResources))
+	} else if len(*l.IncludedEncounterResources) == 1 {
+		encounter = &(*l.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (l *ListPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if l.IncludedSubjectGroupResources != nil {
+		for _, r := range *l.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSubjectDeviceResources != nil {
+		for _, r := range *l.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSubjectPatientResources != nil {
+		for _, r := range *l.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSubjectLocationResources != nil {
+		for _, r := range *l.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedPatientResources != nil {
+		for _, r := range *l.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSourcePractitionerResources != nil {
+		for _, r := range *l.IncludedSourcePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSourceDeviceResources != nil {
+		for _, r := range *l.IncludedSourceDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedSourcePatientResources != nil {
+		for _, r := range *l.IncludedSourcePatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedEncounterResources != nil {
+		for _, r := range *l.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/media.go
+++ b/models/media.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Media struct {
 	DomainResource `bson:",inline"`
@@ -71,4 +75,136 @@ func (x *Media) UnmarshalJSON(data []byte) (err error) {
 		*x = Media(x2)
 	}
 	return
+}
+
+type MediaPlus struct {
+	Media             `bson:",inline"`
+	MediaPlusIncludes `bson:",inline"`
+}
+
+type MediaPlusIncludes struct {
+	IncludedSubjectPractitionerResources *[]Practitioner `bson:"_includedSubjectPractitionerResources,omitempty"`
+	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectSpecimenResources     *[]Specimen     `bson:"_includedSubjectSpecimenResources,omitempty"`
+	IncludedSubjectDeviceResources       *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedOperatorResources            *[]Practitioner `bson:"_includedOperatorResources,omitempty"`
+}
+
+func (m *MediaPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
+	if m.IncludedSubjectPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedSubjectPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedSubjectPractitionerResources))
+	} else if len(*m.IncludedSubjectPractitionerResources) == 1 {
+		practitioner = &(*m.IncludedSubjectPractitionerResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if m.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*m.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*m.IncludedSubjectGroupResources))
+	} else if len(*m.IncludedSubjectGroupResources) == 1 {
+		group = &(*m.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedSubjectSpecimenResource() (specimen *Specimen, err error) {
+	if m.IncludedSubjectSpecimenResources == nil {
+		err = errors.New("Included specimen not requested")
+	} else if len(*m.IncludedSubjectSpecimenResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*m.IncludedSubjectSpecimenResources))
+	} else if len(*m.IncludedSubjectSpecimenResources) == 1 {
+		specimen = &(*m.IncludedSubjectSpecimenResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if m.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*m.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedSubjectDeviceResources))
+	} else if len(*m.IncludedSubjectDeviceResources) == 1 {
+		device = &(*m.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if m.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedSubjectPatientResources))
+	} else if len(*m.IncludedSubjectPatientResources) == 1 {
+		patient = &(*m.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if m.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
+	} else if len(*m.IncludedPatientResources) == 1 {
+		patient = &(*m.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedOperatorResource() (practitioner *Practitioner, err error) {
+	if m.IncludedOperatorResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedOperatorResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedOperatorResources))
+	} else if len(*m.IncludedOperatorResources) == 1 {
+		practitioner = &(*m.IncludedOperatorResources)[0]
+	}
+	return
+}
+
+func (m *MediaPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedSubjectPractitionerResources != nil {
+		for _, r := range *m.IncludedSubjectPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSubjectGroupResources != nil {
+		for _, r := range *m.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSubjectSpecimenResources != nil {
+		for _, r := range *m.IncludedSubjectSpecimenResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSubjectDeviceResources != nil {
+		for _, r := range *m.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSubjectPatientResources != nil {
+		for _, r := range *m.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResources != nil {
+		for _, r := range *m.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedOperatorResources != nil {
+		for _, r := range *m.IncludedOperatorResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/medication.go
+++ b/models/medication.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Medication struct {
 	DomainResource `bson:",inline"`
@@ -90,4 +94,85 @@ type MedicationPackageComponent struct {
 type MedicationPackageContentComponent struct {
 	Item   *Reference `bson:"item,omitempty" json:"item,omitempty"`
 	Amount *Quantity  `bson:"amount,omitempty" json:"amount,omitempty"`
+}
+
+type MedicationPlus struct {
+	Medication             `bson:",inline"`
+	MedicationPlusIncludes `bson:",inline"`
+}
+
+type MedicationPlusIncludes struct {
+	IncludedIngredientMedicationResources *[]Medication   `bson:"_includedIngredientMedicationResources,omitempty"`
+	IncludedIngredientSubstanceResources  *[]Substance    `bson:"_includedIngredientSubstanceResources,omitempty"`
+	IncludedContentResources              *[]Medication   `bson:"_includedContentResources,omitempty"`
+	IncludedManufacturerResources         *[]Organization `bson:"_includedManufacturerResources,omitempty"`
+}
+
+func (m *MedicationPlusIncludes) GetIncludedIngredientMedicationResource() (medication *Medication, err error) {
+	if m.IncludedIngredientMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedIngredientMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedIngredientMedicationResources))
+	} else if len(*m.IncludedIngredientMedicationResources) == 1 {
+		medication = &(*m.IncludedIngredientMedicationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationPlusIncludes) GetIncludedIngredientSubstanceResource() (substance *Substance, err error) {
+	if m.IncludedIngredientSubstanceResources == nil {
+		err = errors.New("Included substances not requested")
+	} else if len(*m.IncludedIngredientSubstanceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*m.IncludedIngredientSubstanceResources))
+	} else if len(*m.IncludedIngredientSubstanceResources) == 1 {
+		substance = &(*m.IncludedIngredientSubstanceResources)[0]
+	}
+	return
+}
+
+func (m *MedicationPlusIncludes) GetIncludedContentResource() (medication *Medication, err error) {
+	if m.IncludedContentResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedContentResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedContentResources))
+	} else if len(*m.IncludedContentResources) == 1 {
+		medication = &(*m.IncludedContentResources)[0]
+	}
+	return
+}
+
+func (m *MedicationPlusIncludes) GetIncludedManufacturerResource() (organization *Organization, err error) {
+	if m.IncludedManufacturerResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*m.IncludedManufacturerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedManufacturerResources))
+	} else if len(*m.IncludedManufacturerResources) == 1 {
+		organization = &(*m.IncludedManufacturerResources)[0]
+	}
+	return
+}
+
+func (m *MedicationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedIngredientMedicationResources != nil {
+		for _, r := range *m.IncludedIngredientMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedIngredientSubstanceResources != nil {
+		for _, r := range *m.IncludedIngredientSubstanceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedContentResources != nil {
+		for _, r := range *m.IncludedContentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedManufacturerResources != nil {
+		for _, r := range *m.IncludedManufacturerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type MedicationAdministration struct {
 	DomainResource            `bson:",inline"`
@@ -86,4 +90,151 @@ type MedicationAdministrationDosageComponent struct {
 	Quantity            *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	RateRatio           *Ratio           `bson:"rateRatio,omitempty" json:"rateRatio,omitempty"`
 	RateRange           *Range           `bson:"rateRange,omitempty" json:"rateRange,omitempty"`
+}
+
+type MedicationAdministrationPlus struct {
+	MedicationAdministration             `bson:",inline"`
+	MedicationAdministrationPlusIncludes `bson:",inline"`
+}
+
+type MedicationAdministrationPlusIncludes struct {
+	IncludedPrescriptionResources              *[]MedicationOrder `bson:"_includedPrescriptionResources,omitempty"`
+	IncludedPractitionerPractitionerResources  *[]Practitioner    `bson:"_includedPractitionerPractitionerResources,omitempty"`
+	IncludedPractitionerPatientResources       *[]Patient         `bson:"_includedPractitionerPatientResources,omitempty"`
+	IncludedPractitionerRelatedPersonResources *[]RelatedPerson   `bson:"_includedPractitionerRelatedPersonResources,omitempty"`
+	IncludedPatientResources                   *[]Patient         `bson:"_includedPatientResources,omitempty"`
+	IncludedMedicationResources                *[]Medication      `bson:"_includedMedicationResources,omitempty"`
+	IncludedEncounterResources                 *[]Encounter       `bson:"_includedEncounterResources,omitempty"`
+	IncludedDeviceResources                    *[]Device          `bson:"_includedDeviceResources,omitempty"`
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedPrescriptionResource() (medicationOrder *MedicationOrder, err error) {
+	if m.IncludedPrescriptionResources == nil {
+		err = errors.New("Included medicationorders not requested")
+	} else if len(*m.IncludedPrescriptionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*m.IncludedPrescriptionResources))
+	} else if len(*m.IncludedPrescriptionResources) == 1 {
+		medicationOrder = &(*m.IncludedPrescriptionResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerPractitionerResource() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedPractitionerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerPractitionerResources))
+	} else if len(*m.IncludedPractitionerPractitionerResources) == 1 {
+		practitioner = &(*m.IncludedPractitionerPractitionerResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerPatientResource() (patient *Patient, err error) {
+	if m.IncludedPractitionerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPractitionerPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPractitionerPatientResources))
+	} else if len(*m.IncludedPractitionerPatientResources) == 1 {
+		patient = &(*m.IncludedPractitionerPatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if m.IncludedPractitionerRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*m.IncludedPractitionerRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedPractitionerRelatedPersonResources))
+	} else if len(*m.IncludedPractitionerRelatedPersonResources) == 1 {
+		relatedPerson = &(*m.IncludedPractitionerRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if m.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
+	} else if len(*m.IncludedPatientResources) == 1 {
+		patient = &(*m.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
+	if m.IncludedMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
+	} else if len(*m.IncludedMedicationResources) == 1 {
+		medication = &(*m.IncludedMedicationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if m.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*m.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResources))
+	} else if len(*m.IncludedEncounterResources) == 1 {
+		encounter = &(*m.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedDeviceResources() (devices []Device, err error) {
+	if m.IncludedDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else {
+		devices = *m.IncludedDeviceResources
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPrescriptionResources != nil {
+		for _, r := range *m.IncludedPrescriptionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerPractitionerResources != nil {
+		for _, r := range *m.IncludedPractitionerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerPatientResources != nil {
+		for _, r := range *m.IncludedPractitionerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerRelatedPersonResources != nil {
+		for _, r := range *m.IncludedPractitionerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResources != nil {
+		for _, r := range *m.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResources != nil {
+		for _, r := range *m.IncludedMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedEncounterResources != nil {
+		for _, r := range *m.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDeviceResources != nil {
+		for _, r := range *m.IncludedDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type MedicationDispense struct {
 	DomainResource            `bson:",inline"`
@@ -99,4 +103,145 @@ type MedicationDispenseSubstitutionComponent struct {
 	Type             *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
 	Reason           []CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 	ResponsibleParty []Reference       `bson:"responsibleParty,omitempty" json:"responsibleParty,omitempty"`
+}
+
+type MedicationDispensePlus struct {
+	MedicationDispense             `bson:",inline"`
+	MedicationDispensePlusIncludes `bson:",inline"`
+}
+
+type MedicationDispensePlusIncludes struct {
+	IncludedReceiverPractitionerResources *[]Practitioner    `bson:"_includedReceiverPractitionerResources,omitempty"`
+	IncludedReceiverPatientResources      *[]Patient         `bson:"_includedReceiverPatientResources,omitempty"`
+	IncludedDestinationResources          *[]Location        `bson:"_includedDestinationResources,omitempty"`
+	IncludedMedicationResources           *[]Medication      `bson:"_includedMedicationResources,omitempty"`
+	IncludedResponsiblepartyResources     *[]Practitioner    `bson:"_includedResponsiblepartyResources,omitempty"`
+	IncludedDispenserResources            *[]Practitioner    `bson:"_includedDispenserResources,omitempty"`
+	IncludedPrescriptionResources         *[]MedicationOrder `bson:"_includedPrescriptionResources,omitempty"`
+	IncludedPatientResources              *[]Patient         `bson:"_includedPatientResources,omitempty"`
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedReceiverPractitionerResources() (practitioners []Practitioner, err error) {
+	if m.IncludedReceiverPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *m.IncludedReceiverPractitionerResources
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedReceiverPatientResources() (patients []Patient, err error) {
+	if m.IncludedReceiverPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *m.IncludedReceiverPatientResources
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedDestinationResource() (location *Location, err error) {
+	if m.IncludedDestinationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*m.IncludedDestinationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*m.IncludedDestinationResources))
+	} else if len(*m.IncludedDestinationResources) == 1 {
+		location = &(*m.IncludedDestinationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
+	if m.IncludedMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
+	} else if len(*m.IncludedMedicationResources) == 1 {
+		medication = &(*m.IncludedMedicationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedResponsiblepartyResources() (practitioners []Practitioner, err error) {
+	if m.IncludedResponsiblepartyResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *m.IncludedResponsiblepartyResources
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedDispenserResource() (practitioner *Practitioner, err error) {
+	if m.IncludedDispenserResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedDispenserResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedDispenserResources))
+	} else if len(*m.IncludedDispenserResources) == 1 {
+		practitioner = &(*m.IncludedDispenserResources)[0]
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedPrescriptionResources() (medicationOrders []MedicationOrder, err error) {
+	if m.IncludedPrescriptionResources == nil {
+		err = errors.New("Included medicationOrders not requested")
+	} else {
+		medicationOrders = *m.IncludedPrescriptionResources
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if m.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
+	} else if len(*m.IncludedPatientResources) == 1 {
+		patient = &(*m.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationDispensePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedReceiverPractitionerResources != nil {
+		for _, r := range *m.IncludedReceiverPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedReceiverPatientResources != nil {
+		for _, r := range *m.IncludedReceiverPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDestinationResources != nil {
+		for _, r := range *m.IncludedDestinationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResources != nil {
+		for _, r := range *m.IncludedMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedResponsiblepartyResources != nil {
+		for _, r := range *m.IncludedResponsiblepartyResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDispenserResources != nil {
+		for _, r := range *m.IncludedDispenserResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPrescriptionResources != nil {
+		for _, r := range *m.IncludedPrescriptionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResources != nil {
+		for _, r := range *m.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/medicationorder.go
+++ b/models/medicationorder.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type MedicationOrder struct {
 	DomainResource            `bson:",inline"`
@@ -107,4 +111,85 @@ type MedicationOrderDispenseRequestComponent struct {
 type MedicationOrderSubstitutionComponent struct {
 	Type   *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 	Reason *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+}
+
+type MedicationOrderPlus struct {
+	MedicationOrder             `bson:",inline"`
+	MedicationOrderPlusIncludes `bson:",inline"`
+}
+
+type MedicationOrderPlusIncludes struct {
+	IncludedPrescriberResources *[]Practitioner `bson:"_includedPrescriberResources,omitempty"`
+	IncludedPatientResources    *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedMedicationResources *[]Medication   `bson:"_includedMedicationResources,omitempty"`
+	IncludedEncounterResources  *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (m *MedicationOrderPlusIncludes) GetIncludedPrescriberResource() (practitioner *Practitioner, err error) {
+	if m.IncludedPrescriberResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedPrescriberResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPrescriberResources))
+	} else if len(*m.IncludedPrescriberResources) == 1 {
+		practitioner = &(*m.IncludedPrescriberResources)[0]
+	}
+	return
+}
+
+func (m *MedicationOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if m.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
+	} else if len(*m.IncludedPatientResources) == 1 {
+		patient = &(*m.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationOrderPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
+	if m.IncludedMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
+	} else if len(*m.IncludedMedicationResources) == 1 {
+		medication = &(*m.IncludedMedicationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if m.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*m.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResources))
+	} else if len(*m.IncludedEncounterResources) == 1 {
+		encounter = &(*m.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (m *MedicationOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPrescriberResources != nil {
+		for _, r := range *m.IncludedPrescriberResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResources != nil {
+		for _, r := range *m.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResources != nil {
+		for _, r := range *m.IncludedMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedEncounterResources != nil {
+		for _, r := range *m.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type MedicationStatement struct {
 	DomainResource              `bson:",inline"`
@@ -91,4 +95,102 @@ type MedicationStatementDosageComponent struct {
 	RateRatio               *Ratio           `bson:"rateRatio,omitempty" json:"rateRatio,omitempty"`
 	RateRange               *Range           `bson:"rateRange,omitempty" json:"rateRange,omitempty"`
 	MaxDosePerPeriod        *Ratio           `bson:"maxDosePerPeriod,omitempty" json:"maxDosePerPeriod,omitempty"`
+}
+
+type MedicationStatementPlus struct {
+	MedicationStatement             `bson:",inline"`
+	MedicationStatementPlusIncludes `bson:",inline"`
+}
+
+type MedicationStatementPlusIncludes struct {
+	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedMedicationResources          *[]Medication    `bson:"_includedMedicationResources,omitempty"`
+	IncludedSourcePractitionerResources  *[]Practitioner  `bson:"_includedSourcePractitionerResources,omitempty"`
+	IncludedSourcePatientResources       *[]Patient       `bson:"_includedSourcePatientResources,omitempty"`
+	IncludedSourceRelatedPersonResources *[]RelatedPerson `bson:"_includedSourceRelatedPersonResources,omitempty"`
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if m.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
+	} else if len(*m.IncludedPatientResources) == 1 {
+		patient = &(*m.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
+	if m.IncludedMedicationResources == nil {
+		err = errors.New("Included medications not requested")
+	} else if len(*m.IncludedMedicationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
+	} else if len(*m.IncludedMedicationResources) == 1 {
+		medication = &(*m.IncludedMedicationResources)[0]
+	}
+	return
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
+	if m.IncludedSourcePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedSourcePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedSourcePractitionerResources))
+	} else if len(*m.IncludedSourcePractitionerResources) == 1 {
+		practitioner = &(*m.IncludedSourcePractitionerResources)[0]
+	}
+	return
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
+	if m.IncludedSourcePatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*m.IncludedSourcePatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedSourcePatientResources))
+	} else if len(*m.IncludedSourcePatientResources) == 1 {
+		patient = &(*m.IncludedSourcePatientResources)[0]
+	}
+	return
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedSourceRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if m.IncludedSourceRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*m.IncludedSourceRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedSourceRelatedPersonResources))
+	} else if len(*m.IncludedSourceRelatedPersonResources) == 1 {
+		relatedPerson = &(*m.IncludedSourceRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (m *MedicationStatementPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPatientResources != nil {
+		for _, r := range *m.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResources != nil {
+		for _, r := range *m.IncludedMedicationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSourcePractitionerResources != nil {
+		for _, r := range *m.IncludedSourcePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSourcePatientResources != nil {
+		for _, r := range *m.IncludedSourcePatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSourceRelatedPersonResources != nil {
+		for _, r := range *m.IncludedSourceRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/messageheader.go
+++ b/models/messageheader.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type MessageHeader struct {
 	DomainResource `bson:",inline"`
@@ -90,4 +94,136 @@ type MessageHeaderMessageDestinationComponent struct {
 	Name     string     `bson:"name,omitempty" json:"name,omitempty"`
 	Target   *Reference `bson:"target,omitempty" json:"target,omitempty"`
 	Endpoint string     `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+}
+
+type MessageHeaderPlus struct {
+	MessageHeader             `bson:",inline"`
+	MessageHeaderPlusIncludes `bson:",inline"`
+}
+
+type MessageHeaderPlusIncludes struct {
+	IncludedReceiverPractitionerResources    *[]Practitioner `bson:"_includedReceiverPractitionerResources,omitempty"`
+	IncludedReceiverOrganizationResources    *[]Organization `bson:"_includedReceiverOrganizationResources,omitempty"`
+	IncludedAuthorResources                  *[]Practitioner `bson:"_includedAuthorResources,omitempty"`
+	IncludedTargetResources                  *[]Device       `bson:"_includedTargetResources,omitempty"`
+	IncludedResponsiblePractitionerResources *[]Practitioner `bson:"_includedResponsiblePractitionerResources,omitempty"`
+	IncludedResponsibleOrganizationResources *[]Organization `bson:"_includedResponsibleOrganizationResources,omitempty"`
+	IncludedEntererResources                 *[]Practitioner `bson:"_includedEntererResources,omitempty"`
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedReceiverPractitionerResource() (practitioner *Practitioner, err error) {
+	if m.IncludedReceiverPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedReceiverPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedReceiverPractitionerResources))
+	} else if len(*m.IncludedReceiverPractitionerResources) == 1 {
+		practitioner = &(*m.IncludedReceiverPractitionerResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedReceiverOrganizationResource() (organization *Organization, err error) {
+	if m.IncludedReceiverOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*m.IncludedReceiverOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedReceiverOrganizationResources))
+	} else if len(*m.IncludedReceiverOrganizationResources) == 1 {
+		organization = &(*m.IncludedReceiverOrganizationResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedAuthorResource() (practitioner *Practitioner, err error) {
+	if m.IncludedAuthorResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedAuthorResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedAuthorResources))
+	} else if len(*m.IncludedAuthorResources) == 1 {
+		practitioner = &(*m.IncludedAuthorResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedTargetResource() (device *Device, err error) {
+	if m.IncludedTargetResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*m.IncludedTargetResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedTargetResources))
+	} else if len(*m.IncludedTargetResources) == 1 {
+		device = &(*m.IncludedTargetResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedResponsiblePractitionerResource() (practitioner *Practitioner, err error) {
+	if m.IncludedResponsiblePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedResponsiblePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedResponsiblePractitionerResources))
+	} else if len(*m.IncludedResponsiblePractitionerResources) == 1 {
+		practitioner = &(*m.IncludedResponsiblePractitionerResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedResponsibleOrganizationResource() (organization *Organization, err error) {
+	if m.IncludedResponsibleOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*m.IncludedResponsibleOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedResponsibleOrganizationResources))
+	} else if len(*m.IncludedResponsibleOrganizationResources) == 1 {
+		organization = &(*m.IncludedResponsibleOrganizationResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedEntererResource() (practitioner *Practitioner, err error) {
+	if m.IncludedEntererResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*m.IncludedEntererResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedEntererResources))
+	} else if len(*m.IncludedEntererResources) == 1 {
+		practitioner = &(*m.IncludedEntererResources)[0]
+	}
+	return
+}
+
+func (m *MessageHeaderPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedReceiverPractitionerResources != nil {
+		for _, r := range *m.IncludedReceiverPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedReceiverOrganizationResources != nil {
+		for _, r := range *m.IncludedReceiverOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedAuthorResources != nil {
+		for _, r := range *m.IncludedAuthorResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedTargetResources != nil {
+		for _, r := range *m.IncludedTargetResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedResponsiblePractitionerResources != nil {
+		for _, r := range *m.IncludedResponsiblePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedResponsibleOrganizationResources != nil {
+		for _, r := range *m.IncludedResponsibleOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedEntererResources != nil {
+		for _, r := range *m.IncludedEntererResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type NutritionOrder struct {
 	DomainResource         `bson:",inline"`
@@ -117,4 +121,68 @@ type NutritionOrderEnteralFormulaAdministrationComponent struct {
 	Quantity           *Quantity `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	RateSimpleQuantity *Quantity `bson:"rateSimpleQuantity,omitempty" json:"rateSimpleQuantity,omitempty"`
 	RateRatio          *Ratio    `bson:"rateRatio,omitempty" json:"rateRatio,omitempty"`
+}
+
+type NutritionOrderPlus struct {
+	NutritionOrder             `bson:",inline"`
+	NutritionOrderPlusIncludes `bson:",inline"`
+}
+
+type NutritionOrderPlusIncludes struct {
+	IncludedProviderResources  *[]Practitioner `bson:"_includedProviderResources,omitempty"`
+	IncludedPatientResources   *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedEncounterResources *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (n *NutritionOrderPlusIncludes) GetIncludedProviderResource() (practitioner *Practitioner, err error) {
+	if n.IncludedProviderResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*n.IncludedProviderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*n.IncludedProviderResources))
+	} else if len(*n.IncludedProviderResources) == 1 {
+		practitioner = &(*n.IncludedProviderResources)[0]
+	}
+	return
+}
+
+func (n *NutritionOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if n.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*n.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*n.IncludedPatientResources))
+	} else if len(*n.IncludedPatientResources) == 1 {
+		patient = &(*n.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (n *NutritionOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if n.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*n.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*n.IncludedEncounterResources))
+	} else if len(*n.IncludedEncounterResources) == 1 {
+		encounter = &(*n.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (n *NutritionOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if n.IncludedProviderResources != nil {
+		for _, r := range *n.IncludedProviderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.IncludedPatientResources != nil {
+		for _, r := range *n.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.IncludedEncounterResources != nil {
+		for _, r := range *n.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/observation.go
+++ b/models/observation.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Observation struct {
 	DomainResource       `bson:",inline"`
@@ -118,4 +122,264 @@ type ObservationComponentComponent struct {
 	ValuePeriod          *Period                              `bson:"valuePeriod,omitempty" json:"valuePeriod,omitempty"`
 	DataAbsentReason     *CodeableConcept                     `bson:"dataAbsentReason,omitempty" json:"dataAbsentReason,omitempty"`
 	ReferenceRange       []ObservationReferenceRangeComponent `bson:"referenceRange,omitempty" json:"referenceRange,omitempty"`
+}
+
+type ObservationPlus struct {
+	Observation             `bson:",inline"`
+	ObservationPlusIncludes `bson:",inline"`
+}
+
+type ObservationPlusIncludes struct {
+	IncludedSubjectGroupResources                       *[]Group                 `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources                      *[]Device                `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources                     *[]Patient               `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectLocationResources                    *[]Location              `bson:"_includedSubjectLocationResources,omitempty"`
+	IncludedPatientResources                            *[]Patient               `bson:"_includedPatientResources,omitempty"`
+	IncludedSpecimenResources                           *[]Specimen              `bson:"_includedSpecimenResources,omitempty"`
+	IncludedPerformerPractitionerResources              *[]Practitioner          `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerOrganizationResources              *[]Organization          `bson:"_includedPerformerOrganizationResources,omitempty"`
+	IncludedPerformerPatientResources                   *[]Patient               `bson:"_includedPerformerPatientResources,omitempty"`
+	IncludedPerformerRelatedPersonResources             *[]RelatedPerson         `bson:"_includedPerformerRelatedPersonResources,omitempty"`
+	IncludedEncounterResources                          *[]Encounter             `bson:"_includedEncounterResources,omitempty"`
+	IncludedRelatedtargetObservationResources           *[]Observation           `bson:"_includedRelatedtargetObservationResources,omitempty"`
+	IncludedRelatedtargetQuestionnaireResponseResources *[]QuestionnaireResponse `bson:"_includedRelatedtargetQuestionnaireResponseResources,omitempty"`
+	IncludedDeviceDeviceResources                       *[]Device                `bson:"_includedDeviceDeviceResources,omitempty"`
+	IncludedDeviceDeviceMetricResources                 *[]DeviceMetric          `bson:"_includedDeviceDeviceMetricResources,omitempty"`
+}
+
+func (o *ObservationPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if o.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*o.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedSubjectGroupResources))
+	} else if len(*o.IncludedSubjectGroupResources) == 1 {
+		group = &(*o.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if o.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*o.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedSubjectDeviceResources))
+	} else if len(*o.IncludedSubjectDeviceResources) == 1 {
+		device = &(*o.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if o.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*o.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedSubjectPatientResources))
+	} else if len(*o.IncludedSubjectPatientResources) == 1 {
+		patient = &(*o.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
+	if o.IncludedSubjectLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*o.IncludedSubjectLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*o.IncludedSubjectLocationResources))
+	} else if len(*o.IncludedSubjectLocationResources) == 1 {
+		location = &(*o.IncludedSubjectLocationResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if o.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*o.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResources))
+	} else if len(*o.IncludedPatientResources) == 1 {
+		patient = &(*o.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedSpecimenResource() (specimen *Specimen, err error) {
+	if o.IncludedSpecimenResources == nil {
+		err = errors.New("Included specimen not requested")
+	} else if len(*o.IncludedSpecimenResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*o.IncludedSpecimenResources))
+	} else if len(*o.IncludedSpecimenResources) == 1 {
+		specimen = &(*o.IncludedSpecimenResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedPerformerPractitionerResources() (practitioners []Practitioner, err error) {
+	if o.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *o.IncludedPerformerPractitionerResources
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedPerformerOrganizationResources() (organizations []Organization, err error) {
+	if o.IncludedPerformerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *o.IncludedPerformerOrganizationResources
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedPerformerPatientResources() (patients []Patient, err error) {
+	if o.IncludedPerformerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *o.IncludedPerformerPatientResources
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedPerformerRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
+	if o.IncludedPerformerRelatedPersonResources == nil {
+		err = errors.New("Included relatedPeople not requested")
+	} else {
+		relatedPeople = *o.IncludedPerformerRelatedPersonResources
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if o.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*o.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*o.IncludedEncounterResources))
+	} else if len(*o.IncludedEncounterResources) == 1 {
+		encounter = &(*o.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedRelatedtargetObservationResource() (observation *Observation, err error) {
+	if o.IncludedRelatedtargetObservationResources == nil {
+		err = errors.New("Included observations not requested")
+	} else if len(*o.IncludedRelatedtargetObservationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*o.IncludedRelatedtargetObservationResources))
+	} else if len(*o.IncludedRelatedtargetObservationResources) == 1 {
+		observation = &(*o.IncludedRelatedtargetObservationResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedRelatedtargetQuestionnaireResponseResource() (questionnaireResponse *QuestionnaireResponse, err error) {
+	if o.IncludedRelatedtargetQuestionnaireResponseResources == nil {
+		err = errors.New("Included questionnaireresponses not requested")
+	} else if len(*o.IncludedRelatedtargetQuestionnaireResponseResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 questionnaireResponse, but found %d", len(*o.IncludedRelatedtargetQuestionnaireResponseResources))
+	} else if len(*o.IncludedRelatedtargetQuestionnaireResponseResources) == 1 {
+		questionnaireResponse = &(*o.IncludedRelatedtargetQuestionnaireResponseResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedDeviceDeviceResource() (device *Device, err error) {
+	if o.IncludedDeviceDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*o.IncludedDeviceDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceDeviceResources))
+	} else if len(*o.IncludedDeviceDeviceResources) == 1 {
+		device = &(*o.IncludedDeviceDeviceResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedDeviceDeviceMetricResource() (deviceMetric *DeviceMetric, err error) {
+	if o.IncludedDeviceDeviceMetricResources == nil {
+		err = errors.New("Included devicemetrics not requested")
+	} else if len(*o.IncludedDeviceDeviceMetricResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceMetric, but found %d", len(*o.IncludedDeviceDeviceMetricResources))
+	} else if len(*o.IncludedDeviceDeviceMetricResources) == 1 {
+		deviceMetric = &(*o.IncludedDeviceDeviceMetricResources)[0]
+	}
+	return
+}
+
+func (o *ObservationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedSubjectGroupResources != nil {
+		for _, r := range *o.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectDeviceResources != nil {
+		for _, r := range *o.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectPatientResources != nil {
+		for _, r := range *o.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectLocationResources != nil {
+		for _, r := range *o.IncludedSubjectLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResources != nil {
+		for _, r := range *o.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSpecimenResources != nil {
+		for _, r := range *o.IncludedSpecimenResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *o.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPerformerOrganizationResources != nil {
+		for _, r := range *o.IncludedPerformerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPerformerPatientResources != nil {
+		for _, r := range *o.IncludedPerformerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPerformerRelatedPersonResources != nil {
+		for _, r := range *o.IncludedPerformerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedEncounterResources != nil {
+		for _, r := range *o.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedRelatedtargetObservationResources != nil {
+		for _, r := range *o.IncludedRelatedtargetObservationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedRelatedtargetQuestionnaireResponseResources != nil {
+		for _, r := range *o.IncludedRelatedtargetQuestionnaireResponseResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceDeviceResources != nil {
+		for _, r := range *o.IncludedDeviceDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceDeviceMetricResources != nil {
+		for _, r := range *o.IncludedDeviceDeviceMetricResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/operationoutcome.go
+++ b/models/operationoutcome.go
@@ -69,3 +69,16 @@ type OperationOutcomeIssueComponent struct {
 	Diagnostics string           `bson:"diagnostics,omitempty" json:"diagnostics,omitempty"`
 	Location    []string         `bson:"location,omitempty" json:"location,omitempty"`
 }
+
+type OperationOutcomePlus struct {
+	OperationOutcome             `bson:",inline"`
+	OperationOutcomePlusIncludes `bson:",inline"`
+}
+
+type OperationOutcomePlusIncludes struct {
+}
+
+func (o *OperationOutcomePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/order.go
+++ b/models/order.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Order struct {
 	DomainResource        `bson:",inline"`
@@ -73,4 +77,187 @@ func (x *Order) UnmarshalJSON(data []byte) (err error) {
 type OrderWhenComponent struct {
 	Code     *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 	Schedule *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
+}
+
+type OrderPlus struct {
+	Order             `bson:",inline"`
+	OrderPlusIncludes `bson:",inline"`
+}
+
+type OrderPlusIncludes struct {
+	IncludedSubjectGroupResources       *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources      *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources     *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectSubstanceResources   *[]Substance    `bson:"_includedSubjectSubstanceResources,omitempty"`
+	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
+	IncludedSourceOrganizationResources *[]Organization `bson:"_includedSourceOrganizationResources,omitempty"`
+	IncludedTargetPractitionerResources *[]Practitioner `bson:"_includedTargetPractitionerResources,omitempty"`
+	IncludedTargetOrganizationResources *[]Organization `bson:"_includedTargetOrganizationResources,omitempty"`
+	IncludedTargetDeviceResources       *[]Device       `bson:"_includedTargetDeviceResources,omitempty"`
+}
+
+func (o *OrderPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if o.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*o.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedSubjectGroupResources))
+	} else if len(*o.IncludedSubjectGroupResources) == 1 {
+		group = &(*o.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if o.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*o.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedSubjectDeviceResources))
+	} else if len(*o.IncludedSubjectDeviceResources) == 1 {
+		device = &(*o.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if o.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*o.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedSubjectPatientResources))
+	} else if len(*o.IncludedSubjectPatientResources) == 1 {
+		patient = &(*o.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedSubjectSubstanceResource() (substance *Substance, err error) {
+	if o.IncludedSubjectSubstanceResources == nil {
+		err = errors.New("Included substances not requested")
+	} else if len(*o.IncludedSubjectSubstanceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*o.IncludedSubjectSubstanceResources))
+	} else if len(*o.IncludedSubjectSubstanceResources) == 1 {
+		substance = &(*o.IncludedSubjectSubstanceResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if o.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*o.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResources))
+	} else if len(*o.IncludedPatientResources) == 1 {
+		patient = &(*o.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
+	if o.IncludedSourcePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*o.IncludedSourcePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedSourcePractitionerResources))
+	} else if len(*o.IncludedSourcePractitionerResources) == 1 {
+		practitioner = &(*o.IncludedSourcePractitionerResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedSourceOrganizationResource() (organization *Organization, err error) {
+	if o.IncludedSourceOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*o.IncludedSourceOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedSourceOrganizationResources))
+	} else if len(*o.IncludedSourceOrganizationResources) == 1 {
+		organization = &(*o.IncludedSourceOrganizationResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedTargetPractitionerResource() (practitioner *Practitioner, err error) {
+	if o.IncludedTargetPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*o.IncludedTargetPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedTargetPractitionerResources))
+	} else if len(*o.IncludedTargetPractitionerResources) == 1 {
+		practitioner = &(*o.IncludedTargetPractitionerResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedTargetOrganizationResource() (organization *Organization, err error) {
+	if o.IncludedTargetOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*o.IncludedTargetOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedTargetOrganizationResources))
+	} else if len(*o.IncludedTargetOrganizationResources) == 1 {
+		organization = &(*o.IncludedTargetOrganizationResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedTargetDeviceResource() (device *Device, err error) {
+	if o.IncludedTargetDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*o.IncludedTargetDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedTargetDeviceResources))
+	} else if len(*o.IncludedTargetDeviceResources) == 1 {
+		device = &(*o.IncludedTargetDeviceResources)[0]
+	}
+	return
+}
+
+func (o *OrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedSubjectGroupResources != nil {
+		for _, r := range *o.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectDeviceResources != nil {
+		for _, r := range *o.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectPatientResources != nil {
+		for _, r := range *o.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubjectSubstanceResources != nil {
+		for _, r := range *o.IncludedSubjectSubstanceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResources != nil {
+		for _, r := range *o.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSourcePractitionerResources != nil {
+		for _, r := range *o.IncludedSourcePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSourceOrganizationResources != nil {
+		for _, r := range *o.IncludedSourceOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedTargetPractitionerResources != nil {
+		for _, r := range *o.IncludedTargetPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedTargetOrganizationResources != nil {
+		for _, r := range *o.IncludedTargetOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedTargetDeviceResources != nil {
+		for _, r := range *o.IncludedTargetDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/orderresponse.go
+++ b/models/orderresponse.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type OrderResponse struct {
 	DomainResource `bson:",inline"`
@@ -66,4 +70,85 @@ func (x *OrderResponse) UnmarshalJSON(data []byte) (err error) {
 		*x = OrderResponse(x2)
 	}
 	return
+}
+
+type OrderResponsePlus struct {
+	OrderResponse             `bson:",inline"`
+	OrderResponsePlusIncludes `bson:",inline"`
+}
+
+type OrderResponsePlusIncludes struct {
+	IncludedRequestResources         *[]Order        `bson:"_includedRequestResources,omitempty"`
+	IncludedWhoPractitionerResources *[]Practitioner `bson:"_includedWhoPractitionerResources,omitempty"`
+	IncludedWhoOrganizationResources *[]Organization `bson:"_includedWhoOrganizationResources,omitempty"`
+	IncludedWhoDeviceResources       *[]Device       `bson:"_includedWhoDeviceResources,omitempty"`
+}
+
+func (o *OrderResponsePlusIncludes) GetIncludedRequestResource() (order *Order, err error) {
+	if o.IncludedRequestResources == nil {
+		err = errors.New("Included orders not requested")
+	} else if len(*o.IncludedRequestResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*o.IncludedRequestResources))
+	} else if len(*o.IncludedRequestResources) == 1 {
+		order = &(*o.IncludedRequestResources)[0]
+	}
+	return
+}
+
+func (o *OrderResponsePlusIncludes) GetIncludedWhoPractitionerResource() (practitioner *Practitioner, err error) {
+	if o.IncludedWhoPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*o.IncludedWhoPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedWhoPractitionerResources))
+	} else if len(*o.IncludedWhoPractitionerResources) == 1 {
+		practitioner = &(*o.IncludedWhoPractitionerResources)[0]
+	}
+	return
+}
+
+func (o *OrderResponsePlusIncludes) GetIncludedWhoOrganizationResource() (organization *Organization, err error) {
+	if o.IncludedWhoOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*o.IncludedWhoOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedWhoOrganizationResources))
+	} else if len(*o.IncludedWhoOrganizationResources) == 1 {
+		organization = &(*o.IncludedWhoOrganizationResources)[0]
+	}
+	return
+}
+
+func (o *OrderResponsePlusIncludes) GetIncludedWhoDeviceResource() (device *Device, err error) {
+	if o.IncludedWhoDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*o.IncludedWhoDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedWhoDeviceResources))
+	} else if len(*o.IncludedWhoDeviceResources) == 1 {
+		device = &(*o.IncludedWhoDeviceResources)[0]
+	}
+	return
+}
+
+func (o *OrderResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedRequestResources != nil {
+		for _, r := range *o.IncludedRequestResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedWhoPractitionerResources != nil {
+		for _, r := range *o.IncludedWhoPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedWhoOrganizationResources != nil {
+		for _, r := range *o.IncludedWhoOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedWhoDeviceResources != nil {
+		for _, r := range *o.IncludedWhoDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/paymentnotice.go
+++ b/models/paymentnotice.go
@@ -70,3 +70,16 @@ func (x *PaymentNotice) UnmarshalJSON(data []byte) (err error) {
 	}
 	return
 }
+
+type PaymentNoticePlus struct {
+	PaymentNotice             `bson:",inline"`
+	PaymentNoticePlusIncludes `bson:",inline"`
+}
+
+type PaymentNoticePlusIncludes struct {
+}
+
+func (p *PaymentNoticePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/paymentreconciliation.go
+++ b/models/paymentreconciliation.go
@@ -90,3 +90,16 @@ type PaymentReconciliationNotesComponent struct {
 	Type *Coding `bson:"type,omitempty" json:"type,omitempty"`
 	Text string  `bson:"text,omitempty" json:"text,omitempty"`
 }
+
+type PaymentReconciliationPlus struct {
+	PaymentReconciliation             `bson:",inline"`
+	PaymentReconciliationPlusIncludes `bson:",inline"`
+}
+
+type PaymentReconciliationPlusIncludes struct {
+}
+
+func (p *PaymentReconciliationPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/person.go
+++ b/models/person.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Person struct {
 	DomainResource       `bson:",inline"`
@@ -74,4 +78,153 @@ func (x *Person) UnmarshalJSON(data []byte) (err error) {
 type PersonLinkComponent struct {
 	Target    *Reference `bson:"target,omitempty" json:"target,omitempty"`
 	Assurance string     `bson:"assurance,omitempty" json:"assurance,omitempty"`
+}
+
+type PersonPlus struct {
+	Person             `bson:",inline"`
+	PersonPlusIncludes `bson:",inline"`
+}
+
+type PersonPlusIncludes struct {
+	IncludedPractitionerResources      *[]Practitioner  `bson:"_includedPractitionerResources,omitempty"`
+	IncludedLinkPractitionerResources  *[]Practitioner  `bson:"_includedLinkPractitionerResources,omitempty"`
+	IncludedLinkPatientResources       *[]Patient       `bson:"_includedLinkPatientResources,omitempty"`
+	IncludedLinkPersonResources        *[]Person        `bson:"_includedLinkPersonResources,omitempty"`
+	IncludedLinkRelatedPersonResources *[]RelatedPerson `bson:"_includedLinkRelatedPersonResources,omitempty"`
+	IncludedRelatedpersonResources     *[]RelatedPerson `bson:"_includedRelatedpersonResources,omitempty"`
+	IncludedPatientResources           *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedOrganizationResources      *[]Organization  `bson:"_includedOrganizationResources,omitempty"`
+}
+
+func (p *PersonPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResources))
+	} else if len(*p.IncludedPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedLinkPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedLinkPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedLinkPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedLinkPractitionerResources))
+	} else if len(*p.IncludedLinkPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedLinkPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedLinkPatientResource() (patient *Patient, err error) {
+	if p.IncludedLinkPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedLinkPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedLinkPatientResources))
+	} else if len(*p.IncludedLinkPatientResources) == 1 {
+		patient = &(*p.IncludedLinkPatientResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedLinkPersonResource() (person *Person, err error) {
+	if p.IncludedLinkPersonResources == nil {
+		err = errors.New("Included people not requested")
+	} else if len(*p.IncludedLinkPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 person, but found %d", len(*p.IncludedLinkPersonResources))
+	} else if len(*p.IncludedLinkPersonResources) == 1 {
+		person = &(*p.IncludedLinkPersonResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedLinkRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedLinkRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedLinkRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedLinkRelatedPersonResources))
+	} else if len(*p.IncludedLinkRelatedPersonResources) == 1 {
+		relatedPerson = &(*p.IncludedLinkRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedRelatedpersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedpersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedRelatedpersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedpersonResources))
+	} else if len(*p.IncludedRelatedpersonResources) == 1 {
+		relatedPerson = &(*p.IncludedRelatedpersonResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if p.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
+	} else if len(*p.IncludedPatientResources) == 1 {
+		patient = &(*p.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
+	if p.IncludedOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
+	} else if len(*p.IncludedOrganizationResources) == 1 {
+		organization = &(*p.IncludedOrganizationResources)[0]
+	}
+	return
+}
+
+func (p *PersonPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResources != nil {
+		for _, r := range *p.IncludedPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLinkPractitionerResources != nil {
+		for _, r := range *p.IncludedLinkPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLinkPatientResources != nil {
+		for _, r := range *p.IncludedLinkPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLinkPersonResources != nil {
+		for _, r := range *p.IncludedLinkPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLinkRelatedPersonResources != nil {
+		for _, r := range *p.IncludedLinkRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedpersonResources != nil {
+		for _, r := range *p.IncludedRelatedpersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResources != nil {
+		for _, r := range *p.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResources != nil {
+		for _, r := range *p.IncludedOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Procedure struct {
 	DomainResource        `bson:",inline"`
@@ -92,4 +96,170 @@ type ProcedurePerformerComponent struct {
 type ProcedureFocalDeviceComponent struct {
 	Action      *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
 	Manipulated *Reference       `bson:"manipulated,omitempty" json:"manipulated,omitempty"`
+}
+
+type ProcedurePlus struct {
+	Procedure             `bson:",inline"`
+	ProcedurePlusIncludes `bson:",inline"`
+}
+
+type ProcedurePlusIncludes struct {
+	IncludedPerformerPractitionerResources  *[]Practitioner  `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerOrganizationResources  *[]Organization  `bson:"_includedPerformerOrganizationResources,omitempty"`
+	IncludedPerformerPatientResources       *[]Patient       `bson:"_includedPerformerPatientResources,omitempty"`
+	IncludedPerformerRelatedPersonResources *[]RelatedPerson `bson:"_includedPerformerRelatedPersonResources,omitempty"`
+	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedLocationResources               *[]Location      `bson:"_includedLocationResources,omitempty"`
+	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedPerformerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPerformerPractitionerResources))
+	} else if len(*p.IncludedPerformerPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedPerformerPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
+	if p.IncludedPerformerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedPerformerOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedPerformerOrganizationResources))
+	} else if len(*p.IncludedPerformerOrganizationResources) == 1 {
+		organization = &(*p.IncludedPerformerOrganizationResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedPerformerPatientResource() (patient *Patient, err error) {
+	if p.IncludedPerformerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedPerformerPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPerformerPatientResources))
+	} else if len(*p.IncludedPerformerPatientResources) == 1 {
+		patient = &(*p.IncludedPerformerPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedPerformerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedPerformerRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedPerformerRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedPerformerRelatedPersonResources))
+	} else if len(*p.IncludedPerformerRelatedPersonResources) == 1 {
+		relatedPerson = &(*p.IncludedPerformerRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if p.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*p.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedSubjectGroupResources))
+	} else if len(*p.IncludedSubjectGroupResources) == 1 {
+		group = &(*p.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if p.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedSubjectPatientResources))
+	} else if len(*p.IncludedSubjectPatientResources) == 1 {
+		patient = &(*p.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if p.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
+	} else if len(*p.IncludedPatientResources) == 1 {
+		patient = &(*p.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if p.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*p.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResources))
+	} else if len(*p.IncludedLocationResources) == 1 {
+		location = &(*p.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if p.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*p.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResources))
+	} else if len(*p.IncludedEncounterResources) == 1 {
+		encounter = &(*p.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (p *ProcedurePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *p.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerOrganizationResources != nil {
+		for _, r := range *p.IncludedPerformerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerPatientResources != nil {
+		for _, r := range *p.IncludedPerformerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerRelatedPersonResources != nil {
+		for _, r := range *p.IncludedPerformerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedSubjectGroupResources != nil {
+		for _, r := range *p.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedSubjectPatientResources != nil {
+		for _, r := range *p.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResources != nil {
+		for _, r := range *p.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLocationResources != nil {
+		for _, r := range *p.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedEncounterResources != nil {
+		for _, r := range *p.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/procedurerequest.go
+++ b/models/procedurerequest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ProcedureRequest struct {
 	DomainResource          `bson:",inline"`
@@ -77,4 +81,221 @@ func (x *ProcedureRequest) UnmarshalJSON(data []byte) (err error) {
 		*x = ProcedureRequest(x2)
 	}
 	return
+}
+
+type ProcedureRequestPlus struct {
+	ProcedureRequest             `bson:",inline"`
+	ProcedureRequestPlusIncludes `bson:",inline"`
+}
+
+type ProcedureRequestPlusIncludes struct {
+	IncludedPerformerPractitionerResources  *[]Practitioner  `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerOrganizationResources  *[]Organization  `bson:"_includedPerformerOrganizationResources,omitempty"`
+	IncludedPerformerPatientResources       *[]Patient       `bson:"_includedPerformerPatientResources,omitempty"`
+	IncludedPerformerRelatedPersonResources *[]RelatedPerson `bson:"_includedPerformerRelatedPersonResources,omitempty"`
+	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedOrdererPractitionerResources    *[]Practitioner  `bson:"_includedOrdererPractitionerResources,omitempty"`
+	IncludedOrdererDeviceResources          *[]Device        `bson:"_includedOrdererDeviceResources,omitempty"`
+	IncludedOrdererPatientResources         *[]Patient       `bson:"_includedOrdererPatientResources,omitempty"`
+	IncludedOrdererRelatedPersonResources   *[]RelatedPerson `bson:"_includedOrdererRelatedPersonResources,omitempty"`
+	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedPerformerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPerformerPractitionerResources))
+	} else if len(*p.IncludedPerformerPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedPerformerPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
+	if p.IncludedPerformerOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedPerformerOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedPerformerOrganizationResources))
+	} else if len(*p.IncludedPerformerOrganizationResources) == 1 {
+		organization = &(*p.IncludedPerformerOrganizationResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerPatientResource() (patient *Patient, err error) {
+	if p.IncludedPerformerPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedPerformerPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPerformerPatientResources))
+	} else if len(*p.IncludedPerformerPatientResources) == 1 {
+		patient = &(*p.IncludedPerformerPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedPerformerRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedPerformerRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedPerformerRelatedPersonResources))
+	} else if len(*p.IncludedPerformerRelatedPersonResources) == 1 {
+		relatedPerson = &(*p.IncludedPerformerRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if p.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*p.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedSubjectGroupResources))
+	} else if len(*p.IncludedSubjectGroupResources) == 1 {
+		group = &(*p.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if p.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedSubjectPatientResources))
+	} else if len(*p.IncludedSubjectPatientResources) == 1 {
+		patient = &(*p.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if p.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
+	} else if len(*p.IncludedPatientResources) == 1 {
+		patient = &(*p.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedOrdererPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedOrdererPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedOrdererPractitionerResources))
+	} else if len(*p.IncludedOrdererPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedOrdererPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererDeviceResource() (device *Device, err error) {
+	if p.IncludedOrdererDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*p.IncludedOrdererDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedOrdererDeviceResources))
+	} else if len(*p.IncludedOrdererDeviceResources) == 1 {
+		device = &(*p.IncludedOrdererDeviceResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererPatientResource() (patient *Patient, err error) {
+	if p.IncludedOrdererPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedOrdererPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedOrdererPatientResources))
+	} else if len(*p.IncludedOrdererPatientResources) == 1 {
+		patient = &(*p.IncludedOrdererPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedOrdererRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedOrdererRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedOrdererRelatedPersonResources))
+	} else if len(*p.IncludedOrdererRelatedPersonResources) == 1 {
+		relatedPerson = &(*p.IncludedOrdererRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if p.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*p.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResources))
+	} else if len(*p.IncludedEncounterResources) == 1 {
+		encounter = &(*p.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *p.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerOrganizationResources != nil {
+		for _, r := range *p.IncludedPerformerOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerPatientResources != nil {
+		for _, r := range *p.IncludedPerformerPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPerformerRelatedPersonResources != nil {
+		for _, r := range *p.IncludedPerformerRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedSubjectGroupResources != nil {
+		for _, r := range *p.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedSubjectPatientResources != nil {
+		for _, r := range *p.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResources != nil {
+		for _, r := range *p.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrdererPractitionerResources != nil {
+		for _, r := range *p.IncludedOrdererPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrdererDeviceResources != nil {
+		for _, r := range *p.IncludedOrdererDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrdererPatientResources != nil {
+		for _, r := range *p.IncludedOrdererPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrdererRelatedPersonResources != nil {
+		for _, r := range *p.IncludedOrdererRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedEncounterResources != nil {
+		for _, r := range *p.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ProcessResponse struct {
 	DomainResource      `bson:",inline"`
@@ -77,4 +81,68 @@ func (x *ProcessResponse) UnmarshalJSON(data []byte) (err error) {
 type ProcessResponseNotesComponent struct {
 	Type *Coding `bson:"type,omitempty" json:"type,omitempty"`
 	Text string  `bson:"text,omitempty" json:"text,omitempty"`
+}
+
+type ProcessResponsePlus struct {
+	ProcessResponse             `bson:",inline"`
+	ProcessResponsePlusIncludes `bson:",inline"`
+}
+
+type ProcessResponsePlusIncludes struct {
+	IncludedOrganizationResources        *[]Organization `bson:"_includedOrganizationResources,omitempty"`
+	IncludedRequestproviderResources     *[]Practitioner `bson:"_includedRequestproviderResources,omitempty"`
+	IncludedRequestorganizationResources *[]Organization `bson:"_includedRequestorganizationResources,omitempty"`
+}
+
+func (p *ProcessResponsePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
+	if p.IncludedOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
+	} else if len(*p.IncludedOrganizationResources) == 1 {
+		organization = &(*p.IncludedOrganizationResources)[0]
+	}
+	return
+}
+
+func (p *ProcessResponsePlusIncludes) GetIncludedRequestproviderResource() (practitioner *Practitioner, err error) {
+	if p.IncludedRequestproviderResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedRequestproviderResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedRequestproviderResources))
+	} else if len(*p.IncludedRequestproviderResources) == 1 {
+		practitioner = &(*p.IncludedRequestproviderResources)[0]
+	}
+	return
+}
+
+func (p *ProcessResponsePlusIncludes) GetIncludedRequestorganizationResource() (organization *Organization, err error) {
+	if p.IncludedRequestorganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedRequestorganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedRequestorganizationResources))
+	} else if len(*p.IncludedRequestorganizationResources) == 1 {
+		organization = &(*p.IncludedRequestorganizationResources)[0]
+	}
+	return
+}
+
+func (p *ProcessResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedOrganizationResources != nil {
+		for _, r := range *p.IncludedOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRequestproviderResources != nil {
+		for _, r := range *p.IncludedRequestproviderResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRequestorganizationResources != nil {
+		for _, r := range *p.IncludedRequestorganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Provenance struct {
 	DomainResource `bson:",inline"`
@@ -89,4 +93,134 @@ type ProvenanceEntityComponent struct {
 	Reference string                    `bson:"reference,omitempty" json:"reference,omitempty"`
 	Display   string                    `bson:"display,omitempty" json:"display,omitempty"`
 	Agent     *ProvenanceAgentComponent `bson:"agent,omitempty" json:"agent,omitempty"`
+}
+
+type ProvenancePlus struct {
+	Provenance             `bson:",inline"`
+	ProvenancePlusIncludes `bson:",inline"`
+}
+
+type ProvenancePlusIncludes struct {
+	IncludedAgentPractitionerResources  *[]Practitioner  `bson:"_includedAgentPractitionerResources,omitempty"`
+	IncludedAgentOrganizationResources  *[]Organization  `bson:"_includedAgentOrganizationResources,omitempty"`
+	IncludedAgentDeviceResources        *[]Device        `bson:"_includedAgentDeviceResources,omitempty"`
+	IncludedAgentPatientResources       *[]Patient       `bson:"_includedAgentPatientResources,omitempty"`
+	IncludedAgentRelatedPersonResources *[]RelatedPerson `bson:"_includedAgentRelatedPersonResources,omitempty"`
+	IncludedPatientResources            *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedLocationResources           *[]Location      `bson:"_includedLocationResources,omitempty"`
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedAgentPractitionerResource() (practitioner *Practitioner, err error) {
+	if p.IncludedAgentPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*p.IncludedAgentPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedAgentPractitionerResources))
+	} else if len(*p.IncludedAgentPractitionerResources) == 1 {
+		practitioner = &(*p.IncludedAgentPractitionerResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedAgentOrganizationResource() (organization *Organization, err error) {
+	if p.IncludedAgentOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*p.IncludedAgentOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedAgentOrganizationResources))
+	} else if len(*p.IncludedAgentOrganizationResources) == 1 {
+		organization = &(*p.IncludedAgentOrganizationResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedAgentDeviceResource() (device *Device, err error) {
+	if p.IncludedAgentDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*p.IncludedAgentDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedAgentDeviceResources))
+	} else if len(*p.IncludedAgentDeviceResources) == 1 {
+		device = &(*p.IncludedAgentDeviceResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedAgentPatientResource() (patient *Patient, err error) {
+	if p.IncludedAgentPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*p.IncludedAgentPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedAgentPatientResources))
+	} else if len(*p.IncludedAgentPatientResources) == 1 {
+		patient = &(*p.IncludedAgentPatientResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedAgentRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedAgentRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*p.IncludedAgentRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedAgentRelatedPersonResources))
+	} else if len(*p.IncludedAgentRelatedPersonResources) == 1 {
+		relatedPerson = &(*p.IncludedAgentRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedPatientResources() (patients []Patient, err error) {
+	if p.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else {
+		patients = *p.IncludedPatientResources
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
+	if p.IncludedLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*p.IncludedLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResources))
+	} else if len(*p.IncludedLocationResources) == 1 {
+		location = &(*p.IncludedLocationResources)[0]
+	}
+	return
+}
+
+func (p *ProvenancePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedAgentPractitionerResources != nil {
+		for _, r := range *p.IncludedAgentPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedAgentOrganizationResources != nil {
+		for _, r := range *p.IncludedAgentOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedAgentDeviceResources != nil {
+		for _, r := range *p.IncludedAgentDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedAgentPatientResources != nil {
+		for _, r := range *p.IncludedAgentPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedAgentRelatedPersonResources != nil {
+		for _, r := range *p.IncludedAgentRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResources != nil {
+		for _, r := range *p.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLocationResources != nil {
+		for _, r := range *p.IncludedLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/questionnaire.go
+++ b/models/questionnaire.go
@@ -91,3 +91,16 @@ type QuestionnaireQuestionComponent struct {
 	Option   []Coding                      `bson:"option,omitempty" json:"option,omitempty"`
 	Group    []QuestionnaireGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
 }
+
+type QuestionnairePlus struct {
+	Questionnaire             `bson:",inline"`
+	QuestionnairePlusIncludes `bson:",inline"`
+}
+
+type QuestionnairePlusIncludes struct {
+}
+
+func (q *QuestionnairePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type QuestionnaireResponse struct {
 	DomainResource `bson:",inline"`
@@ -100,4 +104,187 @@ type QuestionnaireResponseQuestionAnswerComponent struct {
 	ValueQuantity   *Quantity                             `bson:"valueQuantity,omitempty" json:"valueQuantity,omitempty"`
 	ValueReference  *Reference                            `bson:"valueReference,omitempty" json:"valueReference,omitempty"`
 	Group           []QuestionnaireResponseGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
+}
+
+type QuestionnaireResponsePlus struct {
+	QuestionnaireResponse             `bson:",inline"`
+	QuestionnaireResponsePlusIncludes `bson:",inline"`
+}
+
+type QuestionnaireResponsePlusIncludes struct {
+	IncludedQuestionnaireResources       *[]Questionnaire `bson:"_includedQuestionnaireResources,omitempty"`
+	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
+	IncludedAuthorDeviceResources        *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
+	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
+	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+	IncludedEncounterResources           *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+	IncludedSourcePractitionerResources  *[]Practitioner  `bson:"_includedSourcePractitionerResources,omitempty"`
+	IncludedSourcePatientResources       *[]Patient       `bson:"_includedSourcePatientResources,omitempty"`
+	IncludedSourceRelatedPersonResources *[]RelatedPerson `bson:"_includedSourceRelatedPersonResources,omitempty"`
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedQuestionnaireResource() (questionnaire *Questionnaire, err error) {
+	if q.IncludedQuestionnaireResources == nil {
+		err = errors.New("Included questionnaires not requested")
+	} else if len(*q.IncludedQuestionnaireResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 questionnaire, but found %d", len(*q.IncludedQuestionnaireResources))
+	} else if len(*q.IncludedQuestionnaireResources) == 1 {
+		questionnaire = &(*q.IncludedQuestionnaireResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
+	if q.IncludedAuthorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*q.IncludedAuthorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedAuthorPractitionerResources))
+	} else if len(*q.IncludedAuthorPractitionerResources) == 1 {
+		practitioner = &(*q.IncludedAuthorPractitionerResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
+	if q.IncludedAuthorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*q.IncludedAuthorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*q.IncludedAuthorDeviceResources))
+	} else if len(*q.IncludedAuthorDeviceResources) == 1 {
+		device = &(*q.IncludedAuthorDeviceResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
+	if q.IncludedAuthorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*q.IncludedAuthorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedAuthorPatientResources))
+	} else if len(*q.IncludedAuthorPatientResources) == 1 {
+		patient = &(*q.IncludedAuthorPatientResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if q.IncludedAuthorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*q.IncludedAuthorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedAuthorRelatedPersonResources))
+	} else if len(*q.IncludedAuthorRelatedPersonResources) == 1 {
+		relatedPerson = &(*q.IncludedAuthorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if q.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*q.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedPatientResources))
+	} else if len(*q.IncludedPatientResources) == 1 {
+		patient = &(*q.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if q.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*q.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*q.IncludedEncounterResources))
+	} else if len(*q.IncludedEncounterResources) == 1 {
+		encounter = &(*q.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
+	if q.IncludedSourcePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*q.IncludedSourcePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedSourcePractitionerResources))
+	} else if len(*q.IncludedSourcePractitionerResources) == 1 {
+		practitioner = &(*q.IncludedSourcePractitionerResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
+	if q.IncludedSourcePatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*q.IncludedSourcePatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedSourcePatientResources))
+	} else if len(*q.IncludedSourcePatientResources) == 1 {
+		patient = &(*q.IncludedSourcePatientResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourceRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if q.IncludedSourceRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*q.IncludedSourceRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedSourceRelatedPersonResources))
+	} else if len(*q.IncludedSourceRelatedPersonResources) == 1 {
+		relatedPerson = &(*q.IncludedSourceRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if q.IncludedQuestionnaireResources != nil {
+		for _, r := range *q.IncludedQuestionnaireResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedAuthorPractitionerResources != nil {
+		for _, r := range *q.IncludedAuthorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedAuthorDeviceResources != nil {
+		for _, r := range *q.IncludedAuthorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedAuthorPatientResources != nil {
+		for _, r := range *q.IncludedAuthorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedAuthorRelatedPersonResources != nil {
+		for _, r := range *q.IncludedAuthorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPatientResources != nil {
+		for _, r := range *q.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedEncounterResources != nil {
+		for _, r := range *q.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedSourcePractitionerResources != nil {
+		for _, r := range *q.IncludedSourcePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedSourcePatientResources != nil {
+		for _, r := range *q.IncludedSourcePatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedSourceRelatedPersonResources != nil {
+		for _, r := range *q.IncludedSourceRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/referralrequest.go
+++ b/models/referralrequest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ReferralRequest struct {
 	DomainResource        `bson:",inline"`
@@ -75,4 +79,115 @@ func (x *ReferralRequest) UnmarshalJSON(data []byte) (err error) {
 		*x = ReferralRequest(x2)
 	}
 	return
+}
+
+type ReferralRequestPlus struct {
+	ReferralRequest             `bson:",inline"`
+	ReferralRequestPlusIncludes `bson:",inline"`
+}
+
+type ReferralRequestPlusIncludes struct {
+	IncludedRequesterPractitionerResources *[]Practitioner `bson:"_includedRequesterPractitionerResources,omitempty"`
+	IncludedRequesterOrganizationResources *[]Organization `bson:"_includedRequesterOrganizationResources,omitempty"`
+	IncludedRequesterPatientResources      *[]Patient      `bson:"_includedRequesterPatientResources,omitempty"`
+	IncludedPatientResources               *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedRecipientPractitionerResources *[]Practitioner `bson:"_includedRecipientPractitionerResources,omitempty"`
+	IncludedRecipientOrganizationResources *[]Organization `bson:"_includedRecipientOrganizationResources,omitempty"`
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedRequesterPractitionerResource() (practitioner *Practitioner, err error) {
+	if r.IncludedRequesterPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*r.IncludedRequesterPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedRequesterPractitionerResources))
+	} else if len(*r.IncludedRequesterPractitionerResources) == 1 {
+		practitioner = &(*r.IncludedRequesterPractitionerResources)[0]
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedRequesterOrganizationResource() (organization *Organization, err error) {
+	if r.IncludedRequesterOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*r.IncludedRequesterOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*r.IncludedRequesterOrganizationResources))
+	} else if len(*r.IncludedRequesterOrganizationResources) == 1 {
+		organization = &(*r.IncludedRequesterOrganizationResources)[0]
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedRequesterPatientResource() (patient *Patient, err error) {
+	if r.IncludedRequesterPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*r.IncludedRequesterPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedRequesterPatientResources))
+	} else if len(*r.IncludedRequesterPatientResources) == 1 {
+		patient = &(*r.IncludedRequesterPatientResources)[0]
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if r.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*r.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResources))
+	} else if len(*r.IncludedPatientResources) == 1 {
+		patient = &(*r.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
+	if r.IncludedRecipientPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else {
+		practitioners = *r.IncludedRecipientPractitionerResources
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
+	if r.IncludedRecipientOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *r.IncludedRecipientOrganizationResources
+	}
+	return
+}
+
+func (r *ReferralRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.IncludedRequesterPractitionerResources != nil {
+		for _, r := range *r.IncludedRequesterPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedRequesterOrganizationResources != nil {
+		for _, r := range *r.IncludedRequesterOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedRequesterPatientResources != nil {
+		for _, r := range *r.IncludedRequesterPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResources != nil {
+		for _, r := range *r.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedRecipientPractitionerResources != nil {
+		for _, r := range *r.IncludedRecipientPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedRecipientOrganizationResources != nil {
+		for _, r := range *r.IncludedRecipientOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/resource_helpers.go
+++ b/models/resource_helpers.go
@@ -217,6 +217,212 @@ func StructForResourceName(name string) interface{} {
 	}
 }
 
+func SlicePlusForResourceName(name string, len int, cap int) interface{} {
+	rType := reflect.TypeOf(StructPlusForResourceName(name))
+	return reflect.MakeSlice(reflect.SliceOf(rType), len, cap).Interface()
+}
+
+func NewSlicePlusForResourceName(name string, len int, cap int) interface{} {
+	rSlice := SlicePlusForResourceName(name, len, cap)
+	rSlicePtr := reflect.New(reflect.TypeOf(rSlice))
+	rSlicePtr.Elem().Set(reflect.ValueOf(rSlice))
+	return rSlicePtr.Interface()
+}
+
+func StructPlusForResourceName(name string) interface{} {
+	switch name {
+	case "Account":
+		return AccountPlus{}
+	case "AllergyIntolerance":
+		return AllergyIntolerancePlus{}
+	case "Appointment":
+		return AppointmentPlus{}
+	case "AppointmentResponse":
+		return AppointmentResponsePlus{}
+	case "AuditEvent":
+		return AuditEventPlus{}
+	case "Basic":
+		return BasicPlus{}
+	case "Binary":
+		return BinaryPlus{}
+	case "BodySite":
+		return BodySitePlus{}
+	case "Bundle":
+		return BundlePlus{}
+	case "CarePlan":
+		return CarePlanPlus{}
+	case "Claim":
+		return ClaimPlus{}
+	case "ClaimResponse":
+		return ClaimResponsePlus{}
+	case "ClinicalImpression":
+		return ClinicalImpressionPlus{}
+	case "Communication":
+		return CommunicationPlus{}
+	case "CommunicationRequest":
+		return CommunicationRequestPlus{}
+	case "Composition":
+		return CompositionPlus{}
+	case "ConceptMap":
+		return ConceptMapPlus{}
+	case "Condition":
+		return ConditionPlus{}
+	case "Conformance":
+		return ConformancePlus{}
+	case "Contract":
+		return ContractPlus{}
+	case "Coverage":
+		return CoveragePlus{}
+	case "DataElement":
+		return DataElementPlus{}
+	case "DetectedIssue":
+		return DetectedIssuePlus{}
+	case "Device":
+		return DevicePlus{}
+	case "DeviceComponent":
+		return DeviceComponentPlus{}
+	case "DeviceMetric":
+		return DeviceMetricPlus{}
+	case "DeviceUseRequest":
+		return DeviceUseRequestPlus{}
+	case "DeviceUseStatement":
+		return DeviceUseStatementPlus{}
+	case "DiagnosticOrder":
+		return DiagnosticOrderPlus{}
+	case "DiagnosticReport":
+		return DiagnosticReportPlus{}
+	case "DocumentManifest":
+		return DocumentManifestPlus{}
+	case "DocumentReference":
+		return DocumentReferencePlus{}
+	case "EligibilityRequest":
+		return EligibilityRequestPlus{}
+	case "EligibilityResponse":
+		return EligibilityResponsePlus{}
+	case "Encounter":
+		return EncounterPlus{}
+	case "EnrollmentRequest":
+		return EnrollmentRequestPlus{}
+	case "EnrollmentResponse":
+		return EnrollmentResponsePlus{}
+	case "EpisodeOfCare":
+		return EpisodeOfCarePlus{}
+	case "ExplanationOfBenefit":
+		return ExplanationOfBenefitPlus{}
+	case "FamilyMemberHistory":
+		return FamilyMemberHistoryPlus{}
+	case "Flag":
+		return FlagPlus{}
+	case "Goal":
+		return GoalPlus{}
+	case "Group":
+		return GroupPlus{}
+	case "HealthcareService":
+		return HealthcareServicePlus{}
+	case "ImagingObjectSelection":
+		return ImagingObjectSelectionPlus{}
+	case "ImagingStudy":
+		return ImagingStudyPlus{}
+	case "Immunization":
+		return ImmunizationPlus{}
+	case "ImmunizationRecommendation":
+		return ImmunizationRecommendationPlus{}
+	case "ImplementationGuide":
+		return ImplementationGuidePlus{}
+	case "List":
+		return ListPlus{}
+	case "Location":
+		return LocationPlus{}
+	case "Media":
+		return MediaPlus{}
+	case "Medication":
+		return MedicationPlus{}
+	case "MedicationAdministration":
+		return MedicationAdministrationPlus{}
+	case "MedicationDispense":
+		return MedicationDispensePlus{}
+	case "MedicationOrder":
+		return MedicationOrderPlus{}
+	case "MedicationStatement":
+		return MedicationStatementPlus{}
+	case "MessageHeader":
+		return MessageHeaderPlus{}
+	case "NamingSystem":
+		return NamingSystemPlus{}
+	case "NutritionOrder":
+		return NutritionOrderPlus{}
+	case "Observation":
+		return ObservationPlus{}
+	case "OperationDefinition":
+		return OperationDefinitionPlus{}
+	case "OperationOutcome":
+		return OperationOutcomePlus{}
+	case "Order":
+		return OrderPlus{}
+	case "OrderResponse":
+		return OrderResponsePlus{}
+	case "Organization":
+		return OrganizationPlus{}
+	case "Patient":
+		return PatientPlus{}
+	case "PaymentNotice":
+		return PaymentNoticePlus{}
+	case "PaymentReconciliation":
+		return PaymentReconciliationPlus{}
+	case "Person":
+		return PersonPlus{}
+	case "Practitioner":
+		return PractitionerPlus{}
+	case "Procedure":
+		return ProcedurePlus{}
+	case "ProcedureRequest":
+		return ProcedureRequestPlus{}
+	case "ProcessRequest":
+		return ProcessRequestPlus{}
+	case "ProcessResponse":
+		return ProcessResponsePlus{}
+	case "Provenance":
+		return ProvenancePlus{}
+	case "Questionnaire":
+		return QuestionnairePlus{}
+	case "QuestionnaireResponse":
+		return QuestionnaireResponsePlus{}
+	case "ReferralRequest":
+		return ReferralRequestPlus{}
+	case "RelatedPerson":
+		return RelatedPersonPlus{}
+	case "RiskAssessment":
+		return RiskAssessmentPlus{}
+	case "Schedule":
+		return SchedulePlus{}
+	case "SearchParameter":
+		return SearchParameterPlus{}
+	case "Slot":
+		return SlotPlus{}
+	case "Specimen":
+		return SpecimenPlus{}
+	case "StructureDefinition":
+		return StructureDefinitionPlus{}
+	case "Subscription":
+		return SubscriptionPlus{}
+	case "Substance":
+		return SubstancePlus{}
+	case "SupplyDelivery":
+		return SupplyDeliveryPlus{}
+	case "SupplyRequest":
+		return SupplyRequestPlus{}
+	case "TestScript":
+		return TestScriptPlus{}
+	case "ValueSet":
+		return ValueSetPlus{}
+	case "VisionPrescription":
+		return VisionPrescriptionPlus{}
+
+	default:
+		return nil
+	}
+}
+
 func PluralizeLowerResourceName(name string) string {
 	switch name {
 	case "Account":

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type RiskAssessment struct {
 	DomainResource `bson:",inline"`
@@ -80,4 +84,136 @@ type RiskAssessmentPredictionComponent struct {
 	WhenPeriod                 *Period          `bson:"whenPeriod,omitempty" json:"whenPeriod,omitempty"`
 	WhenRange                  *Range           `bson:"whenRange,omitempty" json:"whenRange,omitempty"`
 	Rationale                  string           `bson:"rationale,omitempty" json:"rationale,omitempty"`
+}
+
+type RiskAssessmentPlus struct {
+	RiskAssessment             `bson:",inline"`
+	RiskAssessmentPlusIncludes `bson:",inline"`
+}
+
+type RiskAssessmentPlusIncludes struct {
+	IncludedConditionResources             *[]Condition    `bson:"_includedConditionResources,omitempty"`
+	IncludedPerformerPractitionerResources *[]Practitioner `bson:"_includedPerformerPractitionerResources,omitempty"`
+	IncludedPerformerDeviceResources       *[]Device       `bson:"_includedPerformerDeviceResources,omitempty"`
+	IncludedSubjectGroupResources          *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectPatientResources        *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedPatientResources               *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedEncounterResources             *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedConditionResource() (condition *Condition, err error) {
+	if r.IncludedConditionResources == nil {
+		err = errors.New("Included conditions not requested")
+	} else if len(*r.IncludedConditionResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 condition, but found %d", len(*r.IncludedConditionResources))
+	} else if len(*r.IncludedConditionResources) == 1 {
+		condition = &(*r.IncludedConditionResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
+	if r.IncludedPerformerPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*r.IncludedPerformerPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedPerformerPractitionerResources))
+	} else if len(*r.IncludedPerformerPractitionerResources) == 1 {
+		practitioner = &(*r.IncludedPerformerPractitionerResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedPerformerDeviceResource() (device *Device, err error) {
+	if r.IncludedPerformerDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*r.IncludedPerformerDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*r.IncludedPerformerDeviceResources))
+	} else if len(*r.IncludedPerformerDeviceResources) == 1 {
+		device = &(*r.IncludedPerformerDeviceResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if r.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*r.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*r.IncludedSubjectGroupResources))
+	} else if len(*r.IncludedSubjectGroupResources) == 1 {
+		group = &(*r.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if r.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*r.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedSubjectPatientResources))
+	} else if len(*r.IncludedSubjectPatientResources) == 1 {
+		patient = &(*r.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if r.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*r.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResources))
+	} else if len(*r.IncludedPatientResources) == 1 {
+		patient = &(*r.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
+	if r.IncludedEncounterResources == nil {
+		err = errors.New("Included encounters not requested")
+	} else if len(*r.IncludedEncounterResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*r.IncludedEncounterResources))
+	} else if len(*r.IncludedEncounterResources) == 1 {
+		encounter = &(*r.IncludedEncounterResources)[0]
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.IncludedConditionResources != nil {
+		for _, r := range *r.IncludedConditionResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPerformerPractitionerResources != nil {
+		for _, r := range *r.IncludedPerformerPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPerformerDeviceResources != nil {
+		for _, r := range *r.IncludedPerformerDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedSubjectGroupResources != nil {
+		for _, r := range *r.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedSubjectPatientResources != nil {
+		for _, r := range *r.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResources != nil {
+		for _, r := range *r.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedEncounterResources != nil {
+		for _, r := range *r.IncludedEncounterResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Schedule struct {
 	DomainResource  `bson:",inline"`
@@ -64,4 +68,119 @@ func (x *Schedule) UnmarshalJSON(data []byte) (err error) {
 		*x = Schedule(x2)
 	}
 	return
+}
+
+type SchedulePlus struct {
+	Schedule             `bson:",inline"`
+	SchedulePlusIncludes `bson:",inline"`
+}
+
+type SchedulePlusIncludes struct {
+	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
+	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
+	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
+	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
+	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
+	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
+	if s.IncludedActorPractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*s.IncludedActorPractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedActorPractitionerResources))
+	} else if len(*s.IncludedActorPractitionerResources) == 1 {
+		practitioner = &(*s.IncludedActorPractitionerResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
+	if s.IncludedActorDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*s.IncludedActorDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedActorDeviceResources))
+	} else if len(*s.IncludedActorDeviceResources) == 1 {
+		device = &(*s.IncludedActorDeviceResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
+	if s.IncludedActorPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*s.IncludedActorPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedActorPatientResources))
+	} else if len(*s.IncludedActorPatientResources) == 1 {
+		patient = &(*s.IncludedActorPatientResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
+	if s.IncludedActorHealthcareServiceResources == nil {
+		err = errors.New("Included healthcareservices not requested")
+	} else if len(*s.IncludedActorHealthcareServiceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*s.IncludedActorHealthcareServiceResources))
+	} else if len(*s.IncludedActorHealthcareServiceResources) == 1 {
+		healthcareService = &(*s.IncludedActorHealthcareServiceResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
+	if s.IncludedActorRelatedPersonResources == nil {
+		err = errors.New("Included relatedpeople not requested")
+	} else if len(*s.IncludedActorRelatedPersonResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*s.IncludedActorRelatedPersonResources))
+	} else if len(*s.IncludedActorRelatedPersonResources) == 1 {
+		relatedPerson = &(*s.IncludedActorRelatedPersonResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
+	if s.IncludedActorLocationResources == nil {
+		err = errors.New("Included locations not requested")
+	} else if len(*s.IncludedActorLocationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*s.IncludedActorLocationResources))
+	} else if len(*s.IncludedActorLocationResources) == 1 {
+		location = &(*s.IncludedActorLocationResources)[0]
+	}
+	return
+}
+
+func (s *SchedulePlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedActorPractitionerResources != nil {
+		for _, r := range *s.IncludedActorPractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedActorDeviceResources != nil {
+		for _, r := range *s.IncludedActorDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedActorPatientResources != nil {
+		for _, r := range *s.IncludedActorPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedActorHealthcareServiceResources != nil {
+		for _, r := range *s.IncludedActorHealthcareServiceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedActorRelatedPersonResources != nil {
+		for _, r := range *s.IncludedActorRelatedPersonResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedActorLocationResources != nil {
+		for _, r := range *s.IncludedActorLocationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/searchparameter.go
+++ b/models/searchparameter.go
@@ -80,3 +80,16 @@ type SearchParameterContactComponent struct {
 	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
 	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
+
+type SearchParameterPlus struct {
+	SearchParameter             `bson:",inline"`
+	SearchParameterPlusIncludes `bson:",inline"`
+}
+
+type SearchParameterPlusIncludes struct {
+}
+
+func (s *SearchParameterPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/specimen.go
+++ b/models/specimen.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type Specimen struct {
 	DomainResource      `bson:",inline"`
@@ -95,4 +99,134 @@ type SpecimenContainerComponent struct {
 	SpecimenQuantity        *Quantity        `bson:"specimenQuantity,omitempty" json:"specimenQuantity,omitempty"`
 	AdditiveCodeableConcept *CodeableConcept `bson:"additiveCodeableConcept,omitempty" json:"additiveCodeableConcept,omitempty"`
 	AdditiveReference       *Reference       `bson:"additiveReference,omitempty" json:"additiveReference,omitempty"`
+}
+
+type SpecimenPlus struct {
+	Specimen             `bson:",inline"`
+	SpecimenPlusIncludes `bson:",inline"`
+}
+
+type SpecimenPlusIncludes struct {
+	IncludedParentResources           *[]Specimen     `bson:"_includedParentResources,omitempty"`
+	IncludedSubjectGroupResources     *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
+	IncludedSubjectDeviceResources    *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
+	IncludedSubjectPatientResources   *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+	IncludedSubjectSubstanceResources *[]Substance    `bson:"_includedSubjectSubstanceResources,omitempty"`
+	IncludedPatientResources          *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedCollectorResources        *[]Practitioner `bson:"_includedCollectorResources,omitempty"`
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedParentResources() (specimen []Specimen, err error) {
+	if s.IncludedParentResources == nil {
+		err = errors.New("Included specimen not requested")
+	} else {
+		specimen = *s.IncludedParentResources
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
+	if s.IncludedSubjectGroupResources == nil {
+		err = errors.New("Included groups not requested")
+	} else if len(*s.IncludedSubjectGroupResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*s.IncludedSubjectGroupResources))
+	} else if len(*s.IncludedSubjectGroupResources) == 1 {
+		group = &(*s.IncludedSubjectGroupResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
+	if s.IncludedSubjectDeviceResources == nil {
+		err = errors.New("Included devices not requested")
+	} else if len(*s.IncludedSubjectDeviceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedSubjectDeviceResources))
+	} else if len(*s.IncludedSubjectDeviceResources) == 1 {
+		device = &(*s.IncludedSubjectDeviceResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
+	if s.IncludedSubjectPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*s.IncludedSubjectPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedSubjectPatientResources))
+	} else if len(*s.IncludedSubjectPatientResources) == 1 {
+		patient = &(*s.IncludedSubjectPatientResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedSubjectSubstanceResource() (substance *Substance, err error) {
+	if s.IncludedSubjectSubstanceResources == nil {
+		err = errors.New("Included substances not requested")
+	} else if len(*s.IncludedSubjectSubstanceResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*s.IncludedSubjectSubstanceResources))
+	} else if len(*s.IncludedSubjectSubstanceResources) == 1 {
+		substance = &(*s.IncludedSubjectSubstanceResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if s.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*s.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResources))
+	} else if len(*s.IncludedPatientResources) == 1 {
+		patient = &(*s.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedCollectorResource() (practitioner *Practitioner, err error) {
+	if s.IncludedCollectorResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*s.IncludedCollectorResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedCollectorResources))
+	} else if len(*s.IncludedCollectorResources) == 1 {
+		practitioner = &(*s.IncludedCollectorResources)[0]
+	}
+	return
+}
+
+func (s *SpecimenPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedParentResources != nil {
+		for _, r := range *s.IncludedParentResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSubjectGroupResources != nil {
+		for _, r := range *s.IncludedSubjectGroupResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSubjectDeviceResources != nil {
+		for _, r := range *s.IncludedSubjectDeviceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSubjectPatientResources != nil {
+		for _, r := range *s.IncludedSubjectPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSubjectSubstanceResources != nil {
+		for _, r := range *s.IncludedSubjectSubstanceResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResources != nil {
+		for _, r := range *s.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedCollectorResources != nil {
+		for _, r := range *s.IncludedCollectorResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -75,3 +75,16 @@ type SubscriptionChannelComponent struct {
 	Payload  string `bson:"payload,omitempty" json:"payload,omitempty"`
 	Header   string `bson:"header,omitempty" json:"header,omitempty"`
 }
+
+type SubscriptionPlus struct {
+	Subscription             `bson:",inline"`
+	SubscriptionPlusIncludes `bson:",inline"`
+}
+
+type SubscriptionPlusIncludes struct {
+}
+
+func (s *SubscriptionPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/supplyrequest.go
+++ b/models/supplyrequest.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type SupplyRequest struct {
 	DomainResource        `bson:",inline"`
@@ -75,4 +79,100 @@ func (x *SupplyRequest) UnmarshalJSON(data []byte) (err error) {
 type SupplyRequestWhenComponent struct {
 	Code     *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 	Schedule *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
+}
+
+type SupplyRequestPlus struct {
+	SupplyRequest             `bson:",inline"`
+	SupplyRequestPlusIncludes `bson:",inline"`
+}
+
+type SupplyRequestPlusIncludes struct {
+	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
+	IncludedSupplierResources           *[]Organization `bson:"_includedSupplierResources,omitempty"`
+	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
+	IncludedSourceOrganizationResources *[]Organization `bson:"_includedSourceOrganizationResources,omitempty"`
+	IncludedSourcePatientResources      *[]Patient      `bson:"_includedSourcePatientResources,omitempty"`
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
+	if s.IncludedPatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*s.IncludedPatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResources))
+	} else if len(*s.IncludedPatientResources) == 1 {
+		patient = &(*s.IncludedPatientResources)[0]
+	}
+	return
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedSupplierResources() (organizations []Organization, err error) {
+	if s.IncludedSupplierResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else {
+		organizations = *s.IncludedSupplierResources
+	}
+	return
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
+	if s.IncludedSourcePractitionerResources == nil {
+		err = errors.New("Included practitioners not requested")
+	} else if len(*s.IncludedSourcePractitionerResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedSourcePractitionerResources))
+	} else if len(*s.IncludedSourcePractitionerResources) == 1 {
+		practitioner = &(*s.IncludedSourcePractitionerResources)[0]
+	}
+	return
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedSourceOrganizationResource() (organization *Organization, err error) {
+	if s.IncludedSourceOrganizationResources == nil {
+		err = errors.New("Included organizations not requested")
+	} else if len(*s.IncludedSourceOrganizationResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*s.IncludedSourceOrganizationResources))
+	} else if len(*s.IncludedSourceOrganizationResources) == 1 {
+		organization = &(*s.IncludedSourceOrganizationResources)[0]
+	}
+	return
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
+	if s.IncludedSourcePatientResources == nil {
+		err = errors.New("Included patients not requested")
+	} else if len(*s.IncludedSourcePatientResources) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedSourcePatientResources))
+	} else if len(*s.IncludedSourcePatientResources) == 1 {
+		patient = &(*s.IncludedSourcePatientResources)[0]
+	}
+	return
+}
+
+func (s *SupplyRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedPatientResources != nil {
+		for _, r := range *s.IncludedPatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSupplierResources != nil {
+		for _, r := range *s.IncludedSupplierResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSourcePractitionerResources != nil {
+		for _, r := range *s.IncludedSourcePractitionerResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSourceOrganizationResources != nil {
+		for _, r := range *s.IncludedSourceOrganizationResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSourcePatientResources != nil {
+		for _, r := range *s.IncludedSourcePatientResources {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
 }

--- a/models/testscript.go
+++ b/models/testscript.go
@@ -191,3 +191,16 @@ type TestScriptTeardownComponent struct {
 type TestScriptTeardownActionComponent struct {
 	Operation *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
 }
+
+type TestScriptPlus struct {
+	TestScript             `bson:",inline"`
+	TestScriptPlusIncludes `bson:",inline"`
+}
+
+type TestScriptPlusIncludes struct {
+}
+
+func (t *TestScriptPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}

--- a/models/valueset.go
+++ b/models/valueset.go
@@ -159,3 +159,16 @@ type ValueSetExpansionContainsComponent struct {
 	Display  string                               `bson:"display,omitempty" json:"display,omitempty"`
 	Contains []ValueSetExpansionContainsComponent `bson:"contains,omitempty" json:"contains,omitempty"`
 }
+
+type ValueSetPlus struct {
+	ValueSet             `bson:",inline"`
+	ValueSetPlusIncludes `bson:",inline"`
+}
+
+type ValueSetPlusIncludes struct {
+}
+
+func (v *ValueSetPlusIncludes) GetIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	return resourceMap
+}


### PR DESCRIPTION
Adds support for using the _include search parameter.  Doesn't support recursive includes or includes of references that are _Any_.

This newly included data is in new "Plus" structs that contain the resource and its includes.  The general design of that "Plus" container is largely influenced by the way Mongo requires you to do joins in the pipeline (joined data is represented as new array fields in the object).  In addition to generating the new "Plus" structs, there are also new helper methods for creating new instances and slices of these structs.