### PR TITLE
Better support for resourceType property in JSON

### DIFF
--- a/fixtures/patient-wrong-type.json
+++ b/fixtures/patient-wrong-type.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Wrong",
+  "identifier": [
+    {
+      "use": "usual",
+      "label": "MRN",
+      "system": "urn:oid:0.1.2.3.4.5.6.7",
+      "value": "654321"
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "family": [
+        "Daffy"
+      ],
+      "given": [
+        "Duck"
+      ]
+    }
+  ],
+  "gender": "male",
+  "active": true
+}

--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -52,14 +52,17 @@ type AllergyIntolerance struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *AllergyIntolerance) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		AllergyIntolerance
-	}{
-		ResourceType:       "AllergyIntolerance",
-		AllergyIntolerance: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "AllergyIntolerance"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to AllergyIntolerance), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *AllergyIntolerance) GetBSON() (interface{}, error) {
+	x.ResourceType = "AllergyIntolerance"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "allergyIntolerance" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -75,8 +78,18 @@ func (x *AllergyIntolerance) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = AllergyIntolerance(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *AllergyIntolerance) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "AllergyIntolerance"
+	} else if x.ResourceType != "AllergyIntolerance" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be AllergyIntolerance, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type AllergyIntoleranceReactionComponent struct {

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -26,7 +26,11 @@
 
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
 
 type ClaimResponse struct {
 	DomainResource          `bson:",inline"`
@@ -60,14 +64,17 @@ type ClaimResponse struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *ClaimResponse) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		ClaimResponse
-	}{
-		ResourceType:  "ClaimResponse",
-		ClaimResponse: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "ClaimResponse"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to ClaimResponse), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *ClaimResponse) GetBSON() (interface{}, error) {
+	x.ResourceType = "ClaimResponse"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "claimResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -83,8 +90,18 @@ func (x *ClaimResponse) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = ClaimResponse(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *ClaimResponse) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "ClaimResponse"
+	} else if x.ResourceType != "ClaimResponse" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be ClaimResponse, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ClaimResponseItemsComponent struct {

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -56,14 +56,17 @@ type ClinicalImpression struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *ClinicalImpression) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		ClinicalImpression
-	}{
-		ResourceType:       "ClinicalImpression",
-		ClinicalImpression: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "ClinicalImpression"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to ClinicalImpression), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *ClinicalImpression) GetBSON() (interface{}, error) {
+	x.ResourceType = "ClinicalImpression"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "clinicalImpression" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -79,8 +82,18 @@ func (x *ClinicalImpression) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = ClinicalImpression(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *ClinicalImpression) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "ClinicalImpression"
+	} else if x.ResourceType != "ClinicalImpression" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be ClinicalImpression, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ClinicalImpressionInvestigationsComponent struct {

--- a/models/communication.go
+++ b/models/communication.go
@@ -51,14 +51,17 @@ type Communication struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *Communication) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		Communication
-	}{
-		ResourceType:  "Communication",
-		Communication: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "Communication"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to Communication), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *Communication) GetBSON() (interface{}, error) {
+	x.ResourceType = "Communication"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "communication" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -74,8 +77,18 @@ func (x *Communication) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = Communication(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *Communication) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "Communication"
+	} else if x.ResourceType != "Communication" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be Communication, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type CommunicationPayloadComponent struct {

--- a/models/constructors.go
+++ b/models/constructors.go
@@ -1,0 +1,18 @@
+package models
+
+// This file contains manually generated convenience constructors for our
+// models.
+
+// NewOperationOutcome creates a pointer to an OperationOutcome and sets the
+// severity, code and diagnostics for the first issue.
+func NewOperationOutcome(severity, code, diagnostics string) *OperationOutcome {
+	return &OperationOutcome{
+		Issue: []OperationOutcomeIssueComponent{
+			OperationOutcomeIssueComponent{
+				Severity:    severity,
+				Code:        code,
+				Diagnostics: diagnostics,
+			},
+		},
+	}
+}

--- a/models/detectedissue.go
+++ b/models/detectedissue.go
@@ -48,14 +48,17 @@ type DetectedIssue struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *DetectedIssue) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		DetectedIssue
-	}{
-		ResourceType:  "DetectedIssue",
-		DetectedIssue: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "DetectedIssue"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to DetectedIssue), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *DetectedIssue) GetBSON() (interface{}, error) {
+	x.ResourceType = "DetectedIssue"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "detectedIssue" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -71,8 +74,18 @@ func (x *DetectedIssue) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = DetectedIssue(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *DetectedIssue) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "DetectedIssue"
+	} else if x.ResourceType != "DetectedIssue" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be DetectedIssue, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type DetectedIssueMitigationComponent struct {

--- a/models/deviceuserequest.go
+++ b/models/deviceuserequest.go
@@ -54,14 +54,17 @@ type DeviceUseRequest struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *DeviceUseRequest) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		DeviceUseRequest
-	}{
-		ResourceType:     "DeviceUseRequest",
-		DeviceUseRequest: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "DeviceUseRequest"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to DeviceUseRequest), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *DeviceUseRequest) GetBSON() (interface{}, error) {
+	x.ResourceType = "DeviceUseRequest"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "deviceUseRequest" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -77,8 +80,18 @@ func (x *DeviceUseRequest) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = DeviceUseRequest(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *DeviceUseRequest) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "DeviceUseRequest"
+	} else if x.ResourceType != "DeviceUseRequest" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be DeviceUseRequest, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type DeviceUseRequestPlus struct {

--- a/models/deviceusestatement.go
+++ b/models/deviceusestatement.go
@@ -50,14 +50,17 @@ type DeviceUseStatement struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *DeviceUseStatement) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		DeviceUseStatement
-	}{
-		ResourceType:       "DeviceUseStatement",
-		DeviceUseStatement: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "DeviceUseStatement"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to DeviceUseStatement), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *DeviceUseStatement) GetBSON() (interface{}, error) {
+	x.ResourceType = "DeviceUseStatement"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "deviceUseStatement" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -73,8 +76,18 @@ func (x *DeviceUseStatement) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = DeviceUseStatement(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *DeviceUseStatement) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "DeviceUseStatement"
+	} else if x.ResourceType != "DeviceUseStatement" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be DeviceUseStatement, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type DeviceUseStatementPlus struct {

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -50,14 +50,17 @@ type DiagnosticOrder struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *DiagnosticOrder) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		DiagnosticOrder
-	}{
-		ResourceType:    "DiagnosticOrder",
-		DiagnosticOrder: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "DiagnosticOrder"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to DiagnosticOrder), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *DiagnosticOrder) GetBSON() (interface{}, error) {
+	x.ResourceType = "DiagnosticOrder"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "diagnosticOrder" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -73,8 +76,18 @@ func (x *DiagnosticOrder) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = DiagnosticOrder(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *DiagnosticOrder) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "DiagnosticOrder"
+	} else if x.ResourceType != "DiagnosticOrder" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be DiagnosticOrder, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type DiagnosticOrderEventComponent struct {

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -55,14 +55,17 @@ type DocumentReference struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *DocumentReference) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		DocumentReference
-	}{
-		ResourceType:      "DocumentReference",
-		DocumentReference: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "DocumentReference"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to DocumentReference), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *DocumentReference) GetBSON() (interface{}, error) {
+	x.ResourceType = "DocumentReference"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "documentReference" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -78,8 +81,18 @@ func (x *DocumentReference) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = DocumentReference(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *DocumentReference) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "DocumentReference"
+	} else if x.ResourceType != "DocumentReference" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be DocumentReference, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type DocumentReferenceRelatesToComponent struct {

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -57,14 +57,17 @@ type Encounter struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *Encounter) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		Encounter
-	}{
-		ResourceType: "Encounter",
-		Encounter:    *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "Encounter"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to Encounter), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *Encounter) GetBSON() (interface{}, error) {
+	x.ResourceType = "Encounter"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "encounter" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -80,8 +83,18 @@ func (x *Encounter) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = Encounter(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *Encounter) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "Encounter"
+	} else if x.ResourceType != "Encounter" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be Encounter, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type EncounterStatusHistoryComponent struct {

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -49,14 +49,17 @@ type EpisodeOfCare struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *EpisodeOfCare) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		EpisodeOfCare
-	}{
-		ResourceType:  "EpisodeOfCare",
-		EpisodeOfCare: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "EpisodeOfCare"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to EpisodeOfCare), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *EpisodeOfCare) GetBSON() (interface{}, error) {
+	x.ResourceType = "EpisodeOfCare"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "episodeOfCare" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -72,8 +75,18 @@ func (x *EpisodeOfCare) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = EpisodeOfCare(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *EpisodeOfCare) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "EpisodeOfCare"
+	} else if x.ResourceType != "EpisodeOfCare" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be EpisodeOfCare, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type EpisodeOfCareStatusHistoryComponent struct {

--- a/models/familymemberhistory.go
+++ b/models/familymemberhistory.go
@@ -58,14 +58,17 @@ type FamilyMemberHistory struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *FamilyMemberHistory) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		FamilyMemberHistory
-	}{
-		ResourceType:        "FamilyMemberHistory",
-		FamilyMemberHistory: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "FamilyMemberHistory"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to FamilyMemberHistory), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *FamilyMemberHistory) GetBSON() (interface{}, error) {
+	x.ResourceType = "FamilyMemberHistory"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "familyMemberHistory" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -81,8 +84,18 @@ func (x *FamilyMemberHistory) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = FamilyMemberHistory(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *FamilyMemberHistory) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "FamilyMemberHistory"
+	} else if x.ResourceType != "FamilyMemberHistory" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be FamilyMemberHistory, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type FamilyMemberHistoryConditionComponent struct {

--- a/models/healthcareservice.go
+++ b/models/healthcareservice.go
@@ -60,14 +60,17 @@ type HealthcareService struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *HealthcareService) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		HealthcareService
-	}{
-		ResourceType:      "HealthcareService",
-		HealthcareService: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "HealthcareService"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to HealthcareService), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *HealthcareService) GetBSON() (interface{}, error) {
+	x.ResourceType = "HealthcareService"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "healthcareService" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -83,8 +86,18 @@ func (x *HealthcareService) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = HealthcareService(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *HealthcareService) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "HealthcareService"
+	} else if x.ResourceType != "HealthcareService" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be HealthcareService, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type HealthcareServiceServiceTypeComponent struct {

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -45,14 +45,17 @@ type ImagingObjectSelection struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *ImagingObjectSelection) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		ImagingObjectSelection
-	}{
-		ResourceType:           "ImagingObjectSelection",
-		ImagingObjectSelection: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "ImagingObjectSelection"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to ImagingObjectSelection), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *ImagingObjectSelection) GetBSON() (interface{}, error) {
+	x.ResourceType = "ImagingObjectSelection"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "imagingObjectSelection" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -68,8 +71,18 @@ func (x *ImagingObjectSelection) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = ImagingObjectSelection(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *ImagingObjectSelection) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "ImagingObjectSelection"
+	} else if x.ResourceType != "ImagingObjectSelection" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be ImagingObjectSelection, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ImagingObjectSelectionStudyComponent struct {

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -41,14 +41,17 @@ type ImmunizationRecommendation struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *ImmunizationRecommendation) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		ImmunizationRecommendation
-	}{
-		ResourceType:               "ImmunizationRecommendation",
-		ImmunizationRecommendation: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "ImmunizationRecommendation"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to ImmunizationRecommendation), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *ImmunizationRecommendation) GetBSON() (interface{}, error) {
+	x.ResourceType = "ImmunizationRecommendation"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "immunizationRecommendation" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -64,8 +67,18 @@ func (x *ImmunizationRecommendation) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = ImmunizationRecommendation(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *ImmunizationRecommendation) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "ImmunizationRecommendation"
+	} else if x.ResourceType != "ImmunizationRecommendation" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be ImmunizationRecommendation, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ImmunizationRecommendationRecommendationComponent struct {

--- a/models/media.go
+++ b/models/media.go
@@ -50,14 +50,17 @@ type Media struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *Media) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		Media
-	}{
-		ResourceType: "Media",
-		Media:        *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "Media"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to Media), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *Media) GetBSON() (interface{}, error) {
+	x.ResourceType = "Media"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "media" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -73,8 +76,18 @@ func (x *Media) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = Media(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *Media) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "Media"
+	} else if x.ResourceType != "Media" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be Media, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type MediaPlus struct {

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -54,14 +54,17 @@ type MedicationAdministration struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *MedicationAdministration) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		MedicationAdministration
-	}{
-		ResourceType:             "MedicationAdministration",
-		MedicationAdministration: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "MedicationAdministration"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to MedicationAdministration), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *MedicationAdministration) GetBSON() (interface{}, error) {
+	x.ResourceType = "MedicationAdministration"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "medicationAdministration" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -77,8 +80,18 @@ func (x *MedicationAdministration) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = MedicationAdministration(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *MedicationAdministration) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "MedicationAdministration"
+	} else if x.ResourceType != "MedicationAdministration" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be MedicationAdministration, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type MedicationAdministrationDosageComponent struct {

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -55,14 +55,17 @@ type MedicationDispense struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *MedicationDispense) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		MedicationDispense
-	}{
-		ResourceType:       "MedicationDispense",
-		MedicationDispense: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "MedicationDispense"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to MedicationDispense), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *MedicationDispense) GetBSON() (interface{}, error) {
+	x.ResourceType = "MedicationDispense"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "medicationDispense" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -78,8 +81,18 @@ func (x *MedicationDispense) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = MedicationDispense(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *MedicationDispense) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "MedicationDispense"
+	} else if x.ResourceType != "MedicationDispense" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be MedicationDispense, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type MedicationDispenseDosageInstructionComponent struct {

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -54,14 +54,17 @@ type MedicationStatement struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *MedicationStatement) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		MedicationStatement
-	}{
-		ResourceType:        "MedicationStatement",
-		MedicationStatement: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "MedicationStatement"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to MedicationStatement), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *MedicationStatement) GetBSON() (interface{}, error) {
+	x.ResourceType = "MedicationStatement"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "medicationStatement" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -77,8 +80,18 @@ func (x *MedicationStatement) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = MedicationStatement(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *MedicationStatement) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "MedicationStatement"
+	} else if x.ResourceType != "MedicationStatement" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be MedicationStatement, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type MedicationStatementDosageComponent struct {

--- a/models/namingsystem.go
+++ b/models/namingsystem.go
@@ -51,14 +51,17 @@ type NamingSystem struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *NamingSystem) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		NamingSystem
-	}{
-		ResourceType: "NamingSystem",
-		NamingSystem: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "NamingSystem"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to NamingSystem), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *NamingSystem) GetBSON() (interface{}, error) {
+	x.ResourceType = "NamingSystem"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "namingSystem" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -74,8 +77,18 @@ func (x *NamingSystem) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = NamingSystem(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *NamingSystem) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "NamingSystem"
+	} else if x.ResourceType != "NamingSystem" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be NamingSystem, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type NamingSystemContactComponent struct {

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -50,14 +50,17 @@ type NutritionOrder struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *NutritionOrder) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		NutritionOrder
-	}{
-		ResourceType:   "NutritionOrder",
-		NutritionOrder: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "NutritionOrder"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to NutritionOrder), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *NutritionOrder) GetBSON() (interface{}, error) {
+	x.ResourceType = "NutritionOrder"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "nutritionOrder" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -73,8 +76,18 @@ func (x *NutritionOrder) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = NutritionOrder(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *NutritionOrder) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "NutritionOrder"
+	} else if x.ResourceType != "NutritionOrder" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be NutritionOrder, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type NutritionOrderOralDietComponent struct {

--- a/models/orderresponse.go
+++ b/models/orderresponse.go
@@ -45,14 +45,17 @@ type OrderResponse struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *OrderResponse) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		OrderResponse
-	}{
-		ResourceType:  "OrderResponse",
-		OrderResponse: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "OrderResponse"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to OrderResponse), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *OrderResponse) GetBSON() (interface{}, error) {
+	x.ResourceType = "OrderResponse"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "orderResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -68,8 +71,18 @@ func (x *OrderResponse) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = OrderResponse(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *OrderResponse) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "OrderResponse"
+	} else if x.ResourceType != "OrderResponse" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be OrderResponse, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type OrderResponsePlus struct {

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -51,14 +51,17 @@ type ProcessResponse struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *ProcessResponse) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		ProcessResponse
-	}{
-		ResourceType:    "ProcessResponse",
-		ProcessResponse: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "ProcessResponse"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to ProcessResponse), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *ProcessResponse) GetBSON() (interface{}, error) {
+	x.ResourceType = "ProcessResponse"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "processResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -74,8 +77,18 @@ func (x *ProcessResponse) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = ProcessResponse(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *ProcessResponse) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "ProcessResponse"
+	} else if x.ResourceType != "ProcessResponse" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be ProcessResponse, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ProcessResponseNotesComponent struct {

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -48,14 +48,17 @@ type Provenance struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *Provenance) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		Provenance
-	}{
-		ResourceType: "Provenance",
-		Provenance:   *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "Provenance"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to Provenance), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *Provenance) GetBSON() (interface{}, error) {
+	x.ResourceType = "Provenance"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "provenance" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -71,8 +74,18 @@ func (x *Provenance) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = Provenance(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *Provenance) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "Provenance"
+	} else if x.ResourceType != "Provenance" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be Provenance, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type ProvenanceAgentComponent struct {

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -47,14 +47,17 @@ type QuestionnaireResponse struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *QuestionnaireResponse) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		QuestionnaireResponse
-	}{
-		ResourceType:          "QuestionnaireResponse",
-		QuestionnaireResponse: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "QuestionnaireResponse"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to QuestionnaireResponse), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *QuestionnaireResponse) GetBSON() (interface{}, error) {
+	x.ResourceType = "QuestionnaireResponse"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "questionnaireResponse" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -70,8 +73,18 @@ func (x *QuestionnaireResponse) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = QuestionnaireResponse(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *QuestionnaireResponse) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "QuestionnaireResponse"
+	} else if x.ResourceType != "QuestionnaireResponse" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be QuestionnaireResponse, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type QuestionnaireResponseGroupComponent struct {

--- a/models/resource.go
+++ b/models/resource.go
@@ -27,6 +27,7 @@
 package models
 
 type Resource struct {
+	ResourceType  string `bson:"resourceType,omitempty" json:"resourceType,omitempty"`
 	Id            string `bson:"_id,omitempty" json:"id,omitempty"`
 	Meta          *Meta  `bson:"meta,omitempty" json:"meta,omitempty"`
 	ImplicitRules string `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -48,14 +48,17 @@ type RiskAssessment struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *RiskAssessment) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		RiskAssessment
-	}{
-		ResourceType:   "RiskAssessment",
-		RiskAssessment: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "RiskAssessment"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to RiskAssessment), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *RiskAssessment) GetBSON() (interface{}, error) {
+	x.ResourceType = "RiskAssessment"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "riskAssessment" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -71,8 +74,18 @@ func (x *RiskAssessment) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = RiskAssessment(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *RiskAssessment) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "RiskAssessment"
+	} else if x.ResourceType != "RiskAssessment" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be RiskAssessment, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type RiskAssessmentPredictionComponent struct {

--- a/models/supplydelivery.go
+++ b/models/supplydelivery.go
@@ -49,14 +49,17 @@ type SupplyDelivery struct {
 
 // Custom marshaller to add the resourceType property, as required by the specification
 func (resource *SupplyDelivery) MarshalJSON() ([]byte, error) {
-	x := struct {
-		ResourceType string `json:"resourceType"`
-		SupplyDelivery
-	}{
-		ResourceType:   "SupplyDelivery",
-		SupplyDelivery: *resource,
-	}
-	return json.Marshal(x)
+	resource.ResourceType = "SupplyDelivery"
+	// Dereferencing the pointer to avoid infinite recursion.
+	// Passing in plain old x (a pointer to SupplyDelivery), would cause this same
+	// MarshallJSON function to be called again
+	return json.Marshal(*resource)
+}
+
+func (x *SupplyDelivery) GetBSON() (interface{}, error) {
+	x.ResourceType = "SupplyDelivery"
+	// See comment in MarshallJSON to see why we dereference
+	return *x, nil
 }
 
 // The "supplyDelivery" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -72,8 +75,18 @@ func (x *SupplyDelivery) UnmarshalJSON(data []byte) (err error) {
 			}
 		}
 		*x = SupplyDelivery(x2)
+		return x.checkResourceType()
 	}
 	return
+}
+
+func (x *SupplyDelivery) checkResourceType() error {
+	if x.ResourceType == "" {
+		x.ResourceType = "SupplyDelivery"
+	} else if x.ResourceType != "SupplyDelivery" {
+		return errors.New(fmt.Sprintf("Expected resourceType to be SupplyDelivery, instead received %s", x.ResourceType))
+	}
+	return nil
 }
 
 type SupplyDeliveryPlus struct {

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	//"github.com/davecgh/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/intervention-engine/fhir/models"
 	"github.com/pebbe/util"
 	. "gopkg.in/check.v1"
@@ -1301,7 +1302,9 @@ func (m *MongoSearchSuite) TestObservationCodeQueryForInclude(c *C) {
 	q := Query{"Observation", "code=http://loinc.org|17856-6&_include=Observation:patient&_include=Observation:encounter"}
 
 	var results []models.ObservationPlus
-	err := m.MongoSearcher.CreatePipeline(q).All(&results)
+	pipeline := m.MongoSearcher.CreatePipeline(q)
+	spew.Dump(pipeline)
+	err := pipeline.All(&results)
 	util.CheckErr(err)
 	c.Assert(results, HasLen, 1)
 

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	//"github.com/davecgh/go-spew/spew"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/intervention-engine/fhir/models"
 	"github.com/pebbe/util"
 	. "gopkg.in/check.v1"
@@ -1302,9 +1301,7 @@ func (m *MongoSearchSuite) TestObservationCodeQueryForInclude(c *C) {
 	q := Query{"Observation", "code=http://loinc.org|17856-6&_include=Observation:patient&_include=Observation:encounter"}
 
 	var results []models.ObservationPlus
-	pipeline := m.MongoSearcher.CreatePipeline(q)
-	spew.Dump(pipeline)
-	err := pipeline.All(&results)
+	err := m.MongoSearcher.CreatePipeline(q).All(&results)
 	util.CheckErr(err)
 	c.Assert(results, HasLen, 1)
 

--- a/server/resource_controller.go
+++ b/server/resource_controller.go
@@ -33,14 +33,7 @@ func (rc *ResourceController) IndexHandler(c *echo.Context) error {
 			case search.Error:
 				return c.JSON(x.HTTPStatus, x.OperationOutcome)
 			default:
-				outcome := &models.OperationOutcome{
-					Issue: []models.OperationOutcomeIssueComponent{
-						models.OperationOutcomeIssueComponent{
-							Severity: "fatal",
-							Code:     "exception",
-						},
-					},
-				}
+				outcome := models.NewOperationOutcome("fatal", "exception", "")
 				return c.JSON(http.StatusInternalServerError, outcome)
 			}
 		}
@@ -220,7 +213,8 @@ func (rc *ResourceController) CreateHandler(c *echo.Context) error {
 	resource := models.NewStructForResourceName(rc.Name)
 	err := c.Bind(resource)
 	if err != nil {
-		return err
+		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
+		return c.JSON(http.StatusBadRequest, oo)
 	}
 
 	collection := Database.C(models.PluralizeLowerResourceName(rc.Name))
@@ -256,7 +250,8 @@ func (rc *ResourceController) UpdateHandler(c *echo.Context) error {
 	resource := models.NewStructForResourceName(rc.Name)
 	err := c.Bind(resource)
 	if err != nil {
-		return err
+		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
+		return c.JSON(http.StatusBadRequest, oo)
 	}
 
 	collection := Database.C(models.PluralizeLowerResourceName(rc.Name))


### PR DESCRIPTION
This change ensures that all resources have a resourceType. When going from JSON
into a go struct, the following will now happen:

If a resourceType is provided and is correct, nothing will happen
If it is not provided, it will be set in the struct
If it is provided and wrong, an error will be returned

Also, the server will now return a 400 and OperationOutcome describing what went
wrong if a resource is PUT/POSTed with the wrong resourceType.