### PR TITLE
Search revinclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binary artifacts
+/fhir
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/fixtures/search_test_data.json
+++ b/fixtures/search_test_data.json
@@ -126,6 +126,9 @@
 	"patient": {
 		"reference": "Patient/4954037118555241963"
 	},
+	"asserter": {
+		"reference": "Practitioner/7045606679745586371"
+	},
 	"code": {
 		"coding": [{
 			"system": "http://snomed.info/sct",
@@ -203,6 +206,9 @@
 	"patient": {
 		"reference": "Patient/4954037118555241963"
 	},
+	"asserter": {
+		"reference": "Patient/4954037118555241963"
+	},
 	"code": {
 		"coding": [{
 			"system": "http://snomed.info/sct",
@@ -252,7 +258,10 @@
 	},
 	"encounter": {
 		"reference": "Encounter/6648204100111387580"
-	}
+	},
+	"performer": [{
+		"reference": "Practitioner/7045606679745586371"
+	}]
 }, {
 	"resourceType": "Procedure",
 	"id": "1203028907289396691",
@@ -316,7 +325,10 @@
 	"status": "final",
 	"subject": {
 		"reference": "Patient/4954037118555241963"
-	}
+	},
+	"performer": [{
+		"reference": "Organization/7045605384245533352"
+	}]
 }, {
 	"resourceType": "Observation",
 	"id": "3436673599267881943",
@@ -594,4 +606,25 @@
       "exclude": false
     }
   ]
+}, {
+  "resourceType": "Practitioner",
+  "id": "7045606679745586371",
+  "name": {
+    "use": "official",
+    "family": [
+      "Heps"
+    ],
+    "given": [
+      "Simone"
+    ],
+    "suffix": [
+      "MD"
+    ]
+  },
+  "gender": "female",
+  "birthDate": "1971-11-07"
+}, {
+  "resourceType": "Organization",
+  "id": "7045605384245533352",
+  "name": "Good Health Clinic"
 }]

--- a/models/account.go
+++ b/models/account.go
@@ -90,148 +90,518 @@ func (x *Account) checkResourceType() error {
 }
 
 type AccountPlus struct {
-	Account             `bson:",inline"`
-	AccountPlusIncludes `bson:",inline"`
+	Account                     `bson:",inline"`
+	AccountPlusRelatedResources `bson:",inline"`
 }
 
-type AccountPlusIncludes struct {
-	IncludedOwnerResources                    *[]Organization      `bson:"_includedOwnerResources,omitempty"`
-	IncludedSubjectPractitionerResources      *[]Practitioner      `bson:"_includedSubjectPractitionerResources,omitempty"`
-	IncludedSubjectOrganizationResources      *[]Organization      `bson:"_includedSubjectOrganizationResources,omitempty"`
-	IncludedSubjectDeviceResources            *[]Device            `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources           *[]Patient           `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectHealthcareServiceResources *[]HealthcareService `bson:"_includedSubjectHealthcareServiceResources,omitempty"`
-	IncludedSubjectLocationResources          *[]Location          `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedPatientResources                  *[]Patient           `bson:"_includedPatientResources,omitempty"`
+type AccountPlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByOwner              *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOwner,omitempty"`
+	IncludedPractitionerResourcesReferencedBySubject            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySubject,omitempty"`
+	IncludedOrganizationResourcesReferencedBySubject            *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedHealthcareServiceResourcesReferencedBySubject       *[]HealthcareService     `bson:"_includedHealthcareServiceResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                *[]Location              `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (a *AccountPlusIncludes) GetIncludedOwnerResource() (organization *Organization, err error) {
-	if a.IncludedOwnerResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOwner() (organization *Organization, err error) {
+	if a.IncludedOrganizationResourcesReferencedByOwner == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*a.IncludedOwnerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedOwnerResources))
-	} else if len(*a.IncludedOwnerResources) == 1 {
-		organization = &(*a.IncludedOwnerResources)[0]
+	} else if len(*a.IncludedOrganizationResourcesReferencedByOwner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedOrganizationResourcesReferencedByOwner))
+	} else if len(*a.IncludedOrganizationResourcesReferencedByOwner) == 1 {
+		organization = &(*a.IncludedOrganizationResourcesReferencedByOwner)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedSubjectPractitionerResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySubject() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedBySubject == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedSubjectPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedSubjectPractitionerResources))
-	} else if len(*a.IncludedSubjectPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedSubjectPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedBySubject))
+	} else if len(*a.IncludedPractitionerResourcesReferencedBySubject) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
-	if a.IncludedSubjectOrganizationResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySubject() (organization *Organization, err error) {
+	if a.IncludedOrganizationResourcesReferencedBySubject == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*a.IncludedSubjectOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedSubjectOrganizationResources))
-	} else if len(*a.IncludedSubjectOrganizationResources) == 1 {
-		organization = &(*a.IncludedSubjectOrganizationResources)[0]
+	} else if len(*a.IncludedOrganizationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedOrganizationResourcesReferencedBySubject))
+	} else if len(*a.IncludedOrganizationResourcesReferencedBySubject) == 1 {
+		organization = &(*a.IncludedOrganizationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if a.IncludedSubjectDeviceResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if a.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*a.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedSubjectDeviceResources))
-	} else if len(*a.IncludedSubjectDeviceResources) == 1 {
-		device = &(*a.IncludedSubjectDeviceResources)[0]
+	} else if len(*a.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*a.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*a.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if a.IncludedSubjectPatientResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedSubjectPatientResources))
-	} else if len(*a.IncludedSubjectPatientResources) == 1 {
-		patient = &(*a.IncludedSubjectPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*a.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
-	if a.IncludedSubjectHealthcareServiceResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedHealthcareServiceResourceReferencedBySubject() (healthcareService *HealthcareService, err error) {
+	if a.IncludedHealthcareServiceResourcesReferencedBySubject == nil {
 		err = errors.New("Included healthcareservices not requested")
-	} else if len(*a.IncludedSubjectHealthcareServiceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedSubjectHealthcareServiceResources))
-	} else if len(*a.IncludedSubjectHealthcareServiceResources) == 1 {
-		healthcareService = &(*a.IncludedSubjectHealthcareServiceResources)[0]
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedHealthcareServiceResourcesReferencedBySubject))
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedBySubject) == 1 {
+		healthcareService = &(*a.IncludedHealthcareServiceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if a.IncludedSubjectLocationResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if a.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*a.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedSubjectLocationResources))
-	} else if len(*a.IncludedSubjectLocationResources) == 1 {
-		location = &(*a.IncludedSubjectLocationResources)[0]
+	} else if len(*a.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*a.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*a.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if a.IncludedPatientResources == nil {
+func (a *AccountPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
-	} else if len(*a.IncludedPatientResources) == 1 {
-		patient = &(*a.IncludedPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (a *AccountPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (a *AccountPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if a.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *a.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if a.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *a.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if a.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *a.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if a.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *a.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if a.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *a.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *a.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *a.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if a.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *a.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if a.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *a.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (a *AccountPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if a.IncludedOwnerResources != nil {
-		for _, r := range *a.IncludedOwnerResources {
+	if a.IncludedOrganizationResourcesReferencedByOwner != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectPractitionerResources != nil {
-		for _, r := range *a.IncludedSubjectPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectOrganizationResources != nil {
-		for _, r := range *a.IncludedSubjectOrganizationResources {
+	if a.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectDeviceResources != nil {
-		for _, r := range *a.IncludedSubjectDeviceResources {
+	if a.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectPatientResources != nil {
-		for _, r := range *a.IncludedSubjectPatientResources {
+	if a.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectHealthcareServiceResources != nil {
-		for _, r := range *a.IncludedSubjectHealthcareServiceResources {
+	if a.IncludedHealthcareServiceResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedSubjectLocationResources != nil {
-		for _, r := range *a.IncludedSubjectLocationResources {
+	if a.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientResources != nil {
-		for _, r := range *a.IncludedPatientResources {
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AccountPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AccountPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedOrganizationResourcesReferencedByOwner != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedHealthcareServiceResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -104,114 +104,514 @@ type AllergyIntoleranceReactionComponent struct {
 }
 
 type AllergyIntolerancePlus struct {
-	AllergyIntolerance             `bson:",inline"`
-	AllergyIntolerancePlusIncludes `bson:",inline"`
+	AllergyIntolerance                     `bson:",inline"`
+	AllergyIntolerancePlusRelatedResources `bson:",inline"`
 }
 
-type AllergyIntolerancePlusIncludes struct {
-	IncludedRecorderPractitionerResources  *[]Practitioner  `bson:"_includedRecorderPractitionerResources,omitempty"`
-	IncludedRecorderPatientResources       *[]Patient       `bson:"_includedRecorderPatientResources,omitempty"`
-	IncludedReporterPractitionerResources  *[]Practitioner  `bson:"_includedReporterPractitionerResources,omitempty"`
-	IncludedReporterPatientResources       *[]Patient       `bson:"_includedReporterPatientResources,omitempty"`
-	IncludedReporterRelatedPersonResources *[]RelatedPerson `bson:"_includedReporterRelatedPersonResources,omitempty"`
-	IncludedPatientResources               *[]Patient       `bson:"_includedPatientResources,omitempty"`
+type AllergyIntolerancePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByRecorder                    *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByRecorder,omitempty"`
+	IncludedPatientResourcesReferencedByRecorder                         *[]Patient                    `bson:"_includedPatientResourcesReferencedByRecorder,omitempty"`
+	IncludedPractitionerResourcesReferencedByReporter                    *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByReporter,omitempty"`
+	IncludedPatientResourcesReferencedByReporter                         *[]Patient                    `bson:"_includedPatientResourcesReferencedByReporter,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByReporter                   *[]RelatedPerson              `bson:"_includedRelatedPersonResourcesReferencedByReporter,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                          *[]Patient                    `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                      *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref            *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref            *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                              *[]List                       `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref           *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                           *[]Order                      `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                          *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                   *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                    *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                      *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated               *[]DetectedIssue              `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment              *[]OrderResponse              `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject          *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest                *[]ProcessResponse            `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger             *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingProblem             *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingProblem,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                     *[]MessageHeader              `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedImmunizationRecommendationResourcesReferencingInformation *[]ImmunizationRecommendation `bson:"_revIncludedImmunizationRecommendationResourcesReferencingInformation,omitempty"`
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedRecorderPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedRecorderPractitionerResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedPractitionerResourceReferencedByRecorder() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByRecorder == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedRecorderPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedRecorderPractitionerResources))
-	} else if len(*a.IncludedRecorderPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedRecorderPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByRecorder) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByRecorder))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByRecorder) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByRecorder)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedRecorderPatientResource() (patient *Patient, err error) {
-	if a.IncludedRecorderPatientResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedPatientResourceReferencedByRecorder() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByRecorder == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedRecorderPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedRecorderPatientResources))
-	} else if len(*a.IncludedRecorderPatientResources) == 1 {
-		patient = &(*a.IncludedRecorderPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByRecorder) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByRecorder))
+	} else if len(*a.IncludedPatientResourcesReferencedByRecorder) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByRecorder)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedReporterPractitionerResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedPractitionerResourceReferencedByReporter() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByReporter == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedReporterPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedReporterPractitionerResources))
-	} else if len(*a.IncludedReporterPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedReporterPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByReporter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByReporter))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByReporter) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByReporter)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterPatientResource() (patient *Patient, err error) {
-	if a.IncludedReporterPatientResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedPatientResourceReferencedByReporter() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByReporter == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedReporterPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedReporterPatientResources))
-	} else if len(*a.IncludedReporterPatientResources) == 1 {
-		patient = &(*a.IncludedReporterPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByReporter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByReporter))
+	} else if len(*a.IncludedPatientResourcesReferencedByReporter) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByReporter)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedReporterRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if a.IncludedReporterRelatedPersonResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByReporter() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedRelatedPersonResourcesReferencedByReporter == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*a.IncludedReporterRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedReporterRelatedPersonResources))
-	} else if len(*a.IncludedReporterRelatedPersonResources) == 1 {
-		relatedPerson = &(*a.IncludedReporterRelatedPersonResources)[0]
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByReporter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedRelatedPersonResourcesReferencedByReporter))
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByReporter) == 1 {
+		relatedPerson = &(*a.IncludedRelatedPersonResourcesReferencedByReporter)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if a.IncludedPatientResources == nil {
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
-	} else if len(*a.IncludedPatientResources) == 1 {
-		patient = &(*a.IncludedPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (a *AllergyIntolerancePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if a.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *a.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if a.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *a.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if a.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *a.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if a.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *a.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if a.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *a.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *a.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *a.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if a.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *a.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingProblem() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingProblem == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingProblem
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if a.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *a.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedImmunizationRecommendationResourcesReferencingInformation() (immunizationRecommendations []ImmunizationRecommendation, err error) {
+	if a.RevIncludedImmunizationRecommendationResourcesReferencingInformation == nil {
+		err = errors.New("RevIncluded immunizationRecommendations not requested")
+	} else {
+		immunizationRecommendations = *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation
+	}
+	return
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if a.IncludedRecorderPractitionerResources != nil {
-		for _, r := range *a.IncludedRecorderPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByRecorder != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByRecorder {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedRecorderPatientResources != nil {
-		for _, r := range *a.IncludedRecorderPatientResources {
+	if a.IncludedPatientResourcesReferencedByRecorder != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByRecorder {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedReporterPractitionerResources != nil {
-		for _, r := range *a.IncludedReporterPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByReporter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedReporterPatientResources != nil {
-		for _, r := range *a.IncludedReporterPatientResources {
+	if a.IncludedPatientResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByReporter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedReporterRelatedPersonResources != nil {
-		for _, r := range *a.IncludedReporterRelatedPersonResources {
+	if a.IncludedRelatedPersonResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientResources != nil {
-		for _, r := range *a.IncludedPatientResources {
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
+		for _, r := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AllergyIntolerancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedPractitionerResourcesReferencedByRecorder != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByRecorder != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedRelatedPersonResourcesReferencedByReporter != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
+		for _, r := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/appointment.go
+++ b/models/appointment.go
@@ -98,165 +98,640 @@ type AppointmentParticipantComponent struct {
 }
 
 type AppointmentPlus struct {
-	Appointment             `bson:",inline"`
-	AppointmentPlusIncludes `bson:",inline"`
+	Appointment                     `bson:",inline"`
+	AppointmentPlusRelatedResources `bson:",inline"`
 }
 
-type AppointmentPlusIncludes struct {
-	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
-	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
-	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
-	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
-	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
-	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
-	IncludedPractitionerResources           *[]Practitioner      `bson:"_includedPractitionerResources,omitempty"`
-	IncludedPatientResources                *[]Patient           `bson:"_includedPatientResources,omitempty"`
-	IncludedLocationResources               *[]Location          `bson:"_includedLocationResources,omitempty"`
+type AppointmentPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByActor                *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActor,omitempty"`
+	IncludedDeviceResourcesReferencedByActor                      *[]Device                `bson:"_includedDeviceResourcesReferencedByActor,omitempty"`
+	IncludedPatientResourcesReferencedByActor                     *[]Patient               `bson:"_includedPatientResourcesReferencedByActor,omitempty"`
+	IncludedHealthcareServiceResourcesReferencedByActor           *[]HealthcareService     `bson:"_includedHealthcareServiceResourcesReferencedByActor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByActor               *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByActor,omitempty"`
+	IncludedLocationResourcesReferencedByActor                    *[]Location              `bson:"_includedLocationResourcesReferencedByActor,omitempty"`
+	IncludedPractitionerResourcesReferencedByPractitioner         *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPractitioner,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                   *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedLocationResourcesReferencedByLocation                 *[]Location              `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget               *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref     *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref     *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference      *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                       *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref    *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                    *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingAppointment *[]AppointmentResponse   `bson:"_revIncludedAppointmentResponseResourcesReferencingAppointment,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                   *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedEncounterResourcesReferencingAppointment           *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingAppointment,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference            *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry               *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated        *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment       *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject   *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest         *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger      *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan         *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData              *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedActorPractitionerResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedPractitionerResourceReferencedByActor() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByActor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedActorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedActorPractitionerResources))
-	} else if len(*a.IncludedActorPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedActorPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByActor))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByActor) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
-	if a.IncludedActorDeviceResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedDeviceResourceReferencedByActor() (device *Device, err error) {
+	if a.IncludedDeviceResourcesReferencedByActor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*a.IncludedActorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedActorDeviceResources))
-	} else if len(*a.IncludedActorDeviceResources) == 1 {
-		device = &(*a.IncludedActorDeviceResources)[0]
+	} else if len(*a.IncludedDeviceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedDeviceResourcesReferencedByActor))
+	} else if len(*a.IncludedDeviceResourcesReferencedByActor) == 1 {
+		device = &(*a.IncludedDeviceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
-	if a.IncludedActorPatientResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedPatientResourceReferencedByActor() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByActor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedActorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedActorPatientResources))
-	} else if len(*a.IncludedActorPatientResources) == 1 {
-		patient = &(*a.IncludedActorPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByActor))
+	} else if len(*a.IncludedPatientResourcesReferencedByActor) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
-	if a.IncludedActorHealthcareServiceResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedHealthcareServiceResourceReferencedByActor() (healthcareService *HealthcareService, err error) {
+	if a.IncludedHealthcareServiceResourcesReferencedByActor == nil {
 		err = errors.New("Included healthcareservices not requested")
-	} else if len(*a.IncludedActorHealthcareServiceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedActorHealthcareServiceResources))
-	} else if len(*a.IncludedActorHealthcareServiceResources) == 1 {
-		healthcareService = &(*a.IncludedActorHealthcareServiceResources)[0]
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedHealthcareServiceResourcesReferencedByActor))
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedByActor) == 1 {
+		healthcareService = &(*a.IncludedHealthcareServiceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if a.IncludedActorRelatedPersonResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByActor() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedRelatedPersonResourcesReferencedByActor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*a.IncludedActorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedActorRelatedPersonResources))
-	} else if len(*a.IncludedActorRelatedPersonResources) == 1 {
-		relatedPerson = &(*a.IncludedActorRelatedPersonResources)[0]
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedRelatedPersonResourcesReferencedByActor))
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByActor) == 1 {
+		relatedPerson = &(*a.IncludedRelatedPersonResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
-	if a.IncludedActorLocationResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedLocationResourceReferencedByActor() (location *Location, err error) {
+	if a.IncludedLocationResourcesReferencedByActor == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*a.IncludedActorLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedActorLocationResources))
-	} else if len(*a.IncludedActorLocationResources) == 1 {
-		location = &(*a.IncludedActorLocationResources)[0]
+	} else if len(*a.IncludedLocationResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResourcesReferencedByActor))
+	} else if len(*a.IncludedLocationResourcesReferencedByActor) == 1 {
+		location = &(*a.IncludedLocationResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedPractitionerResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPractitioner() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResources))
-	} else if len(*a.IncludedPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByPractitioner))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByPractitioner) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if a.IncludedPatientResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
-	} else if len(*a.IncludedPatientResources) == 1 {
-		patient = &(*a.IncludedPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if a.IncludedLocationResources == nil {
+func (a *AppointmentPlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if a.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*a.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResources))
-	} else if len(*a.IncludedLocationResources) == 1 {
-		location = &(*a.IncludedLocationResources)[0]
+	} else if len(*a.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*a.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*a.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (a *AppointmentPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (a *AppointmentPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if a.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *a.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if a.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *a.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if a.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *a.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if a.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *a.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingAppointment() (appointmentResponses []AppointmentResponse, err error) {
+	if a.RevIncludedAppointmentResponseResourcesReferencingAppointment == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *a.RevIncludedAppointmentResponseResourcesReferencingAppointment
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if a.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *a.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingAppointment() (encounters []Encounter, err error) {
+	if a.RevIncludedEncounterResourcesReferencingAppointment == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *a.RevIncludedEncounterResourcesReferencingAppointment
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if a.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *a.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *a.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *a.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if a.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *a.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if a.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *a.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (a *AppointmentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if a.IncludedActorPractitionerResources != nil {
-		for _, r := range *a.IncludedActorPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorDeviceResources != nil {
-		for _, r := range *a.IncludedActorDeviceResources {
+	if a.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorPatientResources != nil {
-		for _, r := range *a.IncludedActorPatientResources {
+	if a.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorHealthcareServiceResources != nil {
-		for _, r := range *a.IncludedActorHealthcareServiceResources {
+	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorRelatedPersonResources != nil {
-		for _, r := range *a.IncludedActorRelatedPersonResources {
+	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorLocationResources != nil {
-		for _, r := range *a.IncludedActorLocationResources {
+	if a.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPractitionerResources != nil {
-		for _, r := range *a.IncludedPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientResources != nil {
-		for _, r := range *a.IncludedPatientResources {
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedLocationResources != nil {
-		for _, r := range *a.IncludedLocationResources {
+	if a.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AppointmentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAppointmentResponseResourcesReferencingAppointment != nil {
+		for _, r := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedEncounterResourcesReferencingAppointment != nil {
+		for _, r := range *a.RevIncludedEncounterResourcesReferencingAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AppointmentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAppointmentResponseResourcesReferencingAppointment != nil {
+		for _, r := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedEncounterResourcesReferencingAppointment != nil {
+		for _, r := range *a.RevIncludedEncounterResourcesReferencingAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/appointmentresponse.go
+++ b/models/appointmentresponse.go
@@ -87,182 +87,562 @@ func (x *AppointmentResponse) checkResourceType() error {
 }
 
 type AppointmentResponsePlus struct {
-	AppointmentResponse             `bson:",inline"`
-	AppointmentResponsePlusIncludes `bson:",inline"`
+	AppointmentResponse                     `bson:",inline"`
+	AppointmentResponsePlusRelatedResources `bson:",inline"`
 }
 
-type AppointmentResponsePlusIncludes struct {
-	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
-	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
-	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
-	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
-	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
-	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
-	IncludedPractitionerResources           *[]Practitioner      `bson:"_includedPractitionerResources,omitempty"`
-	IncludedPatientResources                *[]Patient           `bson:"_includedPatientResources,omitempty"`
-	IncludedAppointmentResources            *[]Appointment       `bson:"_includedAppointmentResources,omitempty"`
-	IncludedLocationResources               *[]Location          `bson:"_includedLocationResources,omitempty"`
+type AppointmentResponsePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByActor              *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActor,omitempty"`
+	IncludedDeviceResourcesReferencedByActor                    *[]Device                `bson:"_includedDeviceResourcesReferencedByActor,omitempty"`
+	IncludedPatientResourcesReferencedByActor                   *[]Patient               `bson:"_includedPatientResourcesReferencedByActor,omitempty"`
+	IncludedHealthcareServiceResourcesReferencedByActor         *[]HealthcareService     `bson:"_includedHealthcareServiceResourcesReferencedByActor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByActor             *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByActor,omitempty"`
+	IncludedLocationResourcesReferencedByActor                  *[]Location              `bson:"_includedLocationResourcesReferencedByActor,omitempty"`
+	IncludedPractitionerResourcesReferencedByPractitioner       *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPractitioner,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedAppointmentResourcesReferencedByAppointment         *[]Appointment           `bson:"_includedAppointmentResourcesReferencedByAppointment,omitempty"`
+	IncludedLocationResourcesReferencedByLocation               *[]Location              `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedActorPractitionerResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedByActor() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByActor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedActorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedActorPractitionerResources))
-	} else if len(*a.IncludedActorPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedActorPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByActor))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByActor) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
-	if a.IncludedActorDeviceResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedDeviceResourceReferencedByActor() (device *Device, err error) {
+	if a.IncludedDeviceResourcesReferencedByActor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*a.IncludedActorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedActorDeviceResources))
-	} else if len(*a.IncludedActorDeviceResources) == 1 {
-		device = &(*a.IncludedActorDeviceResources)[0]
+	} else if len(*a.IncludedDeviceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedDeviceResourcesReferencedByActor))
+	} else if len(*a.IncludedDeviceResourcesReferencedByActor) == 1 {
+		device = &(*a.IncludedDeviceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
-	if a.IncludedActorPatientResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedPatientResourceReferencedByActor() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByActor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedActorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedActorPatientResources))
-	} else if len(*a.IncludedActorPatientResources) == 1 {
-		patient = &(*a.IncludedActorPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByActor))
+	} else if len(*a.IncludedPatientResourcesReferencedByActor) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
-	if a.IncludedActorHealthcareServiceResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedHealthcareServiceResourceReferencedByActor() (healthcareService *HealthcareService, err error) {
+	if a.IncludedHealthcareServiceResourcesReferencedByActor == nil {
 		err = errors.New("Included healthcareservices not requested")
-	} else if len(*a.IncludedActorHealthcareServiceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedActorHealthcareServiceResources))
-	} else if len(*a.IncludedActorHealthcareServiceResources) == 1 {
-		healthcareService = &(*a.IncludedActorHealthcareServiceResources)[0]
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*a.IncludedHealthcareServiceResourcesReferencedByActor))
+	} else if len(*a.IncludedHealthcareServiceResourcesReferencedByActor) == 1 {
+		healthcareService = &(*a.IncludedHealthcareServiceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if a.IncludedActorRelatedPersonResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByActor() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedRelatedPersonResourcesReferencedByActor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*a.IncludedActorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedActorRelatedPersonResources))
-	} else if len(*a.IncludedActorRelatedPersonResources) == 1 {
-		relatedPerson = &(*a.IncludedActorRelatedPersonResources)[0]
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedRelatedPersonResourcesReferencedByActor))
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByActor) == 1 {
+		relatedPerson = &(*a.IncludedRelatedPersonResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
-	if a.IncludedActorLocationResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedLocationResourceReferencedByActor() (location *Location, err error) {
+	if a.IncludedLocationResourcesReferencedByActor == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*a.IncludedActorLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedActorLocationResources))
-	} else if len(*a.IncludedActorLocationResources) == 1 {
-		location = &(*a.IncludedActorLocationResources)[0]
+	} else if len(*a.IncludedLocationResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResourcesReferencedByActor))
+	} else if len(*a.IncludedLocationResourcesReferencedByActor) == 1 {
+		location = &(*a.IncludedLocationResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedPractitionerResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedByPractitioner() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResources))
-	} else if len(*a.IncludedPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByPractitioner))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByPractitioner) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if a.IncludedPatientResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResources))
-	} else if len(*a.IncludedPatientResources) == 1 {
-		patient = &(*a.IncludedPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedAppointmentResource() (appointment *Appointment, err error) {
-	if a.IncludedAppointmentResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedAppointmentResourceReferencedByAppointment() (appointment *Appointment, err error) {
+	if a.IncludedAppointmentResourcesReferencedByAppointment == nil {
 		err = errors.New("Included appointments not requested")
-	} else if len(*a.IncludedAppointmentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*a.IncludedAppointmentResources))
-	} else if len(*a.IncludedAppointmentResources) == 1 {
-		appointment = &(*a.IncludedAppointmentResources)[0]
+	} else if len(*a.IncludedAppointmentResourcesReferencedByAppointment) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*a.IncludedAppointmentResourcesReferencedByAppointment))
+	} else if len(*a.IncludedAppointmentResourcesReferencedByAppointment) == 1 {
+		appointment = &(*a.IncludedAppointmentResourcesReferencedByAppointment)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if a.IncludedLocationResources == nil {
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if a.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*a.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResources))
-	} else if len(*a.IncludedLocationResources) == 1 {
-		location = &(*a.IncludedLocationResources)[0]
+	} else if len(*a.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*a.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*a.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*a.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (a *AppointmentResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if a.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *a.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if a.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *a.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if a.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *a.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if a.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *a.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if a.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *a.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *a.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *a.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if a.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *a.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if a.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *a.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if a.IncludedActorPractitionerResources != nil {
-		for _, r := range *a.IncludedActorPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorDeviceResources != nil {
-		for _, r := range *a.IncludedActorDeviceResources {
+	if a.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorPatientResources != nil {
-		for _, r := range *a.IncludedActorPatientResources {
+	if a.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorHealthcareServiceResources != nil {
-		for _, r := range *a.IncludedActorHealthcareServiceResources {
+	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorRelatedPersonResources != nil {
-		for _, r := range *a.IncludedActorRelatedPersonResources {
+	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedActorLocationResources != nil {
-		for _, r := range *a.IncludedActorLocationResources {
+	if a.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPractitionerResources != nil {
-		for _, r := range *a.IncludedPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientResources != nil {
-		for _, r := range *a.IncludedPatientResources {
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedAppointmentResources != nil {
-		for _, r := range *a.IncludedAppointmentResources {
+	if a.IncludedAppointmentResourcesReferencedByAppointment != nil {
+		for _, r := range *a.IncludedAppointmentResourcesReferencedByAppointment {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedLocationResources != nil {
-		for _, r := range *a.IncludedLocationResources {
+	if a.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AppointmentResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedAppointmentResourcesReferencedByAppointment != nil {
+		for _, r := range *a.IncludedAppointmentResourcesReferencedByAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/auditevent.go
+++ b/models/auditevent.go
@@ -136,131 +136,496 @@ type AuditEventObjectDetailComponent struct {
 }
 
 type AuditEventPlus struct {
-	AuditEvent             `bson:",inline"`
-	AuditEventPlusIncludes `bson:",inline"`
+	AuditEvent                     `bson:",inline"`
+	AuditEventPlusRelatedResources `bson:",inline"`
 }
 
-type AuditEventPlusIncludes struct {
-	IncludedParticipantPractitionerResources  *[]Practitioner  `bson:"_includedParticipantPractitionerResources,omitempty"`
-	IncludedParticipantOrganizationResources  *[]Organization  `bson:"_includedParticipantOrganizationResources,omitempty"`
-	IncludedParticipantDeviceResources        *[]Device        `bson:"_includedParticipantDeviceResources,omitempty"`
-	IncludedParticipantPatientResources       *[]Patient       `bson:"_includedParticipantPatientResources,omitempty"`
-	IncludedParticipantRelatedPersonResources *[]RelatedPerson `bson:"_includedParticipantRelatedPersonResources,omitempty"`
-	IncludedPatientPath1Resources             *[]Patient       `bson:"_includedPatientPath1Resources,omitempty"`
-	IncludedPatientPath2Resources             *[]Patient       `bson:"_includedPatientPath2Resources,omitempty"`
+type AuditEventPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByParticipant        *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByParticipant,omitempty"`
+	IncludedOrganizationResourcesReferencedByParticipant        *[]Organization          `bson:"_includedOrganizationResourcesReferencedByParticipant,omitempty"`
+	IncludedDeviceResourcesReferencedByParticipant              *[]Device                `bson:"_includedDeviceResourcesReferencedByParticipant,omitempty"`
+	IncludedPatientResourcesReferencedByParticipant             *[]Patient               `bson:"_includedPatientResourcesReferencedByParticipant,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByParticipant       *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByParticipant,omitempty"`
+	IncludedPatientResourcesReferencedByPatientPath1            *[]Patient               `bson:"_includedPatientResourcesReferencedByPatientPath1,omitempty"`
+	IncludedPatientResourcesReferencedByPatientPath2            *[]Patient               `bson:"_includedPatientResourcesReferencedByPatientPath2,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
-	if a.IncludedParticipantPractitionerResources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedPractitionerResourceReferencedByParticipant() (practitioner *Practitioner, err error) {
+	if a.IncludedPractitionerResourcesReferencedByParticipant == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*a.IncludedParticipantPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedParticipantPractitionerResources))
-	} else if len(*a.IncludedParticipantPractitionerResources) == 1 {
-		practitioner = &(*a.IncludedParticipantPractitionerResources)[0]
+	} else if len(*a.IncludedPractitionerResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*a.IncludedPractitionerResourcesReferencedByParticipant))
+	} else if len(*a.IncludedPractitionerResourcesReferencedByParticipant) == 1 {
+		practitioner = &(*a.IncludedPractitionerResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedParticipantOrganizationResource() (organization *Organization, err error) {
-	if a.IncludedParticipantOrganizationResources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedOrganizationResourceReferencedByParticipant() (organization *Organization, err error) {
+	if a.IncludedOrganizationResourcesReferencedByParticipant == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*a.IncludedParticipantOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedParticipantOrganizationResources))
-	} else if len(*a.IncludedParticipantOrganizationResources) == 1 {
-		organization = &(*a.IncludedParticipantOrganizationResources)[0]
+	} else if len(*a.IncludedOrganizationResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*a.IncludedOrganizationResourcesReferencedByParticipant))
+	} else if len(*a.IncludedOrganizationResourcesReferencedByParticipant) == 1 {
+		organization = &(*a.IncludedOrganizationResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedParticipantDeviceResource() (device *Device, err error) {
-	if a.IncludedParticipantDeviceResources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedDeviceResourceReferencedByParticipant() (device *Device, err error) {
+	if a.IncludedDeviceResourcesReferencedByParticipant == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*a.IncludedParticipantDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedParticipantDeviceResources))
-	} else if len(*a.IncludedParticipantDeviceResources) == 1 {
-		device = &(*a.IncludedParticipantDeviceResources)[0]
+	} else if len(*a.IncludedDeviceResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*a.IncludedDeviceResourcesReferencedByParticipant))
+	} else if len(*a.IncludedDeviceResourcesReferencedByParticipant) == 1 {
+		device = &(*a.IncludedDeviceResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedParticipantPatientResource() (patient *Patient, err error) {
-	if a.IncludedParticipantPatientResources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedPatientResourceReferencedByParticipant() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByParticipant == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedParticipantPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedParticipantPatientResources))
-	} else if len(*a.IncludedParticipantPatientResources) == 1 {
-		patient = &(*a.IncludedParticipantPatientResources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByParticipant))
+	} else if len(*a.IncludedPatientResourcesReferencedByParticipant) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if a.IncludedParticipantRelatedPersonResources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByParticipant() (relatedPerson *RelatedPerson, err error) {
+	if a.IncludedRelatedPersonResourcesReferencedByParticipant == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*a.IncludedParticipantRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedParticipantRelatedPersonResources))
-	} else if len(*a.IncludedParticipantRelatedPersonResources) == 1 {
-		relatedPerson = &(*a.IncludedParticipantRelatedPersonResources)[0]
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*a.IncludedRelatedPersonResourcesReferencedByParticipant))
+	} else if len(*a.IncludedRelatedPersonResourcesReferencedByParticipant) == 1 {
+		relatedPerson = &(*a.IncludedRelatedPersonResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedPatientPath1Resource() (patient *Patient, err error) {
-	if a.IncludedPatientPath1Resources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedPatientResourceReferencedByPatientPath1() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatientPath1 == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientPath1Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientPath1Resources))
-	} else if len(*a.IncludedPatientPath1Resources) == 1 {
-		patient = &(*a.IncludedPatientPath1Resources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatientPath1) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatientPath1))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatientPath1) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatientPath1)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedPatientPath2Resource() (patient *Patient, err error) {
-	if a.IncludedPatientPath2Resources == nil {
+func (a *AuditEventPlusRelatedResources) GetIncludedPatientResourceReferencedByPatientPath2() (patient *Patient, err error) {
+	if a.IncludedPatientResourcesReferencedByPatientPath2 == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*a.IncludedPatientPath2Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientPath2Resources))
-	} else if len(*a.IncludedPatientPath2Resources) == 1 {
-		patient = &(*a.IncludedPatientPath2Resources)[0]
+	} else if len(*a.IncludedPatientResourcesReferencedByPatientPath2) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*a.IncludedPatientResourcesReferencedByPatientPath2))
+	} else if len(*a.IncludedPatientResourcesReferencedByPatientPath2) == 1 {
+		patient = &(*a.IncludedPatientResourcesReferencedByPatientPath2)[0]
 	}
 	return
 }
 
-func (a *AuditEventPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (a *AuditEventPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if a.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *a.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *a.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if a.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *a.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if a.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *a.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if a.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *a.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if a.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *a.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if a.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *a.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *a.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *a.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if a.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *a.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *a.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if a.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *a.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (a *AuditEventPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if a.IncludedParticipantPractitionerResources != nil {
-		for _, r := range *a.IncludedParticipantPractitionerResources {
+	if a.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedParticipantOrganizationResources != nil {
-		for _, r := range *a.IncludedParticipantOrganizationResources {
+	if a.IncludedOrganizationResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedParticipantDeviceResources != nil {
-		for _, r := range *a.IncludedParticipantDeviceResources {
+	if a.IncludedDeviceResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedParticipantPatientResources != nil {
-		for _, r := range *a.IncludedParticipantPatientResources {
+	if a.IncludedPatientResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedParticipantRelatedPersonResources != nil {
-		for _, r := range *a.IncludedParticipantRelatedPersonResources {
+	if a.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientPath1Resources != nil {
-		for _, r := range *a.IncludedPatientPath1Resources {
+	if a.IncludedPatientResourcesReferencedByPatientPath1 != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if a.IncludedPatientPath2Resources != nil {
-		for _, r := range *a.IncludedPatientPath2Resources {
+	if a.IncludedPatientResourcesReferencedByPatientPath2 != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AuditEventPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (a *AuditEventPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if a.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedPractitionerResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedOrganizationResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedOrganizationResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedDeviceResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedDeviceResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatientPath1 != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.IncludedPatientResourcesReferencedByPatientPath2 != nil {
+		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *a.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/basic.go
+++ b/models/basic.go
@@ -84,80 +84,430 @@ func (x *Basic) checkResourceType() error {
 }
 
 type BasicPlus struct {
-	Basic             `bson:",inline"`
-	BasicPlusIncludes `bson:",inline"`
+	Basic                     `bson:",inline"`
+	BasicPlusRelatedResources `bson:",inline"`
 }
 
-type BasicPlusIncludes struct {
-	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
+type BasicPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (b *BasicPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if b.IncludedPatientResources == nil {
+func (b *BasicPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if b.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*b.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResources))
-	} else if len(*b.IncludedPatientResources) == 1 {
-		patient = &(*b.IncludedPatientResources)[0]
+	} else if len(*b.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*b.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*b.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (b *BasicPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
-	if b.IncludedAuthorPractitionerResources == nil {
+func (b *BasicPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if b.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*b.IncludedAuthorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*b.IncludedAuthorPractitionerResources))
-	} else if len(*b.IncludedAuthorPractitionerResources) == 1 {
-		practitioner = &(*b.IncludedAuthorPractitionerResources)[0]
+	} else if len(*b.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*b.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*b.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*b.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (b *BasicPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
-	if b.IncludedAuthorPatientResources == nil {
+func (b *BasicPlusRelatedResources) GetIncludedPatientResourceReferencedByAuthor() (patient *Patient, err error) {
+	if b.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*b.IncludedAuthorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedAuthorPatientResources))
-	} else if len(*b.IncludedAuthorPatientResources) == 1 {
-		patient = &(*b.IncludedAuthorPatientResources)[0]
+	} else if len(*b.IncludedPatientResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResourcesReferencedByAuthor))
+	} else if len(*b.IncludedPatientResourcesReferencedByAuthor) == 1 {
+		patient = &(*b.IncludedPatientResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (b *BasicPlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if b.IncludedAuthorRelatedPersonResources == nil {
+func (b *BasicPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByAuthor() (relatedPerson *RelatedPerson, err error) {
+	if b.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*b.IncludedAuthorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*b.IncludedAuthorRelatedPersonResources))
-	} else if len(*b.IncludedAuthorRelatedPersonResources) == 1 {
-		relatedPerson = &(*b.IncludedAuthorRelatedPersonResources)[0]
+	} else if len(*b.IncludedRelatedPersonResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*b.IncludedRelatedPersonResourcesReferencedByAuthor))
+	} else if len(*b.IncludedRelatedPersonResourcesReferencedByAuthor) == 1 {
+		relatedPerson = &(*b.IncludedRelatedPersonResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (b *BasicPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (b *BasicPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if b.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *b.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if b.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *b.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if b.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *b.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if b.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *b.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if b.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *b.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *b.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *b.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if b.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *b.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *b.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if b.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *b.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (b *BasicPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if b.IncludedPatientResources != nil {
-		for _, r := range *b.IncludedPatientResources {
+	if b.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if b.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *b.IncludedAuthorPractitionerResources {
+	if b.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if b.IncludedAuthorPatientResources != nil {
-		for _, r := range *b.IncludedAuthorPatientResources {
+	if b.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if b.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *b.IncludedAuthorRelatedPersonResources {
+	if b.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BasicPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BasicPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/binary.go
+++ b/models/binary.go
@@ -76,14 +76,344 @@ func (x *Binary) checkResourceType() error {
 }
 
 type BinaryPlus struct {
-	Binary             `bson:",inline"`
-	BinaryPlusIncludes `bson:",inline"`
+	Binary                     `bson:",inline"`
+	BinaryPlusRelatedResources `bson:",inline"`
 }
 
-type BinaryPlusIncludes struct {
+type BinaryPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (b *BinaryPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (b *BinaryPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if b.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *b.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if b.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *b.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if b.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *b.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if b.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *b.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if b.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *b.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *b.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *b.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if b.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *b.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *b.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if b.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *b.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (b *BinaryPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (b *BinaryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BinaryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/bodysite.go
+++ b/models/bodysite.go
@@ -85,29 +85,364 @@ func (x *BodySite) checkResourceType() error {
 }
 
 type BodySitePlus struct {
-	BodySite             `bson:",inline"`
-	BodySitePlusIncludes `bson:",inline"`
+	BodySite                     `bson:",inline"`
+	BodySitePlusRelatedResources `bson:",inline"`
 }
 
-type BodySitePlusIncludes struct {
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+type BodySitePlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (b *BodySitePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if b.IncludedPatientResources == nil {
+func (b *BodySitePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if b.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*b.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResources))
-	} else if len(*b.IncludedPatientResources) == 1 {
-		patient = &(*b.IncludedPatientResources)[0]
+	} else if len(*b.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*b.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*b.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*b.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (b *BodySitePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (b *BodySitePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if b.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *b.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if b.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *b.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if b.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *b.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if b.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *b.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if b.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *b.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *b.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *b.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if b.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *b.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *b.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if b.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *b.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (b *BodySitePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if b.IncludedPatientResources != nil {
-		for _, r := range *b.IncludedPatientResources {
+	if b.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BodySitePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BodySitePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/bundle.go
+++ b/models/bundle.go
@@ -129,46 +129,386 @@ type BundleEntryResponseComponent struct {
 }
 
 type BundlePlus struct {
-	Bundle             `bson:",inline"`
-	BundlePlusIncludes `bson:",inline"`
+	Bundle                     `bson:",inline"`
+	BundlePlusRelatedResources `bson:",inline"`
 }
 
-type BundlePlusIncludes struct {
-	IncludedCompositionResources *[]Composition   `bson:"_includedCompositionResources,omitempty"`
-	IncludedMessageResources     *[]MessageHeader `bson:"_includedMessageResources,omitempty"`
+type BundlePlusRelatedResources struct {
+	IncludedCompositionResourcesReferencedByComposition         *[]Composition           `bson:"_includedCompositionResourcesReferencedByComposition,omitempty"`
+	IncludedMessageHeaderResourcesReferencedByMessage           *[]MessageHeader         `bson:"_includedMessageHeaderResourcesReferencedByMessage,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (b *BundlePlusIncludes) GetIncludedCompositionResource() (composition *Composition, err error) {
-	if b.IncludedCompositionResources == nil {
+func (b *BundlePlusRelatedResources) GetIncludedCompositionResourceReferencedByComposition() (composition *Composition, err error) {
+	if b.IncludedCompositionResourcesReferencedByComposition == nil {
 		err = errors.New("Included compositions not requested")
-	} else if len(*b.IncludedCompositionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 composition, but found %d", len(*b.IncludedCompositionResources))
-	} else if len(*b.IncludedCompositionResources) == 1 {
-		composition = &(*b.IncludedCompositionResources)[0]
+	} else if len(*b.IncludedCompositionResourcesReferencedByComposition) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 composition, but found %d", len(*b.IncludedCompositionResourcesReferencedByComposition))
+	} else if len(*b.IncludedCompositionResourcesReferencedByComposition) == 1 {
+		composition = &(*b.IncludedCompositionResourcesReferencedByComposition)[0]
 	}
 	return
 }
 
-func (b *BundlePlusIncludes) GetIncludedMessageResource() (messageHeader *MessageHeader, err error) {
-	if b.IncludedMessageResources == nil {
+func (b *BundlePlusRelatedResources) GetIncludedMessageHeaderResourceReferencedByMessage() (messageHeader *MessageHeader, err error) {
+	if b.IncludedMessageHeaderResourcesReferencedByMessage == nil {
 		err = errors.New("Included messageheaders not requested")
-	} else if len(*b.IncludedMessageResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 messageHeader, but found %d", len(*b.IncludedMessageResources))
-	} else if len(*b.IncludedMessageResources) == 1 {
-		messageHeader = &(*b.IncludedMessageResources)[0]
+	} else if len(*b.IncludedMessageHeaderResourcesReferencedByMessage) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 messageHeader, but found %d", len(*b.IncludedMessageHeaderResourcesReferencedByMessage))
+	} else if len(*b.IncludedMessageHeaderResourcesReferencedByMessage) == 1 {
+		messageHeader = &(*b.IncludedMessageHeaderResourcesReferencedByMessage)[0]
 	}
 	return
 }
 
-func (b *BundlePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (b *BundlePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if b.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *b.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *b.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if b.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *b.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if b.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *b.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if b.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *b.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if b.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *b.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if b.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *b.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *b.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *b.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if b.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *b.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *b.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if b.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *b.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (b *BundlePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if b.IncludedCompositionResources != nil {
-		for _, r := range *b.IncludedCompositionResources {
+	if b.IncludedCompositionResourcesReferencedByComposition != nil {
+		for _, r := range *b.IncludedCompositionResourcesReferencedByComposition {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if b.IncludedMessageResources != nil {
-		for _, r := range *b.IncludedMessageResources {
+	if b.IncludedMessageHeaderResourcesReferencedByMessage != nil {
+		for _, r := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BundlePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (b *BundlePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if b.IncludedCompositionResourcesReferencedByComposition != nil {
+		for _, r := range *b.IncludedCompositionResourcesReferencedByComposition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.IncludedMessageHeaderResourcesReferencedByMessage != nil {
+		for _, r := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *b.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/careplan.go
+++ b/models/careplan.go
@@ -133,442 +133,942 @@ type CarePlanActivityDetailComponent struct {
 }
 
 type CarePlanPlus struct {
-	CarePlan             `bson:",inline"`
-	CarePlanPlusIncludes `bson:",inline"`
+	CarePlan                     `bson:",inline"`
+	CarePlanPlusRelatedResources `bson:",inline"`
 }
 
-type CarePlanPlusIncludes struct {
-	IncludedActivityreferenceAppointmentResources          *[]Appointment          `bson:"_includedActivityreferenceAppointmentResources,omitempty"`
-	IncludedActivityreferenceOrderResources                *[]Order                `bson:"_includedActivityreferenceOrderResources,omitempty"`
-	IncludedActivityreferenceReferralRequestResources      *[]ReferralRequest      `bson:"_includedActivityreferenceReferralRequestResources,omitempty"`
-	IncludedActivityreferenceProcessRequestResources       *[]ProcessRequest       `bson:"_includedActivityreferenceProcessRequestResources,omitempty"`
-	IncludedActivityreferenceNutritionOrderResources       *[]NutritionOrder       `bson:"_includedActivityreferenceNutritionOrderResources,omitempty"`
-	IncludedActivityreferenceVisionPrescriptionResources   *[]VisionPrescription   `bson:"_includedActivityreferenceVisionPrescriptionResources,omitempty"`
-	IncludedActivityreferenceDiagnosticOrderResources      *[]DiagnosticOrder      `bson:"_includedActivityreferenceDiagnosticOrderResources,omitempty"`
-	IncludedActivityreferenceProcedureRequestResources     *[]ProcedureRequest     `bson:"_includedActivityreferenceProcedureRequestResources,omitempty"`
-	IncludedActivityreferenceDeviceUseRequestResources     *[]DeviceUseRequest     `bson:"_includedActivityreferenceDeviceUseRequestResources,omitempty"`
-	IncludedActivityreferenceMedicationOrderResources      *[]MedicationOrder      `bson:"_includedActivityreferenceMedicationOrderResources,omitempty"`
-	IncludedActivityreferenceCommunicationRequestResources *[]CommunicationRequest `bson:"_includedActivityreferenceCommunicationRequestResources,omitempty"`
-	IncludedActivityreferenceSupplyRequestResources        *[]SupplyRequest        `bson:"_includedActivityreferenceSupplyRequestResources,omitempty"`
-	IncludedPerformerPractitionerResources                 *[]Practitioner         `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerOrganizationResources                 *[]Organization         `bson:"_includedPerformerOrganizationResources,omitempty"`
-	IncludedPerformerPatientResources                      *[]Patient              `bson:"_includedPerformerPatientResources,omitempty"`
-	IncludedPerformerRelatedPersonResources                *[]RelatedPerson        `bson:"_includedPerformerRelatedPersonResources,omitempty"`
-	IncludedGoalResources                                  *[]Goal                 `bson:"_includedGoalResources,omitempty"`
-	IncludedSubjectGroupResources                          *[]Group                `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectPatientResources                        *[]Patient              `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedParticipantPractitionerResources               *[]Practitioner         `bson:"_includedParticipantPractitionerResources,omitempty"`
-	IncludedParticipantOrganizationResources               *[]Organization         `bson:"_includedParticipantOrganizationResources,omitempty"`
-	IncludedParticipantPatientResources                    *[]Patient              `bson:"_includedParticipantPatientResources,omitempty"`
-	IncludedParticipantRelatedPersonResources              *[]RelatedPerson        `bson:"_includedParticipantRelatedPersonResources,omitempty"`
-	IncludedRelatedplanResources                           *[]CarePlan             `bson:"_includedRelatedplanResources,omitempty"`
-	IncludedConditionResources                             *[]Condition            `bson:"_includedConditionResources,omitempty"`
-	IncludedPatientResources                               *[]Patient              `bson:"_includedPatientResources,omitempty"`
+type CarePlanPlusRelatedResources struct {
+	IncludedAppointmentResourcesReferencedByActivityreference          *[]Appointment           `bson:"_includedAppointmentResourcesReferencedByActivityreference,omitempty"`
+	IncludedOrderResourcesReferencedByActivityreference                *[]Order                 `bson:"_includedOrderResourcesReferencedByActivityreference,omitempty"`
+	IncludedReferralRequestResourcesReferencedByActivityreference      *[]ReferralRequest       `bson:"_includedReferralRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedProcessRequestResourcesReferencedByActivityreference       *[]ProcessRequest        `bson:"_includedProcessRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedNutritionOrderResourcesReferencedByActivityreference       *[]NutritionOrder        `bson:"_includedNutritionOrderResourcesReferencedByActivityreference,omitempty"`
+	IncludedVisionPrescriptionResourcesReferencedByActivityreference   *[]VisionPrescription    `bson:"_includedVisionPrescriptionResourcesReferencedByActivityreference,omitempty"`
+	IncludedDiagnosticOrderResourcesReferencedByActivityreference      *[]DiagnosticOrder       `bson:"_includedDiagnosticOrderResourcesReferencedByActivityreference,omitempty"`
+	IncludedProcedureRequestResourcesReferencedByActivityreference     *[]ProcedureRequest      `bson:"_includedProcedureRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedDeviceUseRequestResourcesReferencedByActivityreference     *[]DeviceUseRequest      `bson:"_includedDeviceUseRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedMedicationOrderResourcesReferencedByActivityreference      *[]MedicationOrder       `bson:"_includedMedicationOrderResourcesReferencedByActivityreference,omitempty"`
+	IncludedCommunicationRequestResourcesReferencedByActivityreference *[]CommunicationRequest  `bson:"_includedCommunicationRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedSupplyRequestResourcesReferencedByActivityreference        *[]SupplyRequest         `bson:"_includedSupplyRequestResourcesReferencedByActivityreference,omitempty"`
+	IncludedPractitionerResourcesReferencedByPerformer                 *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedOrganizationResourcesReferencedByPerformer                 *[]Organization          `bson:"_includedOrganizationResourcesReferencedByPerformer,omitempty"`
+	IncludedPatientResourcesReferencedByPerformer                      *[]Patient               `bson:"_includedPatientResourcesReferencedByPerformer,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByPerformer                *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByPerformer,omitempty"`
+	IncludedGoalResourcesReferencedByGoal                              *[]Goal                  `bson:"_includedGoalResourcesReferencedByGoal,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                          *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                        *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPractitionerResourcesReferencedByParticipant               *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByParticipant,omitempty"`
+	IncludedOrganizationResourcesReferencedByParticipant               *[]Organization          `bson:"_includedOrganizationResourcesReferencedByParticipant,omitempty"`
+	IncludedPatientResourcesReferencedByParticipant                    *[]Patient               `bson:"_includedPatientResourcesReferencedByParticipant,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByParticipant              *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByParticipant,omitempty"`
+	IncludedCarePlanResourcesReferencedByRelatedplan                   *[]CarePlan              `bson:"_includedCarePlanResourcesReferencedByRelatedplan,omitempty"`
+	IncludedConditionResourcesReferencedByCondition                    *[]Condition             `bson:"_includedConditionResourcesReferencedByCondition,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                        *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                    *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref          *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref          *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingRelatedplan                 *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingRelatedplan,omitempty"`
+	RevIncludedListResourcesReferencingItem                            *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref         *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                         *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                        *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                 *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                  *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                    *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated             *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment            *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject        *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest              *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger           *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan              *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                   *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceAppointmentResource() (appointment *Appointment, err error) {
-	if c.IncludedActivityreferenceAppointmentResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedAppointmentResourceReferencedByActivityreference() (appointment *Appointment, err error) {
+	if c.IncludedAppointmentResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included appointments not requested")
-	} else if len(*c.IncludedActivityreferenceAppointmentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*c.IncludedActivityreferenceAppointmentResources))
-	} else if len(*c.IncludedActivityreferenceAppointmentResources) == 1 {
-		appointment = &(*c.IncludedActivityreferenceAppointmentResources)[0]
+	} else if len(*c.IncludedAppointmentResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*c.IncludedAppointmentResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedAppointmentResourcesReferencedByActivityreference) == 1 {
+		appointment = &(*c.IncludedAppointmentResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceOrderResource() (order *Order, err error) {
-	if c.IncludedActivityreferenceOrderResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedOrderResourceReferencedByActivityreference() (order *Order, err error) {
+	if c.IncludedOrderResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included orders not requested")
-	} else if len(*c.IncludedActivityreferenceOrderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*c.IncludedActivityreferenceOrderResources))
-	} else if len(*c.IncludedActivityreferenceOrderResources) == 1 {
-		order = &(*c.IncludedActivityreferenceOrderResources)[0]
+	} else if len(*c.IncludedOrderResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*c.IncludedOrderResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedOrderResourcesReferencedByActivityreference) == 1 {
+		order = &(*c.IncludedOrderResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceReferralRequestResource() (referralRequest *ReferralRequest, err error) {
-	if c.IncludedActivityreferenceReferralRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedReferralRequestResourceReferencedByActivityreference() (referralRequest *ReferralRequest, err error) {
+	if c.IncludedReferralRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included referralrequests not requested")
-	} else if len(*c.IncludedActivityreferenceReferralRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 referralRequest, but found %d", len(*c.IncludedActivityreferenceReferralRequestResources))
-	} else if len(*c.IncludedActivityreferenceReferralRequestResources) == 1 {
-		referralRequest = &(*c.IncludedActivityreferenceReferralRequestResources)[0]
+	} else if len(*c.IncludedReferralRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 referralRequest, but found %d", len(*c.IncludedReferralRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedReferralRequestResourcesReferencedByActivityreference) == 1 {
+		referralRequest = &(*c.IncludedReferralRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceProcessRequestResource() (processRequest *ProcessRequest, err error) {
-	if c.IncludedActivityreferenceProcessRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedProcessRequestResourceReferencedByActivityreference() (processRequest *ProcessRequest, err error) {
+	if c.IncludedProcessRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included processrequests not requested")
-	} else if len(*c.IncludedActivityreferenceProcessRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 processRequest, but found %d", len(*c.IncludedActivityreferenceProcessRequestResources))
-	} else if len(*c.IncludedActivityreferenceProcessRequestResources) == 1 {
-		processRequest = &(*c.IncludedActivityreferenceProcessRequestResources)[0]
+	} else if len(*c.IncludedProcessRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 processRequest, but found %d", len(*c.IncludedProcessRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedProcessRequestResourcesReferencedByActivityreference) == 1 {
+		processRequest = &(*c.IncludedProcessRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceNutritionOrderResource() (nutritionOrder *NutritionOrder, err error) {
-	if c.IncludedActivityreferenceNutritionOrderResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedNutritionOrderResourceReferencedByActivityreference() (nutritionOrder *NutritionOrder, err error) {
+	if c.IncludedNutritionOrderResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included nutritionorders not requested")
-	} else if len(*c.IncludedActivityreferenceNutritionOrderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 nutritionOrder, but found %d", len(*c.IncludedActivityreferenceNutritionOrderResources))
-	} else if len(*c.IncludedActivityreferenceNutritionOrderResources) == 1 {
-		nutritionOrder = &(*c.IncludedActivityreferenceNutritionOrderResources)[0]
+	} else if len(*c.IncludedNutritionOrderResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 nutritionOrder, but found %d", len(*c.IncludedNutritionOrderResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedNutritionOrderResourcesReferencedByActivityreference) == 1 {
+		nutritionOrder = &(*c.IncludedNutritionOrderResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceVisionPrescriptionResource() (visionPrescription *VisionPrescription, err error) {
-	if c.IncludedActivityreferenceVisionPrescriptionResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedVisionPrescriptionResourceReferencedByActivityreference() (visionPrescription *VisionPrescription, err error) {
+	if c.IncludedVisionPrescriptionResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included visionprescriptions not requested")
-	} else if len(*c.IncludedActivityreferenceVisionPrescriptionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 visionPrescription, but found %d", len(*c.IncludedActivityreferenceVisionPrescriptionResources))
-	} else if len(*c.IncludedActivityreferenceVisionPrescriptionResources) == 1 {
-		visionPrescription = &(*c.IncludedActivityreferenceVisionPrescriptionResources)[0]
+	} else if len(*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 visionPrescription, but found %d", len(*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference) == 1 {
+		visionPrescription = &(*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceDiagnosticOrderResource() (diagnosticOrder *DiagnosticOrder, err error) {
-	if c.IncludedActivityreferenceDiagnosticOrderResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedDiagnosticOrderResourceReferencedByActivityreference() (diagnosticOrder *DiagnosticOrder, err error) {
+	if c.IncludedDiagnosticOrderResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included diagnosticorders not requested")
-	} else if len(*c.IncludedActivityreferenceDiagnosticOrderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 diagnosticOrder, but found %d", len(*c.IncludedActivityreferenceDiagnosticOrderResources))
-	} else if len(*c.IncludedActivityreferenceDiagnosticOrderResources) == 1 {
-		diagnosticOrder = &(*c.IncludedActivityreferenceDiagnosticOrderResources)[0]
+	} else if len(*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 diagnosticOrder, but found %d", len(*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference) == 1 {
+		diagnosticOrder = &(*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceProcedureRequestResource() (procedureRequest *ProcedureRequest, err error) {
-	if c.IncludedActivityreferenceProcedureRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedProcedureRequestResourceReferencedByActivityreference() (procedureRequest *ProcedureRequest, err error) {
+	if c.IncludedProcedureRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included procedurerequests not requested")
-	} else if len(*c.IncludedActivityreferenceProcedureRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 procedureRequest, but found %d", len(*c.IncludedActivityreferenceProcedureRequestResources))
-	} else if len(*c.IncludedActivityreferenceProcedureRequestResources) == 1 {
-		procedureRequest = &(*c.IncludedActivityreferenceProcedureRequestResources)[0]
+	} else if len(*c.IncludedProcedureRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 procedureRequest, but found %d", len(*c.IncludedProcedureRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedProcedureRequestResourcesReferencedByActivityreference) == 1 {
+		procedureRequest = &(*c.IncludedProcedureRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceDeviceUseRequestResource() (deviceUseRequest *DeviceUseRequest, err error) {
-	if c.IncludedActivityreferenceDeviceUseRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedDeviceUseRequestResourceReferencedByActivityreference() (deviceUseRequest *DeviceUseRequest, err error) {
+	if c.IncludedDeviceUseRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included deviceuserequests not requested")
-	} else if len(*c.IncludedActivityreferenceDeviceUseRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 deviceUseRequest, but found %d", len(*c.IncludedActivityreferenceDeviceUseRequestResources))
-	} else if len(*c.IncludedActivityreferenceDeviceUseRequestResources) == 1 {
-		deviceUseRequest = &(*c.IncludedActivityreferenceDeviceUseRequestResources)[0]
+	} else if len(*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceUseRequest, but found %d", len(*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference) == 1 {
+		deviceUseRequest = &(*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceMedicationOrderResource() (medicationOrder *MedicationOrder, err error) {
-	if c.IncludedActivityreferenceMedicationOrderResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedMedicationOrderResourceReferencedByActivityreference() (medicationOrder *MedicationOrder, err error) {
+	if c.IncludedMedicationOrderResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included medicationorders not requested")
-	} else if len(*c.IncludedActivityreferenceMedicationOrderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*c.IncludedActivityreferenceMedicationOrderResources))
-	} else if len(*c.IncludedActivityreferenceMedicationOrderResources) == 1 {
-		medicationOrder = &(*c.IncludedActivityreferenceMedicationOrderResources)[0]
+	} else if len(*c.IncludedMedicationOrderResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*c.IncludedMedicationOrderResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedMedicationOrderResourcesReferencedByActivityreference) == 1 {
+		medicationOrder = &(*c.IncludedMedicationOrderResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceCommunicationRequestResource() (communicationRequest *CommunicationRequest, err error) {
-	if c.IncludedActivityreferenceCommunicationRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedCommunicationRequestResourceReferencedByActivityreference() (communicationRequest *CommunicationRequest, err error) {
+	if c.IncludedCommunicationRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included communicationrequests not requested")
-	} else if len(*c.IncludedActivityreferenceCommunicationRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedActivityreferenceCommunicationRequestResources))
-	} else if len(*c.IncludedActivityreferenceCommunicationRequestResources) == 1 {
-		communicationRequest = &(*c.IncludedActivityreferenceCommunicationRequestResources)[0]
+	} else if len(*c.IncludedCommunicationRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedCommunicationRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedCommunicationRequestResourcesReferencedByActivityreference) == 1 {
+		communicationRequest = &(*c.IncludedCommunicationRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedActivityreferenceSupplyRequestResource() (supplyRequest *SupplyRequest, err error) {
-	if c.IncludedActivityreferenceSupplyRequestResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedSupplyRequestResourceReferencedByActivityreference() (supplyRequest *SupplyRequest, err error) {
+	if c.IncludedSupplyRequestResourcesReferencedByActivityreference == nil {
 		err = errors.New("Included supplyrequests not requested")
-	} else if len(*c.IncludedActivityreferenceSupplyRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 supplyRequest, but found %d", len(*c.IncludedActivityreferenceSupplyRequestResources))
-	} else if len(*c.IncludedActivityreferenceSupplyRequestResources) == 1 {
-		supplyRequest = &(*c.IncludedActivityreferenceSupplyRequestResources)[0]
+	} else if len(*c.IncludedSupplyRequestResourcesReferencedByActivityreference) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 supplyRequest, but found %d", len(*c.IncludedSupplyRequestResourcesReferencedByActivityreference))
+	} else if len(*c.IncludedSupplyRequestResourcesReferencedByActivityreference) == 1 {
+		supplyRequest = &(*c.IncludedSupplyRequestResourcesReferencedByActivityreference)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedPerformerPractitionerResources() (practitioners []Practitioner, err error) {
-	if c.IncludedPerformerPractitionerResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByPerformer() (practitioners []Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *c.IncludedPerformerPractitionerResources
+		practitioners = *c.IncludedPractitionerResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedPerformerOrganizationResources() (organizations []Organization, err error) {
-	if c.IncludedPerformerOrganizationResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByPerformer() (organizations []Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByPerformer == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *c.IncludedPerformerOrganizationResources
+		organizations = *c.IncludedOrganizationResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedPerformerPatientResources() (patients []Patient, err error) {
-	if c.IncludedPerformerPatientResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPatientResourcesReferencedByPerformer() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPerformer == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedPerformerPatientResources
+		patients = *c.IncludedPatientResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedPerformerRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if c.IncludedPerformerRelatedPersonResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByPerformer() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByPerformer == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *c.IncludedPerformerRelatedPersonResources
+		relatedPeople = *c.IncludedRelatedPersonResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedGoalResources() (goals []Goal, err error) {
-	if c.IncludedGoalResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedGoalResourcesReferencedByGoal() (goals []Goal, err error) {
+	if c.IncludedGoalResourcesReferencedByGoal == nil {
 		err = errors.New("Included goals not requested")
 	} else {
-		goals = *c.IncludedGoalResources
+		goals = *c.IncludedGoalResourcesReferencedByGoal
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if c.IncludedSubjectGroupResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if c.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*c.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedSubjectGroupResources))
-	} else if len(*c.IncludedSubjectGroupResources) == 1 {
-		group = &(*c.IncludedSubjectGroupResources)[0]
+	} else if len(*c.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*c.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*c.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if c.IncludedSubjectPatientResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectPatientResources))
-	} else if len(*c.IncludedSubjectPatientResources) == 1 {
-		patient = &(*c.IncludedSubjectPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedParticipantPractitionerResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPractitionerResourceReferencedByParticipant() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByParticipant == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedParticipantPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedParticipantPractitionerResources))
-	} else if len(*c.IncludedParticipantPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedParticipantPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByParticipant))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByParticipant) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedParticipantOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedParticipantOrganizationResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedOrganizationResourceReferencedByParticipant() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByParticipant == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedParticipantOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedParticipantOrganizationResources))
-	} else if len(*c.IncludedParticipantOrganizationResources) == 1 {
-		organization = &(*c.IncludedParticipantOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedByParticipant))
+	} else if len(*c.IncludedOrganizationResourcesReferencedByParticipant) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedParticipantPatientResource() (patient *Patient, err error) {
-	if c.IncludedParticipantPatientResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPatientResourceReferencedByParticipant() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByParticipant == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedParticipantPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedParticipantPatientResources))
-	} else if len(*c.IncludedParticipantPatientResources) == 1 {
-		patient = &(*c.IncludedParticipantPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByParticipant))
+	} else if len(*c.IncludedPatientResourcesReferencedByParticipant) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedParticipantRelatedPersonResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByParticipant() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByParticipant == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedParticipantRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedParticipantRelatedPersonResources))
-	} else if len(*c.IncludedParticipantRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedParticipantRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedByParticipant))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByParticipant) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedRelatedplanResource() (carePlan *CarePlan, err error) {
-	if c.IncludedRelatedplanResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedCarePlanResourceReferencedByRelatedplan() (carePlan *CarePlan, err error) {
+	if c.IncludedCarePlanResourcesReferencedByRelatedplan == nil {
 		err = errors.New("Included careplans not requested")
-	} else if len(*c.IncludedRelatedplanResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 carePlan, but found %d", len(*c.IncludedRelatedplanResources))
-	} else if len(*c.IncludedRelatedplanResources) == 1 {
-		carePlan = &(*c.IncludedRelatedplanResources)[0]
+	} else if len(*c.IncludedCarePlanResourcesReferencedByRelatedplan) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 carePlan, but found %d", len(*c.IncludedCarePlanResourcesReferencedByRelatedplan))
+	} else if len(*c.IncludedCarePlanResourcesReferencedByRelatedplan) == 1 {
+		carePlan = &(*c.IncludedCarePlanResourcesReferencedByRelatedplan)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
-	if c.IncludedConditionResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedConditionResourcesReferencedByCondition() (conditions []Condition, err error) {
+	if c.IncludedConditionResourcesReferencedByCondition == nil {
 		err = errors.New("Included conditions not requested")
 	} else {
-		conditions = *c.IncludedConditionResources
+		conditions = *c.IncludedConditionResourcesReferencedByCondition
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *CarePlanPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *CarePlanPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *CarePlanPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingRelatedplan() (carePlans []CarePlan, err error) {
+	if c.RevIncludedCarePlanResourcesReferencingRelatedplan == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *c.RevIncludedCarePlanResourcesReferencingRelatedplan
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *CarePlanPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedActivityreferenceAppointmentResources != nil {
-		for _, r := range *c.IncludedActivityreferenceAppointmentResources {
+	if c.IncludedAppointmentResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceOrderResources != nil {
-		for _, r := range *c.IncludedActivityreferenceOrderResources {
+	if c.IncludedOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedOrderResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceReferralRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceReferralRequestResources {
+	if c.IncludedReferralRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceProcessRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceProcessRequestResources {
+	if c.IncludedProcessRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceNutritionOrderResources != nil {
-		for _, r := range *c.IncludedActivityreferenceNutritionOrderResources {
+	if c.IncludedNutritionOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceVisionPrescriptionResources != nil {
-		for _, r := range *c.IncludedActivityreferenceVisionPrescriptionResources {
+	if c.IncludedVisionPrescriptionResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceDiagnosticOrderResources != nil {
-		for _, r := range *c.IncludedActivityreferenceDiagnosticOrderResources {
+	if c.IncludedDiagnosticOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceProcedureRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceProcedureRequestResources {
+	if c.IncludedProcedureRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceDeviceUseRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceDeviceUseRequestResources {
+	if c.IncludedDeviceUseRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceMedicationOrderResources != nil {
-		for _, r := range *c.IncludedActivityreferenceMedicationOrderResources {
+	if c.IncludedMedicationOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceCommunicationRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceCommunicationRequestResources {
+	if c.IncludedCommunicationRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActivityreferenceSupplyRequestResources != nil {
-		for _, r := range *c.IncludedActivityreferenceSupplyRequestResources {
+	if c.IncludedSupplyRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *c.IncludedPerformerPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPerformerOrganizationResources != nil {
-		for _, r := range *c.IncludedPerformerOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPerformerPatientResources != nil {
-		for _, r := range *c.IncludedPerformerPatientResources {
+	if c.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPerformerRelatedPersonResources != nil {
-		for _, r := range *c.IncludedPerformerRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedGoalResources != nil {
-		for _, r := range *c.IncludedGoalResources {
+	if c.IncludedGoalResourcesReferencedByGoal != nil {
+		for _, r := range *c.IncludedGoalResourcesReferencedByGoal {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSubjectGroupResources != nil {
-		for _, r := range *c.IncludedSubjectGroupResources {
+	if c.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSubjectPatientResources != nil {
-		for _, r := range *c.IncludedSubjectPatientResources {
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedParticipantPractitionerResources != nil {
-		for _, r := range *c.IncludedParticipantPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedParticipantOrganizationResources != nil {
-		for _, r := range *c.IncludedParticipantOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedParticipantPatientResources != nil {
-		for _, r := range *c.IncludedParticipantPatientResources {
+	if c.IncludedPatientResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedParticipantRelatedPersonResources != nil {
-		for _, r := range *c.IncludedParticipantRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRelatedplanResources != nil {
-		for _, r := range *c.IncludedRelatedplanResources {
+	if c.IncludedCarePlanResourcesReferencedByRelatedplan != nil {
+		for _, r := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedConditionResources != nil {
-		for _, r := range *c.IncludedConditionResources {
+	if c.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *c.IncludedConditionResourcesReferencedByCondition {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CarePlanPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingRelatedplan != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CarePlanPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedAppointmentResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedOrderResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedReferralRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcessRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedNutritionOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedVisionPrescriptionResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDiagnosticOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcedureRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceUseRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedMedicationOrderResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedCommunicationRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSupplyRequestResourcesReferencedByActivityreference != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedGoalResourcesReferencedByGoal != nil {
+		for _, r := range *c.IncludedGoalResourcesReferencedByGoal {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedCarePlanResourcesReferencedByRelatedplan != nil {
+		for _, r := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *c.IncludedConditionResourcesReferencedByCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingRelatedplan != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/claim.go
+++ b/models/claim.go
@@ -188,46 +188,386 @@ type ClaimMissingTeethComponent struct {
 }
 
 type ClaimPlus struct {
-	Claim             `bson:",inline"`
-	ClaimPlusIncludes `bson:",inline"`
+	Claim                     `bson:",inline"`
+	ClaimPlusRelatedResources `bson:",inline"`
 }
 
-type ClaimPlusIncludes struct {
-	IncludedProviderResources *[]Practitioner `bson:"_includedProviderResources,omitempty"`
-	IncludedPatientResources  *[]Patient      `bson:"_includedPatientResources,omitempty"`
+type ClaimPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByProvider           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByProvider,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ClaimPlusIncludes) GetIncludedProviderResource() (practitioner *Practitioner, err error) {
-	if c.IncludedProviderResources == nil {
+func (c *ClaimPlusRelatedResources) GetIncludedPractitionerResourceReferencedByProvider() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByProvider == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedProviderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedProviderResources))
-	} else if len(*c.IncludedProviderResources) == 1 {
-		practitioner = &(*c.IncludedProviderResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByProvider) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByProvider))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByProvider) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByProvider)[0]
 	}
 	return
 }
 
-func (c *ClaimPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *ClaimPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *ClaimPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ClaimPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ClaimPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedProviderResources != nil {
-		for _, r := range *c.IncludedProviderResources {
+	if c.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByProvider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ClaimPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ClaimPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -192,14 +192,344 @@ type ClaimResponseCoverageComponent struct {
 }
 
 type ClaimResponsePlus struct {
-	ClaimResponse             `bson:",inline"`
-	ClaimResponsePlusIncludes `bson:",inline"`
+	ClaimResponse                     `bson:",inline"`
+	ClaimResponsePlusRelatedResources `bson:",inline"`
 }
 
-type ClaimResponsePlusIncludes struct {
+type ClaimResponsePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ClaimResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ClaimResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -112,468 +112,968 @@ type ClinicalImpressionRuledOutComponent struct {
 }
 
 type ClinicalImpressionPlus struct {
-	ClinicalImpression             `bson:",inline"`
-	ClinicalImpressionPlusIncludes `bson:",inline"`
+	ClinicalImpression                     `bson:",inline"`
+	ClinicalImpressionPlusRelatedResources `bson:",inline"`
 }
 
-type ClinicalImpressionPlusIncludes struct {
-	IncludedPreviousResources                           *[]ClinicalImpression    `bson:"_includedPreviousResources,omitempty"`
-	IncludedAssessorResources                           *[]Practitioner          `bson:"_includedAssessorResources,omitempty"`
-	IncludedProblemConditionResources                   *[]Condition             `bson:"_includedProblemConditionResources,omitempty"`
-	IncludedProblemAllergyIntoleranceResources          *[]AllergyIntolerance    `bson:"_includedProblemAllergyIntoleranceResources,omitempty"`
-	IncludedPatientResources                            *[]Patient               `bson:"_includedPatientResources,omitempty"`
-	IncludedInvestigationFamilyMemberHistoryResources   *[]FamilyMemberHistory   `bson:"_includedInvestigationFamilyMemberHistoryResources,omitempty"`
-	IncludedInvestigationObservationResources           *[]Observation           `bson:"_includedInvestigationObservationResources,omitempty"`
-	IncludedInvestigationDiagnosticReportResources      *[]DiagnosticReport      `bson:"_includedInvestigationDiagnosticReportResources,omitempty"`
-	IncludedInvestigationQuestionnaireResponseResources *[]QuestionnaireResponse `bson:"_includedInvestigationQuestionnaireResponseResources,omitempty"`
-	IncludedActionAppointmentResources                  *[]Appointment           `bson:"_includedActionAppointmentResources,omitempty"`
-	IncludedActionReferralRequestResources              *[]ReferralRequest       `bson:"_includedActionReferralRequestResources,omitempty"`
-	IncludedActionNutritionOrderResources               *[]NutritionOrder        `bson:"_includedActionNutritionOrderResources,omitempty"`
-	IncludedActionProcedureRequestResources             *[]ProcedureRequest      `bson:"_includedActionProcedureRequestResources,omitempty"`
-	IncludedActionProcedureResources                    *[]Procedure             `bson:"_includedActionProcedureResources,omitempty"`
-	IncludedActionDiagnosticOrderResources              *[]DiagnosticOrder       `bson:"_includedActionDiagnosticOrderResources,omitempty"`
-	IncludedActionMedicationOrderResources              *[]MedicationOrder       `bson:"_includedActionMedicationOrderResources,omitempty"`
-	IncludedActionSupplyRequestResources                *[]SupplyRequest         `bson:"_includedActionSupplyRequestResources,omitempty"`
-	IncludedPlanAppointmentResources                    *[]Appointment           `bson:"_includedPlanAppointmentResources,omitempty"`
-	IncludedPlanOrderResources                          *[]Order                 `bson:"_includedPlanOrderResources,omitempty"`
-	IncludedPlanReferralRequestResources                *[]ReferralRequest       `bson:"_includedPlanReferralRequestResources,omitempty"`
-	IncludedPlanProcessRequestResources                 *[]ProcessRequest        `bson:"_includedPlanProcessRequestResources,omitempty"`
-	IncludedPlanVisionPrescriptionResources             *[]VisionPrescription    `bson:"_includedPlanVisionPrescriptionResources,omitempty"`
-	IncludedPlanDiagnosticOrderResources                *[]DiagnosticOrder       `bson:"_includedPlanDiagnosticOrderResources,omitempty"`
-	IncludedPlanProcedureRequestResources               *[]ProcedureRequest      `bson:"_includedPlanProcedureRequestResources,omitempty"`
-	IncludedPlanDeviceUseRequestResources               *[]DeviceUseRequest      `bson:"_includedPlanDeviceUseRequestResources,omitempty"`
-	IncludedPlanSupplyRequestResources                  *[]SupplyRequest         `bson:"_includedPlanSupplyRequestResources,omitempty"`
-	IncludedPlanCarePlanResources                       *[]CarePlan              `bson:"_includedPlanCarePlanResources,omitempty"`
-	IncludedPlanNutritionOrderResources                 *[]NutritionOrder        `bson:"_includedPlanNutritionOrderResources,omitempty"`
-	IncludedPlanMedicationOrderResources                *[]MedicationOrder       `bson:"_includedPlanMedicationOrderResources,omitempty"`
-	IncludedPlanCommunicationRequestResources           *[]CommunicationRequest  `bson:"_includedPlanCommunicationRequestResources,omitempty"`
+type ClinicalImpressionPlusRelatedResources struct {
+	IncludedClinicalImpressionResourcesReferencedByPrevious         *[]ClinicalImpression    `bson:"_includedClinicalImpressionResourcesReferencedByPrevious,omitempty"`
+	IncludedPractitionerResourcesReferencedByAssessor               *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAssessor,omitempty"`
+	IncludedConditionResourcesReferencedByProblem                   *[]Condition             `bson:"_includedConditionResourcesReferencedByProblem,omitempty"`
+	IncludedAllergyIntoleranceResourcesReferencedByProblem          *[]AllergyIntolerance    `bson:"_includedAllergyIntoleranceResourcesReferencedByProblem,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                     *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedFamilyMemberHistoryResourcesReferencedByInvestigation   *[]FamilyMemberHistory   `bson:"_includedFamilyMemberHistoryResourcesReferencedByInvestigation,omitempty"`
+	IncludedObservationResourcesReferencedByInvestigation           *[]Observation           `bson:"_includedObservationResourcesReferencedByInvestigation,omitempty"`
+	IncludedDiagnosticReportResourcesReferencedByInvestigation      *[]DiagnosticReport      `bson:"_includedDiagnosticReportResourcesReferencedByInvestigation,omitempty"`
+	IncludedQuestionnaireResponseResourcesReferencedByInvestigation *[]QuestionnaireResponse `bson:"_includedQuestionnaireResponseResourcesReferencedByInvestigation,omitempty"`
+	IncludedAppointmentResourcesReferencedByAction                  *[]Appointment           `bson:"_includedAppointmentResourcesReferencedByAction,omitempty"`
+	IncludedReferralRequestResourcesReferencedByAction              *[]ReferralRequest       `bson:"_includedReferralRequestResourcesReferencedByAction,omitempty"`
+	IncludedNutritionOrderResourcesReferencedByAction               *[]NutritionOrder        `bson:"_includedNutritionOrderResourcesReferencedByAction,omitempty"`
+	IncludedProcedureRequestResourcesReferencedByAction             *[]ProcedureRequest      `bson:"_includedProcedureRequestResourcesReferencedByAction,omitempty"`
+	IncludedProcedureResourcesReferencedByAction                    *[]Procedure             `bson:"_includedProcedureResourcesReferencedByAction,omitempty"`
+	IncludedDiagnosticOrderResourcesReferencedByAction              *[]DiagnosticOrder       `bson:"_includedDiagnosticOrderResourcesReferencedByAction,omitempty"`
+	IncludedMedicationOrderResourcesReferencedByAction              *[]MedicationOrder       `bson:"_includedMedicationOrderResourcesReferencedByAction,omitempty"`
+	IncludedSupplyRequestResourcesReferencedByAction                *[]SupplyRequest         `bson:"_includedSupplyRequestResourcesReferencedByAction,omitempty"`
+	IncludedAppointmentResourcesReferencedByPlan                    *[]Appointment           `bson:"_includedAppointmentResourcesReferencedByPlan,omitempty"`
+	IncludedOrderResourcesReferencedByPlan                          *[]Order                 `bson:"_includedOrderResourcesReferencedByPlan,omitempty"`
+	IncludedReferralRequestResourcesReferencedByPlan                *[]ReferralRequest       `bson:"_includedReferralRequestResourcesReferencedByPlan,omitempty"`
+	IncludedProcessRequestResourcesReferencedByPlan                 *[]ProcessRequest        `bson:"_includedProcessRequestResourcesReferencedByPlan,omitempty"`
+	IncludedVisionPrescriptionResourcesReferencedByPlan             *[]VisionPrescription    `bson:"_includedVisionPrescriptionResourcesReferencedByPlan,omitempty"`
+	IncludedDiagnosticOrderResourcesReferencedByPlan                *[]DiagnosticOrder       `bson:"_includedDiagnosticOrderResourcesReferencedByPlan,omitempty"`
+	IncludedProcedureRequestResourcesReferencedByPlan               *[]ProcedureRequest      `bson:"_includedProcedureRequestResourcesReferencedByPlan,omitempty"`
+	IncludedDeviceUseRequestResourcesReferencedByPlan               *[]DeviceUseRequest      `bson:"_includedDeviceUseRequestResourcesReferencedByPlan,omitempty"`
+	IncludedSupplyRequestResourcesReferencedByPlan                  *[]SupplyRequest         `bson:"_includedSupplyRequestResourcesReferencedByPlan,omitempty"`
+	IncludedCarePlanResourcesReferencedByPlan                       *[]CarePlan              `bson:"_includedCarePlanResourcesReferencedByPlan,omitempty"`
+	IncludedNutritionOrderResourcesReferencedByPlan                 *[]NutritionOrder        `bson:"_includedNutritionOrderResourcesReferencedByPlan,omitempty"`
+	IncludedMedicationOrderResourcesReferencedByPlan                *[]MedicationOrder       `bson:"_includedMedicationOrderResourcesReferencedByPlan,omitempty"`
+	IncludedCommunicationRequestResourcesReferencedByPlan           *[]CommunicationRequest  `bson:"_includedCommunicationRequestResourcesReferencedByPlan,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                 *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref       *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref       *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                         *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref      *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                      *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                     *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference              *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject               *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                 *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated          *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment         *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject     *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest           *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPrevious       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPrevious,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger        *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPreviousResource() (clinicalImpression *ClinicalImpression, err error) {
-	if c.IncludedPreviousResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedClinicalImpressionResourceReferencedByPrevious() (clinicalImpression *ClinicalImpression, err error) {
+	if c.IncludedClinicalImpressionResourcesReferencedByPrevious == nil {
 		err = errors.New("Included clinicalimpressions not requested")
-	} else if len(*c.IncludedPreviousResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 clinicalImpression, but found %d", len(*c.IncludedPreviousResources))
-	} else if len(*c.IncludedPreviousResources) == 1 {
-		clinicalImpression = &(*c.IncludedPreviousResources)[0]
+	} else if len(*c.IncludedClinicalImpressionResourcesReferencedByPrevious) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 clinicalImpression, but found %d", len(*c.IncludedClinicalImpressionResourcesReferencedByPrevious))
+	} else if len(*c.IncludedClinicalImpressionResourcesReferencedByPrevious) == 1 {
+		clinicalImpression = &(*c.IncludedClinicalImpressionResourcesReferencedByPrevious)[0]
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedAssessorResource() (practitioner *Practitioner, err error) {
-	if c.IncludedAssessorResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAssessor() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByAssessor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedAssessorResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAssessorResources))
-	} else if len(*c.IncludedAssessorResources) == 1 {
-		practitioner = &(*c.IncludedAssessorResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAssessor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByAssessor))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAssessor) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByAssessor)[0]
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedProblemConditionResources() (conditions []Condition, err error) {
-	if c.IncludedProblemConditionResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedConditionResourcesReferencedByProblem() (conditions []Condition, err error) {
+	if c.IncludedConditionResourcesReferencedByProblem == nil {
 		err = errors.New("Included conditions not requested")
 	} else {
-		conditions = *c.IncludedProblemConditionResources
+		conditions = *c.IncludedConditionResourcesReferencedByProblem
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedProblemAllergyIntoleranceResources() (allergyIntolerances []AllergyIntolerance, err error) {
-	if c.IncludedProblemAllergyIntoleranceResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedAllergyIntoleranceResourcesReferencedByProblem() (allergyIntolerances []AllergyIntolerance, err error) {
+	if c.IncludedAllergyIntoleranceResourcesReferencedByProblem == nil {
 		err = errors.New("Included allergyIntolerances not requested")
 	} else {
-		allergyIntolerances = *c.IncludedProblemAllergyIntoleranceResources
+		allergyIntolerances = *c.IncludedAllergyIntoleranceResourcesReferencedByProblem
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationFamilyMemberHistoryResources() (familyMemberHistories []FamilyMemberHistory, err error) {
-	if c.IncludedInvestigationFamilyMemberHistoryResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedFamilyMemberHistoryResourcesReferencedByInvestigation() (familyMemberHistories []FamilyMemberHistory, err error) {
+	if c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation == nil {
 		err = errors.New("Included familyMemberHistories not requested")
 	} else {
-		familyMemberHistories = *c.IncludedInvestigationFamilyMemberHistoryResources
+		familyMemberHistories = *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationObservationResources() (observations []Observation, err error) {
-	if c.IncludedInvestigationObservationResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedObservationResourcesReferencedByInvestigation() (observations []Observation, err error) {
+	if c.IncludedObservationResourcesReferencedByInvestigation == nil {
 		err = errors.New("Included observations not requested")
 	} else {
-		observations = *c.IncludedInvestigationObservationResources
+		observations = *c.IncludedObservationResourcesReferencedByInvestigation
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationDiagnosticReportResources() (diagnosticReports []DiagnosticReport, err error) {
-	if c.IncludedInvestigationDiagnosticReportResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedDiagnosticReportResourcesReferencedByInvestigation() (diagnosticReports []DiagnosticReport, err error) {
+	if c.IncludedDiagnosticReportResourcesReferencedByInvestigation == nil {
 		err = errors.New("Included diagnosticReports not requested")
 	} else {
-		diagnosticReports = *c.IncludedInvestigationDiagnosticReportResources
+		diagnosticReports = *c.IncludedDiagnosticReportResourcesReferencedByInvestigation
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedInvestigationQuestionnaireResponseResources() (questionnaireResponses []QuestionnaireResponse, err error) {
-	if c.IncludedInvestigationQuestionnaireResponseResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedQuestionnaireResponseResourcesReferencedByInvestigation() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation == nil {
 		err = errors.New("Included questionnaireResponses not requested")
 	} else {
-		questionnaireResponses = *c.IncludedInvestigationQuestionnaireResponseResources
+		questionnaireResponses = *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionAppointmentResources() (appointments []Appointment, err error) {
-	if c.IncludedActionAppointmentResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedAppointmentResourcesReferencedByAction() (appointments []Appointment, err error) {
+	if c.IncludedAppointmentResourcesReferencedByAction == nil {
 		err = errors.New("Included appointments not requested")
 	} else {
-		appointments = *c.IncludedActionAppointmentResources
+		appointments = *c.IncludedAppointmentResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionReferralRequestResources() (referralRequests []ReferralRequest, err error) {
-	if c.IncludedActionReferralRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedReferralRequestResourcesReferencedByAction() (referralRequests []ReferralRequest, err error) {
+	if c.IncludedReferralRequestResourcesReferencedByAction == nil {
 		err = errors.New("Included referralRequests not requested")
 	} else {
-		referralRequests = *c.IncludedActionReferralRequestResources
+		referralRequests = *c.IncludedReferralRequestResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionNutritionOrderResources() (nutritionOrders []NutritionOrder, err error) {
-	if c.IncludedActionNutritionOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedNutritionOrderResourcesReferencedByAction() (nutritionOrders []NutritionOrder, err error) {
+	if c.IncludedNutritionOrderResourcesReferencedByAction == nil {
 		err = errors.New("Included nutritionOrders not requested")
 	} else {
-		nutritionOrders = *c.IncludedActionNutritionOrderResources
+		nutritionOrders = *c.IncludedNutritionOrderResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
-	if c.IncludedActionProcedureRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedProcedureRequestResourcesReferencedByAction() (procedureRequests []ProcedureRequest, err error) {
+	if c.IncludedProcedureRequestResourcesReferencedByAction == nil {
 		err = errors.New("Included procedureRequests not requested")
 	} else {
-		procedureRequests = *c.IncludedActionProcedureRequestResources
+		procedureRequests = *c.IncludedProcedureRequestResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionProcedureResources() (procedures []Procedure, err error) {
-	if c.IncludedActionProcedureResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedProcedureResourcesReferencedByAction() (procedures []Procedure, err error) {
+	if c.IncludedProcedureResourcesReferencedByAction == nil {
 		err = errors.New("Included procedures not requested")
 	} else {
-		procedures = *c.IncludedActionProcedureResources
+		procedures = *c.IncludedProcedureResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
-	if c.IncludedActionDiagnosticOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedDiagnosticOrderResourcesReferencedByAction() (diagnosticOrders []DiagnosticOrder, err error) {
+	if c.IncludedDiagnosticOrderResourcesReferencedByAction == nil {
 		err = errors.New("Included diagnosticOrders not requested")
 	} else {
-		diagnosticOrders = *c.IncludedActionDiagnosticOrderResources
+		diagnosticOrders = *c.IncludedDiagnosticOrderResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionMedicationOrderResources() (medicationOrders []MedicationOrder, err error) {
-	if c.IncludedActionMedicationOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedMedicationOrderResourcesReferencedByAction() (medicationOrders []MedicationOrder, err error) {
+	if c.IncludedMedicationOrderResourcesReferencedByAction == nil {
 		err = errors.New("Included medicationOrders not requested")
 	} else {
-		medicationOrders = *c.IncludedActionMedicationOrderResources
+		medicationOrders = *c.IncludedMedicationOrderResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedActionSupplyRequestResources() (supplyRequests []SupplyRequest, err error) {
-	if c.IncludedActionSupplyRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedSupplyRequestResourcesReferencedByAction() (supplyRequests []SupplyRequest, err error) {
+	if c.IncludedSupplyRequestResourcesReferencedByAction == nil {
 		err = errors.New("Included supplyRequests not requested")
 	} else {
-		supplyRequests = *c.IncludedActionSupplyRequestResources
+		supplyRequests = *c.IncludedSupplyRequestResourcesReferencedByAction
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanAppointmentResources() (appointments []Appointment, err error) {
-	if c.IncludedPlanAppointmentResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedAppointmentResourcesReferencedByPlan() (appointments []Appointment, err error) {
+	if c.IncludedAppointmentResourcesReferencedByPlan == nil {
 		err = errors.New("Included appointments not requested")
 	} else {
-		appointments = *c.IncludedPlanAppointmentResources
+		appointments = *c.IncludedAppointmentResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanOrderResources() (orders []Order, err error) {
-	if c.IncludedPlanOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedOrderResourcesReferencedByPlan() (orders []Order, err error) {
+	if c.IncludedOrderResourcesReferencedByPlan == nil {
 		err = errors.New("Included orders not requested")
 	} else {
-		orders = *c.IncludedPlanOrderResources
+		orders = *c.IncludedOrderResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanReferralRequestResources() (referralRequests []ReferralRequest, err error) {
-	if c.IncludedPlanReferralRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedReferralRequestResourcesReferencedByPlan() (referralRequests []ReferralRequest, err error) {
+	if c.IncludedReferralRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included referralRequests not requested")
 	} else {
-		referralRequests = *c.IncludedPlanReferralRequestResources
+		referralRequests = *c.IncludedReferralRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanProcessRequestResources() (processRequests []ProcessRequest, err error) {
-	if c.IncludedPlanProcessRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedProcessRequestResourcesReferencedByPlan() (processRequests []ProcessRequest, err error) {
+	if c.IncludedProcessRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included processRequests not requested")
 	} else {
-		processRequests = *c.IncludedPlanProcessRequestResources
+		processRequests = *c.IncludedProcessRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanVisionPrescriptionResources() (visionPrescriptions []VisionPrescription, err error) {
-	if c.IncludedPlanVisionPrescriptionResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedVisionPrescriptionResourcesReferencedByPlan() (visionPrescriptions []VisionPrescription, err error) {
+	if c.IncludedVisionPrescriptionResourcesReferencedByPlan == nil {
 		err = errors.New("Included visionPrescriptions not requested")
 	} else {
-		visionPrescriptions = *c.IncludedPlanVisionPrescriptionResources
+		visionPrescriptions = *c.IncludedVisionPrescriptionResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
-	if c.IncludedPlanDiagnosticOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedDiagnosticOrderResourcesReferencedByPlan() (diagnosticOrders []DiagnosticOrder, err error) {
+	if c.IncludedDiagnosticOrderResourcesReferencedByPlan == nil {
 		err = errors.New("Included diagnosticOrders not requested")
 	} else {
-		diagnosticOrders = *c.IncludedPlanDiagnosticOrderResources
+		diagnosticOrders = *c.IncludedDiagnosticOrderResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
-	if c.IncludedPlanProcedureRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedProcedureRequestResourcesReferencedByPlan() (procedureRequests []ProcedureRequest, err error) {
+	if c.IncludedProcedureRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included procedureRequests not requested")
 	} else {
-		procedureRequests = *c.IncludedPlanProcedureRequestResources
+		procedureRequests = *c.IncludedProcedureRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanDeviceUseRequestResources() (deviceUseRequests []DeviceUseRequest, err error) {
-	if c.IncludedPlanDeviceUseRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedDeviceUseRequestResourcesReferencedByPlan() (deviceUseRequests []DeviceUseRequest, err error) {
+	if c.IncludedDeviceUseRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included deviceUseRequests not requested")
 	} else {
-		deviceUseRequests = *c.IncludedPlanDeviceUseRequestResources
+		deviceUseRequests = *c.IncludedDeviceUseRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanSupplyRequestResources() (supplyRequests []SupplyRequest, err error) {
-	if c.IncludedPlanSupplyRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedSupplyRequestResourcesReferencedByPlan() (supplyRequests []SupplyRequest, err error) {
+	if c.IncludedSupplyRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included supplyRequests not requested")
 	} else {
-		supplyRequests = *c.IncludedPlanSupplyRequestResources
+		supplyRequests = *c.IncludedSupplyRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanCarePlanResources() (carePlans []CarePlan, err error) {
-	if c.IncludedPlanCarePlanResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedCarePlanResourcesReferencedByPlan() (carePlans []CarePlan, err error) {
+	if c.IncludedCarePlanResourcesReferencedByPlan == nil {
 		err = errors.New("Included carePlans not requested")
 	} else {
-		carePlans = *c.IncludedPlanCarePlanResources
+		carePlans = *c.IncludedCarePlanResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanNutritionOrderResources() (nutritionOrders []NutritionOrder, err error) {
-	if c.IncludedPlanNutritionOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedNutritionOrderResourcesReferencedByPlan() (nutritionOrders []NutritionOrder, err error) {
+	if c.IncludedNutritionOrderResourcesReferencedByPlan == nil {
 		err = errors.New("Included nutritionOrders not requested")
 	} else {
-		nutritionOrders = *c.IncludedPlanNutritionOrderResources
+		nutritionOrders = *c.IncludedNutritionOrderResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanMedicationOrderResources() (medicationOrders []MedicationOrder, err error) {
-	if c.IncludedPlanMedicationOrderResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedMedicationOrderResourcesReferencedByPlan() (medicationOrders []MedicationOrder, err error) {
+	if c.IncludedMedicationOrderResourcesReferencedByPlan == nil {
 		err = errors.New("Included medicationOrders not requested")
 	} else {
-		medicationOrders = *c.IncludedPlanMedicationOrderResources
+		medicationOrders = *c.IncludedMedicationOrderResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedPlanCommunicationRequestResources() (communicationRequests []CommunicationRequest, err error) {
-	if c.IncludedPlanCommunicationRequestResources == nil {
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedCommunicationRequestResourcesReferencedByPlan() (communicationRequests []CommunicationRequest, err error) {
+	if c.IncludedCommunicationRequestResourcesReferencedByPlan == nil {
 		err = errors.New("Included communicationRequests not requested")
 	} else {
-		communicationRequests = *c.IncludedPlanCommunicationRequestResources
+		communicationRequests = *c.IncludedCommunicationRequestResourcesReferencedByPlan
 	}
 	return
 }
 
-func (c *ClinicalImpressionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPrevious() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingPrevious == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingPrevious
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedPreviousResources != nil {
-		for _, r := range *c.IncludedPreviousResources {
+	if c.IncludedClinicalImpressionResourcesReferencedByPrevious != nil {
+		for _, r := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAssessorResources != nil {
-		for _, r := range *c.IncludedAssessorResources {
+	if c.IncludedPractitionerResourcesReferencedByAssessor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAssessor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedProblemConditionResources != nil {
-		for _, r := range *c.IncludedProblemConditionResources {
+	if c.IncludedConditionResourcesReferencedByProblem != nil {
+		for _, r := range *c.IncludedConditionResourcesReferencedByProblem {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedProblemAllergyIntoleranceResources != nil {
-		for _, r := range *c.IncludedProblemAllergyIntoleranceResources {
+	if c.IncludedAllergyIntoleranceResourcesReferencedByProblem != nil {
+		for _, r := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedInvestigationFamilyMemberHistoryResources != nil {
-		for _, r := range *c.IncludedInvestigationFamilyMemberHistoryResources {
+	if c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedInvestigationObservationResources != nil {
-		for _, r := range *c.IncludedInvestigationObservationResources {
+	if c.IncludedObservationResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedObservationResourcesReferencedByInvestigation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedInvestigationDiagnosticReportResources != nil {
-		for _, r := range *c.IncludedInvestigationDiagnosticReportResources {
+	if c.IncludedDiagnosticReportResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedInvestigationQuestionnaireResponseResources != nil {
-		for _, r := range *c.IncludedInvestigationQuestionnaireResponseResources {
+	if c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionAppointmentResources != nil {
-		for _, r := range *c.IncludedActionAppointmentResources {
+	if c.IncludedAppointmentResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionReferralRequestResources != nil {
-		for _, r := range *c.IncludedActionReferralRequestResources {
+	if c.IncludedReferralRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionNutritionOrderResources != nil {
-		for _, r := range *c.IncludedActionNutritionOrderResources {
+	if c.IncludedNutritionOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionProcedureRequestResources != nil {
-		for _, r := range *c.IncludedActionProcedureRequestResources {
+	if c.IncludedProcedureRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionProcedureResources != nil {
-		for _, r := range *c.IncludedActionProcedureResources {
+	if c.IncludedProcedureResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedProcedureResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionDiagnosticOrderResources != nil {
-		for _, r := range *c.IncludedActionDiagnosticOrderResources {
+	if c.IncludedDiagnosticOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionMedicationOrderResources != nil {
-		for _, r := range *c.IncludedActionMedicationOrderResources {
+	if c.IncludedMedicationOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActionSupplyRequestResources != nil {
-		for _, r := range *c.IncludedActionSupplyRequestResources {
+	if c.IncludedSupplyRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByAction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanAppointmentResources != nil {
-		for _, r := range *c.IncludedPlanAppointmentResources {
+	if c.IncludedAppointmentResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanOrderResources != nil {
-		for _, r := range *c.IncludedPlanOrderResources {
+	if c.IncludedOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedOrderResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanReferralRequestResources != nil {
-		for _, r := range *c.IncludedPlanReferralRequestResources {
+	if c.IncludedReferralRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanProcessRequestResources != nil {
-		for _, r := range *c.IncludedPlanProcessRequestResources {
+	if c.IncludedProcessRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedProcessRequestResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanVisionPrescriptionResources != nil {
-		for _, r := range *c.IncludedPlanVisionPrescriptionResources {
+	if c.IncludedVisionPrescriptionResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanDiagnosticOrderResources != nil {
-		for _, r := range *c.IncludedPlanDiagnosticOrderResources {
+	if c.IncludedDiagnosticOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanProcedureRequestResources != nil {
-		for _, r := range *c.IncludedPlanProcedureRequestResources {
+	if c.IncludedProcedureRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanDeviceUseRequestResources != nil {
-		for _, r := range *c.IncludedPlanDeviceUseRequestResources {
+	if c.IncludedDeviceUseRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanSupplyRequestResources != nil {
-		for _, r := range *c.IncludedPlanSupplyRequestResources {
+	if c.IncludedSupplyRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanCarePlanResources != nil {
-		for _, r := range *c.IncludedPlanCarePlanResources {
+	if c.IncludedCarePlanResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedCarePlanResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanNutritionOrderResources != nil {
-		for _, r := range *c.IncludedPlanNutritionOrderResources {
+	if c.IncludedNutritionOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanMedicationOrderResources != nil {
-		for _, r := range *c.IncludedPlanMedicationOrderResources {
+	if c.IncludedMedicationOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPlanCommunicationRequestResources != nil {
-		for _, r := range *c.IncludedPlanCommunicationRequestResources {
+	if c.IncludedCommunicationRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPrevious != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ClinicalImpressionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedClinicalImpressionResourcesReferencedByPrevious != nil {
+		for _, r := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByAssessor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAssessor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedConditionResourcesReferencedByProblem != nil {
+		for _, r := range *c.IncludedConditionResourcesReferencedByProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAllergyIntoleranceResourcesReferencedByProblem != nil {
+		for _, r := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedObservationResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedObservationResourcesReferencedByInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDiagnosticReportResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation != nil {
+		for _, r := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAppointmentResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedReferralRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedNutritionOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcedureRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcedureResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedProcedureResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDiagnosticOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedMedicationOrderResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSupplyRequestResourcesReferencedByAction != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedAppointmentResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedAppointmentResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedOrderResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedReferralRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedReferralRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcessRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedProcessRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedVisionPrescriptionResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDiagnosticOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedProcedureRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceUseRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSupplyRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedCarePlanResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedCarePlanResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedNutritionOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedMedicationOrderResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedCommunicationRequestResourcesReferencedByPlan != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPrevious != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/communication.go
+++ b/models/communication.go
@@ -98,255 +98,660 @@ type CommunicationPayloadComponent struct {
 }
 
 type CommunicationPlus struct {
-	Communication             `bson:",inline"`
-	CommunicationPlusIncludes `bson:",inline"`
+	Communication                     `bson:",inline"`
+	CommunicationPlusRelatedResources `bson:",inline"`
 }
 
-type CommunicationPlusIncludes struct {
-	IncludedRequestResources                *[]CommunicationRequest `bson:"_includedRequestResources,omitempty"`
-	IncludedSenderPractitionerResources     *[]Practitioner         `bson:"_includedSenderPractitionerResources,omitempty"`
-	IncludedSenderOrganizationResources     *[]Organization         `bson:"_includedSenderOrganizationResources,omitempty"`
-	IncludedSenderDeviceResources           *[]Device               `bson:"_includedSenderDeviceResources,omitempty"`
-	IncludedSenderPatientResources          *[]Patient              `bson:"_includedSenderPatientResources,omitempty"`
-	IncludedSenderRelatedPersonResources    *[]RelatedPerson        `bson:"_includedSenderRelatedPersonResources,omitempty"`
-	IncludedSubjectResources                *[]Patient              `bson:"_includedSubjectResources,omitempty"`
-	IncludedPatientResources                *[]Patient              `bson:"_includedPatientResources,omitempty"`
-	IncludedRecipientPractitionerResources  *[]Practitioner         `bson:"_includedRecipientPractitionerResources,omitempty"`
-	IncludedRecipientGroupResources         *[]Group                `bson:"_includedRecipientGroupResources,omitempty"`
-	IncludedRecipientOrganizationResources  *[]Organization         `bson:"_includedRecipientOrganizationResources,omitempty"`
-	IncludedRecipientDeviceResources        *[]Device               `bson:"_includedRecipientDeviceResources,omitempty"`
-	IncludedRecipientPatientResources       *[]Patient              `bson:"_includedRecipientPatientResources,omitempty"`
-	IncludedRecipientRelatedPersonResources *[]RelatedPerson        `bson:"_includedRecipientRelatedPersonResources,omitempty"`
-	IncludedEncounterResources              *[]Encounter            `bson:"_includedEncounterResources,omitempty"`
+type CommunicationPlusRelatedResources struct {
+	IncludedCommunicationRequestResourcesReferencedByRequest    *[]CommunicationRequest  `bson:"_includedCommunicationRequestResourcesReferencedByRequest,omitempty"`
+	IncludedPractitionerResourcesReferencedBySender             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySender,omitempty"`
+	IncludedOrganizationResourcesReferencedBySender             *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySender,omitempty"`
+	IncludedDeviceResourcesReferencedBySender                   *[]Device                `bson:"_includedDeviceResourcesReferencedBySender,omitempty"`
+	IncludedPatientResourcesReferencedBySender                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySender,omitempty"`
+	IncludedRelatedPersonResourcesReferencedBySender            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedBySender,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByRecipient          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRecipient,omitempty"`
+	IncludedGroupResourcesReferencedByRecipient                 *[]Group                 `bson:"_includedGroupResourcesReferencedByRecipient,omitempty"`
+	IncludedOrganizationResourcesReferencedByRecipient          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRecipient,omitempty"`
+	IncludedDeviceResourcesReferencedByRecipient                *[]Device                `bson:"_includedDeviceResourcesReferencedByRecipient,omitempty"`
+	IncludedPatientResourcesReferencedByRecipient               *[]Patient               `bson:"_includedPatientResourcesReferencedByRecipient,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByRecipient         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByRecipient,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRequestResource() (communicationRequest *CommunicationRequest, err error) {
-	if c.IncludedRequestResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedCommunicationRequestResourceReferencedByRequest() (communicationRequest *CommunicationRequest, err error) {
+	if c.IncludedCommunicationRequestResourcesReferencedByRequest == nil {
 		err = errors.New("Included communicationrequests not requested")
-	} else if len(*c.IncludedRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedRequestResources))
-	} else if len(*c.IncludedRequestResources) == 1 {
-		communicationRequest = &(*c.IncludedRequestResources)[0]
+	} else if len(*c.IncludedCommunicationRequestResourcesReferencedByRequest) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 communicationRequest, but found %d", len(*c.IncludedCommunicationRequestResourcesReferencedByRequest))
+	} else if len(*c.IncludedCommunicationRequestResourcesReferencedByRequest) == 1 {
+		communicationRequest = &(*c.IncludedCommunicationRequestResourcesReferencedByRequest)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSenderPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedSenderPractitionerResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySender() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedBySender == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedSenderPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSenderPractitionerResources))
-	} else if len(*c.IncludedSenderPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedSenderPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedBySender))
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySender) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSenderOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedSenderOrganizationResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySender() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedBySender == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedSenderOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSenderOrganizationResources))
-	} else if len(*c.IncludedSenderOrganizationResources) == 1 {
-		organization = &(*c.IncludedSenderOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedBySender))
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySender) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSenderDeviceResource() (device *Device, err error) {
-	if c.IncludedSenderDeviceResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedDeviceResourceReferencedBySender() (device *Device, err error) {
+	if c.IncludedDeviceResourcesReferencedBySender == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*c.IncludedSenderDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedSenderDeviceResources))
-	} else if len(*c.IncludedSenderDeviceResources) == 1 {
-		device = &(*c.IncludedSenderDeviceResources)[0]
+	} else if len(*c.IncludedDeviceResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedDeviceResourcesReferencedBySender))
+	} else if len(*c.IncludedDeviceResourcesReferencedBySender) == 1 {
+		device = &(*c.IncludedDeviceResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSenderPatientResource() (patient *Patient, err error) {
-	if c.IncludedSenderPatientResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPatientResourceReferencedBySender() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySender == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSenderPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSenderPatientResources))
-	} else if len(*c.IncludedSenderPatientResources) == 1 {
-		patient = &(*c.IncludedSenderPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySender))
+	} else if len(*c.IncludedPatientResourcesReferencedBySender) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSenderRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedSenderRelatedPersonResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedBySender() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedBySender == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedSenderRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSenderRelatedPersonResources))
-	} else if len(*c.IncludedSenderRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedSenderRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedBySender))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySender) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
-	if c.IncludedSubjectResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSubjectResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectResources))
-	} else if len(*c.IncludedSubjectResources) == 1 {
-		patient = &(*c.IncludedSubjectResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
-	if c.IncludedRecipientPractitionerResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByRecipient() (practitioners []Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByRecipient == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *c.IncludedRecipientPractitionerResources
+		practitioners = *c.IncludedPractitionerResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientGroupResources() (groups []Group, err error) {
-	if c.IncludedRecipientGroupResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedGroupResourcesReferencedByRecipient() (groups []Group, err error) {
+	if c.IncludedGroupResourcesReferencedByRecipient == nil {
 		err = errors.New("Included groups not requested")
 	} else {
-		groups = *c.IncludedRecipientGroupResources
+		groups = *c.IncludedGroupResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
-	if c.IncludedRecipientOrganizationResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByRecipient() (organizations []Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByRecipient == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *c.IncludedRecipientOrganizationResources
+		organizations = *c.IncludedOrganizationResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientDeviceResources() (devices []Device, err error) {
-	if c.IncludedRecipientDeviceResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedDeviceResourcesReferencedByRecipient() (devices []Device, err error) {
+	if c.IncludedDeviceResourcesReferencedByRecipient == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *c.IncludedRecipientDeviceResources
+		devices = *c.IncludedDeviceResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
-	if c.IncludedRecipientPatientResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedPatientResourcesReferencedByRecipient() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByRecipient == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedRecipientPatientResources
+		patients = *c.IncludedPatientResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if c.IncludedRecipientRelatedPersonResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByRecipient() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *c.IncludedRecipientRelatedPersonResources
+		relatedPeople = *c.IncludedRelatedPersonResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if c.IncludedEncounterResources == nil {
+func (c *CommunicationPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*c.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
-	} else if len(*c.IncludedEncounterResources) == 1 {
-		encounter = &(*c.IncludedEncounterResources)[0]
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*c.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (c *CommunicationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *CommunicationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *CommunicationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedRequestResources != nil {
-		for _, r := range *c.IncludedRequestResources {
+	if c.IncludedCommunicationRequestResourcesReferencedByRequest != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderPractitionerResources != nil {
-		for _, r := range *c.IncludedSenderPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderOrganizationResources != nil {
-		for _, r := range *c.IncludedSenderOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderDeviceResources != nil {
-		for _, r := range *c.IncludedSenderDeviceResources {
+	if c.IncludedDeviceResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderPatientResources != nil {
-		for _, r := range *c.IncludedSenderPatientResources {
+	if c.IncludedPatientResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderRelatedPersonResources != nil {
-		for _, r := range *c.IncludedSenderRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSubjectResources != nil {
-		for _, r := range *c.IncludedSubjectResources {
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientPractitionerResources != nil {
-		for _, r := range *c.IncludedRecipientPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientGroupResources != nil {
-		for _, r := range *c.IncludedRecipientGroupResources {
+	if c.IncludedGroupResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientOrganizationResources != nil {
-		for _, r := range *c.IncludedRecipientOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientDeviceResources != nil {
-		for _, r := range *c.IncludedRecipientDeviceResources {
+	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientPatientResources != nil {
-		for _, r := range *c.IncludedRecipientPatientResources {
+	if c.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientRelatedPersonResources != nil {
-		for _, r := range *c.IncludedRecipientRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedEncounterResources != nil {
-		for _, r := range *c.IncludedEncounterResources {
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CommunicationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CommunicationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedCommunicationRequestResourcesReferencedByRequest != nil {
+		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedGroupResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/communicationrequest.go
+++ b/models/communicationrequest.go
@@ -100,274 +100,744 @@ type CommunicationRequestPayloadComponent struct {
 }
 
 type CommunicationRequestPlus struct {
-	CommunicationRequest             `bson:",inline"`
-	CommunicationRequestPlusIncludes `bson:",inline"`
+	CommunicationRequest                     `bson:",inline"`
+	CommunicationRequestPlusRelatedResources `bson:",inline"`
 }
 
-type CommunicationRequestPlusIncludes struct {
-	IncludedRequesterPractitionerResources  *[]Practitioner  `bson:"_includedRequesterPractitionerResources,omitempty"`
-	IncludedRequesterPatientResources       *[]Patient       `bson:"_includedRequesterPatientResources,omitempty"`
-	IncludedRequesterRelatedPersonResources *[]RelatedPerson `bson:"_includedRequesterRelatedPersonResources,omitempty"`
-	IncludedSubjectResources                *[]Patient       `bson:"_includedSubjectResources,omitempty"`
-	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
-	IncludedSenderPractitionerResources     *[]Practitioner  `bson:"_includedSenderPractitionerResources,omitempty"`
-	IncludedSenderOrganizationResources     *[]Organization  `bson:"_includedSenderOrganizationResources,omitempty"`
-	IncludedSenderDeviceResources           *[]Device        `bson:"_includedSenderDeviceResources,omitempty"`
-	IncludedSenderPatientResources          *[]Patient       `bson:"_includedSenderPatientResources,omitempty"`
-	IncludedSenderRelatedPersonResources    *[]RelatedPerson `bson:"_includedSenderRelatedPersonResources,omitempty"`
-	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedRecipientPractitionerResources  *[]Practitioner  `bson:"_includedRecipientPractitionerResources,omitempty"`
-	IncludedRecipientOrganizationResources  *[]Organization  `bson:"_includedRecipientOrganizationResources,omitempty"`
-	IncludedRecipientDeviceResources        *[]Device        `bson:"_includedRecipientDeviceResources,omitempty"`
-	IncludedRecipientPatientResources       *[]Patient       `bson:"_includedRecipientPatientResources,omitempty"`
-	IncludedRecipientRelatedPersonResources *[]RelatedPerson `bson:"_includedRecipientRelatedPersonResources,omitempty"`
+type CommunicationRequestPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByRequester          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRequester,omitempty"`
+	IncludedPatientResourcesReferencedByRequester               *[]Patient               `bson:"_includedPatientResourcesReferencedByRequester,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByRequester         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByRequester,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedPractitionerResourcesReferencedBySender             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySender,omitempty"`
+	IncludedOrganizationResourcesReferencedBySender             *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySender,omitempty"`
+	IncludedDeviceResourcesReferencedBySender                   *[]Device                `bson:"_includedDeviceResourcesReferencedBySender,omitempty"`
+	IncludedPatientResourcesReferencedBySender                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySender,omitempty"`
+	IncludedRelatedPersonResourcesReferencedBySender            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedBySender,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByRecipient          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRecipient,omitempty"`
+	IncludedOrganizationResourcesReferencedByRecipient          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRecipient,omitempty"`
+	IncludedDeviceResourcesReferencedByRecipient                *[]Device                `bson:"_includedDeviceResourcesReferencedByRecipient,omitempty"`
+	IncludedPatientResourcesReferencedByRecipient               *[]Patient               `bson:"_includedPatientResourcesReferencedByRecipient,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByRecipient         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByRecipient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRequest         *[]Communication         `bson:"_revIncludedCommunicationResourcesReferencingRequest,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedRequesterPractitionerResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedByRequester() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByRequester == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedRequesterPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedRequesterPractitionerResources))
-	} else if len(*c.IncludedRequesterPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedRequesterPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByRequester))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByRequester) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterPatientResource() (patient *Patient, err error) {
-	if c.IncludedRequesterPatientResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByRequester() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByRequester == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedRequesterPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedRequesterPatientResources))
-	} else if len(*c.IncludedRequesterPatientResources) == 1 {
-		patient = &(*c.IncludedRequesterPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByRequester))
+	} else if len(*c.IncludedPatientResourcesReferencedByRequester) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRequesterRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedRequesterRelatedPersonResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByRequester() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByRequester == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedRequesterRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRequesterRelatedPersonResources))
-	} else if len(*c.IncludedRequesterRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedRequesterRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedByRequester))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByRequester) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
-	if c.IncludedSubjectResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSubjectResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSubjectResources))
-	} else if len(*c.IncludedSubjectResources) == 1 {
-		patient = &(*c.IncludedSubjectResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*c.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if c.IncludedEncounterResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*c.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
-	} else if len(*c.IncludedEncounterResources) == 1 {
-		encounter = &(*c.IncludedEncounterResources)[0]
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*c.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSenderPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedSenderPractitionerResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySender() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedBySender == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedSenderPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSenderPractitionerResources))
-	} else if len(*c.IncludedSenderPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedSenderPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedBySender))
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySender) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSenderOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedSenderOrganizationResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySender() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedBySender == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedSenderOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSenderOrganizationResources))
-	} else if len(*c.IncludedSenderOrganizationResources) == 1 {
-		organization = &(*c.IncludedSenderOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedBySender))
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySender) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSenderDeviceResource() (device *Device, err error) {
-	if c.IncludedSenderDeviceResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedDeviceResourceReferencedBySender() (device *Device, err error) {
+	if c.IncludedDeviceResourcesReferencedBySender == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*c.IncludedSenderDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedSenderDeviceResources))
-	} else if len(*c.IncludedSenderDeviceResources) == 1 {
-		device = &(*c.IncludedSenderDeviceResources)[0]
+	} else if len(*c.IncludedDeviceResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedDeviceResourcesReferencedBySender))
+	} else if len(*c.IncludedDeviceResourcesReferencedBySender) == 1 {
+		device = &(*c.IncludedDeviceResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSenderPatientResource() (patient *Patient, err error) {
-	if c.IncludedSenderPatientResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySender() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySender == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSenderPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSenderPatientResources))
-	} else if len(*c.IncludedSenderPatientResources) == 1 {
-		patient = &(*c.IncludedSenderPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySender))
+	} else if len(*c.IncludedPatientResourcesReferencedBySender) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedSenderRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedSenderRelatedPersonResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedBySender() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedBySender == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedSenderRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSenderRelatedPersonResources))
-	} else if len(*c.IncludedSenderRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedSenderRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySender) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedBySender))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySender) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedBySender)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
-	if c.IncludedRecipientPractitionerResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByRecipient() (practitioners []Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByRecipient == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *c.IncludedRecipientPractitionerResources
+		practitioners = *c.IncludedPractitionerResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
-	if c.IncludedRecipientOrganizationResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByRecipient() (organizations []Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByRecipient == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *c.IncludedRecipientOrganizationResources
+		organizations = *c.IncludedOrganizationResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientDeviceResources() (devices []Device, err error) {
-	if c.IncludedRecipientDeviceResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedDeviceResourcesReferencedByRecipient() (devices []Device, err error) {
+	if c.IncludedDeviceResourcesReferencedByRecipient == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *c.IncludedRecipientDeviceResources
+		devices = *c.IncludedDeviceResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
-	if c.IncludedRecipientPatientResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedPatientResourcesReferencedByRecipient() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByRecipient == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedRecipientPatientResources
+		patients = *c.IncludedPatientResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if c.IncludedRecipientRelatedPersonResources == nil {
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByRecipient() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *c.IncludedRecipientRelatedPersonResources
+		relatedPeople = *c.IncludedRelatedPersonResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (c *CommunicationRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if c.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *c.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRequest() (communications []Communication, err error) {
+	if c.RevIncludedCommunicationResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *c.RevIncludedCommunicationResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedRequesterPractitionerResources != nil {
-		for _, r := range *c.IncludedRequesterPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRequesterPatientResources != nil {
-		for _, r := range *c.IncludedRequesterPatientResources {
+	if c.IncludedPatientResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRequesterRelatedPersonResources != nil {
-		for _, r := range *c.IncludedRequesterRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSubjectResources != nil {
-		for _, r := range *c.IncludedSubjectResources {
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedEncounterResources != nil {
-		for _, r := range *c.IncludedEncounterResources {
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderPractitionerResources != nil {
-		for _, r := range *c.IncludedSenderPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderOrganizationResources != nil {
-		for _, r := range *c.IncludedSenderOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderDeviceResources != nil {
-		for _, r := range *c.IncludedSenderDeviceResources {
+	if c.IncludedDeviceResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderPatientResources != nil {
-		for _, r := range *c.IncludedSenderPatientResources {
+	if c.IncludedPatientResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSenderRelatedPersonResources != nil {
-		for _, r := range *c.IncludedSenderRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientPractitionerResources != nil {
-		for _, r := range *c.IncludedRecipientPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientOrganizationResources != nil {
-		for _, r := range *c.IncludedRecipientOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientDeviceResources != nil {
-		for _, r := range *c.IncludedRecipientDeviceResources {
+	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientPatientResources != nil {
-		for _, r := range *c.IncludedRecipientPatientResources {
+	if c.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedRecipientRelatedPersonResources != nil {
-		for _, r := range *c.IncludedRecipientRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCommunicationResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedCommunicationResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CommunicationRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByRequester != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCommunicationResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedCommunicationResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/composition.go
+++ b/models/composition.go
@@ -116,157 +116,552 @@ type CompositionSectionComponent struct {
 }
 
 type CompositionPlus struct {
-	Composition             `bson:",inline"`
-	CompositionPlusIncludes `bson:",inline"`
+	Composition                     `bson:",inline"`
+	CompositionPlusRelatedResources `bson:",inline"`
 }
 
-type CompositionPlusIncludes struct {
-	IncludedAuthorPractitionerResources   *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorDeviceResources         *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources        *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources  *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
-	IncludedEncounterResources            *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
-	IncludedAttesterPractitionerResources *[]Practitioner  `bson:"_includedAttesterPractitionerResources,omitempty"`
-	IncludedAttesterOrganizationResources *[]Organization  `bson:"_includedAttesterOrganizationResources,omitempty"`
-	IncludedAttesterPatientResources      *[]Patient       `bson:"_includedAttesterPatientResources,omitempty"`
-	IncludedPatientResources              *[]Patient       `bson:"_includedPatientResources,omitempty"`
+type CompositionPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedPractitionerResourcesReferencedByAttester           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAttester,omitempty"`
+	IncludedOrganizationResourcesReferencedByAttester           *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAttester,omitempty"`
+	IncludedPatientResourcesReferencedByAttester                *[]Patient               `bson:"_includedPatientResourcesReferencedByAttester,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedBundleResourcesReferencingComposition            *[]Bundle                `bson:"_revIncludedBundleResourcesReferencingComposition,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
-	if c.IncludedAuthorPractitionerResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByAuthor() (practitioners []Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *c.IncludedAuthorPractitionerResources
+		practitioners = *c.IncludedPractitionerResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
-	if c.IncludedAuthorDeviceResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedDeviceResourcesReferencedByAuthor() (devices []Device, err error) {
+	if c.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *c.IncludedAuthorDeviceResources
+		devices = *c.IncludedDeviceResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
-	if c.IncludedAuthorPatientResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedPatientResourcesReferencedByAuthor() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedAuthorPatientResources
+		patients = *c.IncludedPatientResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if c.IncludedAuthorRelatedPersonResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByAuthor() (relatedPeople []RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *c.IncludedAuthorRelatedPersonResources
+		relatedPeople = *c.IncludedRelatedPersonResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if c.IncludedEncounterResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*c.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
-	} else if len(*c.IncludedEncounterResources) == 1 {
-		encounter = &(*c.IncludedEncounterResources)[0]
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*c.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAttesterPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedAttesterPractitionerResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAttester() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByAttester == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedAttesterPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAttesterPractitionerResources))
-	} else if len(*c.IncludedAttesterPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedAttesterPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAttester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByAttester))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAttester) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByAttester)[0]
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAttesterOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedAttesterOrganizationResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedOrganizationResourceReferencedByAttester() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByAttester == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedAttesterOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedAttesterOrganizationResources))
-	} else if len(*c.IncludedAttesterOrganizationResources) == 1 {
-		organization = &(*c.IncludedAttesterOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedByAttester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedByAttester))
+	} else if len(*c.IncludedOrganizationResourcesReferencedByAttester) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedByAttester)[0]
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedAttesterPatientResource() (patient *Patient, err error) {
-	if c.IncludedAttesterPatientResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedPatientResourceReferencedByAttester() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByAttester == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedAttesterPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedAttesterPatientResources))
-	} else if len(*c.IncludedAttesterPatientResources) == 1 {
-		patient = &(*c.IncludedAttesterPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByAttester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByAttester))
+	} else if len(*c.IncludedPatientResourcesReferencedByAttester) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByAttester)[0]
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *CompositionPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *CompositionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *CompositionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedBundleResourcesReferencingComposition() (bundles []Bundle, err error) {
+	if c.RevIncludedBundleResourcesReferencingComposition == nil {
+		err = errors.New("RevIncluded bundles not requested")
+	} else {
+		bundles = *c.RevIncludedBundleResourcesReferencingComposition
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *CompositionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *c.IncludedAuthorPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAuthorDeviceResources != nil {
-		for _, r := range *c.IncludedAuthorDeviceResources {
+	if c.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAuthorPatientResources != nil {
-		for _, r := range *c.IncludedAuthorPatientResources {
+	if c.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *c.IncludedAuthorRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedEncounterResources != nil {
-		for _, r := range *c.IncludedEncounterResources {
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAttesterPractitionerResources != nil {
-		for _, r := range *c.IncludedAttesterPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAttester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAttesterOrganizationResources != nil {
-		for _, r := range *c.IncludedAttesterOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByAttester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAttesterPatientResources != nil {
-		for _, r := range *c.IncludedAttesterPatientResources {
+	if c.IncludedPatientResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAttester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CompositionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBundleResourcesReferencingComposition != nil {
+		for _, r := range *c.RevIncludedBundleResourcesReferencingComposition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CompositionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByAttester != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBundleResourcesReferencingComposition != nil {
+		for _, r := range *c.RevIncludedBundleResourcesReferencingComposition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/conceptmap.go
+++ b/models/conceptmap.go
@@ -123,114 +123,474 @@ type ConceptMapOtherElementComponent struct {
 }
 
 type ConceptMapPlus struct {
-	ConceptMap             `bson:",inline"`
-	ConceptMapPlusIncludes `bson:",inline"`
+	ConceptMap                     `bson:",inline"`
+	ConceptMapPlusRelatedResources `bson:",inline"`
 }
 
-type ConceptMapPlusIncludes struct {
-	IncludedSourceStructureDefinitionResources    *[]StructureDefinition `bson:"_includedSourceStructureDefinitionResources,omitempty"`
-	IncludedSourceValueSetResources               *[]ValueSet            `bson:"_includedSourceValueSetResources,omitempty"`
-	IncludedTargetStructureDefinitionResources    *[]StructureDefinition `bson:"_includedTargetStructureDefinitionResources,omitempty"`
-	IncludedTargetValueSetResources               *[]ValueSet            `bson:"_includedTargetValueSetResources,omitempty"`
-	IncludedSourceuriStructureDefinitionResources *[]StructureDefinition `bson:"_includedSourceuriStructureDefinitionResources,omitempty"`
-	IncludedSourceuriValueSetResources            *[]ValueSet            `bson:"_includedSourceuriValueSetResources,omitempty"`
+type ConceptMapPlusRelatedResources struct {
+	IncludedStructureDefinitionResourcesReferencedBySource      *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedBySource,omitempty"`
+	IncludedValueSetResourcesReferencedBySource                 *[]ValueSet              `bson:"_includedValueSetResourcesReferencedBySource,omitempty"`
+	IncludedStructureDefinitionResourcesReferencedByTarget      *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedByTarget,omitempty"`
+	IncludedValueSetResourcesReferencedByTarget                 *[]ValueSet              `bson:"_includedValueSetResourcesReferencedByTarget,omitempty"`
+	IncludedStructureDefinitionResourcesReferencedBySourceuri   *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedBySourceuri,omitempty"`
+	IncludedValueSetResourcesReferencedBySourceuri              *[]ValueSet              `bson:"_includedValueSetResourcesReferencedBySourceuri,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedSourceStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
-	if c.IncludedSourceStructureDefinitionResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedStructureDefinitionResourceReferencedBySource() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedStructureDefinitionResourcesReferencedBySource == nil {
 		err = errors.New("Included structuredefinitions not requested")
-	} else if len(*c.IncludedSourceStructureDefinitionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedSourceStructureDefinitionResources))
-	} else if len(*c.IncludedSourceStructureDefinitionResources) == 1 {
-		structureDefinition = &(*c.IncludedSourceStructureDefinitionResources)[0]
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedStructureDefinitionResourcesReferencedBySource))
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedBySource) == 1 {
+		structureDefinition = &(*c.IncludedStructureDefinitionResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedSourceValueSetResource() (valueSet *ValueSet, err error) {
-	if c.IncludedSourceValueSetResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedValueSetResourceReferencedBySource() (valueSet *ValueSet, err error) {
+	if c.IncludedValueSetResourcesReferencedBySource == nil {
 		err = errors.New("Included valuesets not requested")
-	} else if len(*c.IncludedSourceValueSetResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedSourceValueSetResources))
-	} else if len(*c.IncludedSourceValueSetResources) == 1 {
-		valueSet = &(*c.IncludedSourceValueSetResources)[0]
+	} else if len(*c.IncludedValueSetResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedValueSetResourcesReferencedBySource))
+	} else if len(*c.IncludedValueSetResourcesReferencedBySource) == 1 {
+		valueSet = &(*c.IncludedValueSetResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedTargetStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
-	if c.IncludedTargetStructureDefinitionResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedStructureDefinitionResourceReferencedByTarget() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedStructureDefinitionResourcesReferencedByTarget == nil {
 		err = errors.New("Included structuredefinitions not requested")
-	} else if len(*c.IncludedTargetStructureDefinitionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedTargetStructureDefinitionResources))
-	} else if len(*c.IncludedTargetStructureDefinitionResources) == 1 {
-		structureDefinition = &(*c.IncludedTargetStructureDefinitionResources)[0]
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedStructureDefinitionResourcesReferencedByTarget))
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedByTarget) == 1 {
+		structureDefinition = &(*c.IncludedStructureDefinitionResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedTargetValueSetResource() (valueSet *ValueSet, err error) {
-	if c.IncludedTargetValueSetResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedValueSetResourceReferencedByTarget() (valueSet *ValueSet, err error) {
+	if c.IncludedValueSetResourcesReferencedByTarget == nil {
 		err = errors.New("Included valuesets not requested")
-	} else if len(*c.IncludedTargetValueSetResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedTargetValueSetResources))
-	} else if len(*c.IncludedTargetValueSetResources) == 1 {
-		valueSet = &(*c.IncludedTargetValueSetResources)[0]
+	} else if len(*c.IncludedValueSetResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedValueSetResourcesReferencedByTarget))
+	} else if len(*c.IncludedValueSetResourcesReferencedByTarget) == 1 {
+		valueSet = &(*c.IncludedValueSetResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedSourceuriStructureDefinitionResource() (structureDefinition *StructureDefinition, err error) {
-	if c.IncludedSourceuriStructureDefinitionResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedStructureDefinitionResourceReferencedBySourceuri() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedStructureDefinitionResourcesReferencedBySourceuri == nil {
 		err = errors.New("Included structuredefinitions not requested")
-	} else if len(*c.IncludedSourceuriStructureDefinitionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedSourceuriStructureDefinitionResources))
-	} else if len(*c.IncludedSourceuriStructureDefinitionResources) == 1 {
-		structureDefinition = &(*c.IncludedSourceuriStructureDefinitionResources)[0]
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedBySourceuri) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedStructureDefinitionResourcesReferencedBySourceuri))
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedBySourceuri) == 1 {
+		structureDefinition = &(*c.IncludedStructureDefinitionResourcesReferencedBySourceuri)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedSourceuriValueSetResource() (valueSet *ValueSet, err error) {
-	if c.IncludedSourceuriValueSetResources == nil {
+func (c *ConceptMapPlusRelatedResources) GetIncludedValueSetResourceReferencedBySourceuri() (valueSet *ValueSet, err error) {
+	if c.IncludedValueSetResourcesReferencedBySourceuri == nil {
 		err = errors.New("Included valuesets not requested")
-	} else if len(*c.IncludedSourceuriValueSetResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedSourceuriValueSetResources))
-	} else if len(*c.IncludedSourceuriValueSetResources) == 1 {
-		valueSet = &(*c.IncludedSourceuriValueSetResources)[0]
+	} else if len(*c.IncludedValueSetResourcesReferencedBySourceuri) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*c.IncludedValueSetResourcesReferencedBySourceuri))
+	} else if len(*c.IncludedValueSetResourcesReferencedBySourceuri) == 1 {
+		valueSet = &(*c.IncludedValueSetResourcesReferencedBySourceuri)[0]
 	}
 	return
 }
 
-func (c *ConceptMapPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ConceptMapPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedSourceStructureDefinitionResources != nil {
-		for _, r := range *c.IncludedSourceStructureDefinitionResources {
+	if c.IncludedStructureDefinitionResourcesReferencedBySource != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSourceValueSetResources != nil {
-		for _, r := range *c.IncludedSourceValueSetResources {
+	if c.IncludedValueSetResourcesReferencedBySource != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedTargetStructureDefinitionResources != nil {
-		for _, r := range *c.IncludedTargetStructureDefinitionResources {
+	if c.IncludedStructureDefinitionResourcesReferencedByTarget != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedTargetValueSetResources != nil {
-		for _, r := range *c.IncludedTargetValueSetResources {
+	if c.IncludedValueSetResourcesReferencedByTarget != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedByTarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSourceuriStructureDefinitionResources != nil {
-		for _, r := range *c.IncludedSourceuriStructureDefinitionResources {
+	if c.IncludedStructureDefinitionResourcesReferencedBySourceuri != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSourceuriValueSetResources != nil {
-		for _, r := range *c.IncludedSourceuriValueSetResources {
+	if c.IncludedValueSetResourcesReferencedBySourceuri != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedBySourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConceptMapPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConceptMapPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedStructureDefinitionResourcesReferencedBySource != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedValueSetResourcesReferencedBySource != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedStructureDefinitionResourcesReferencedByTarget != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedValueSetResourcesReferencedByTarget != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedStructureDefinitionResourcesReferencedBySourceuri != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedValueSetResourcesReferencedBySourceuri != nil {
+		for _, r := range *c.IncludedValueSetResourcesReferencedBySourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/condition.go
+++ b/models/condition.go
@@ -114,80 +114,550 @@ type ConditionEvidenceComponent struct {
 }
 
 type ConditionPlus struct {
-	Condition             `bson:",inline"`
-	ConditionPlusIncludes `bson:",inline"`
+	Condition                     `bson:",inline"`
+	ConditionPlusRelatedResources `bson:",inline"`
 }
 
-type ConditionPlusIncludes struct {
-	IncludedEncounterResources            *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
-	IncludedAsserterPractitionerResources *[]Practitioner `bson:"_includedAsserterPractitionerResources,omitempty"`
-	IncludedAsserterPatientResources      *[]Patient      `bson:"_includedAsserterPatientResources,omitempty"`
-	IncludedPatientResources              *[]Patient      `bson:"_includedPatientResources,omitempty"`
+type ConditionPlusRelatedResources struct {
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedPractitionerResourcesReferencedByAsserter           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAsserter,omitempty"`
+	IncludedPatientResourcesReferencedByAsserter                *[]Patient               `bson:"_includedPatientResourcesReferencedByAsserter,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingCondition            *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingCondition,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingCondition       *[]EpisodeOfCare         `bson:"_revIncludedEpisodeOfCareResourcesReferencingCondition,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingCondition      *[]RiskAssessment        `bson:"_revIncludedRiskAssessmentResourcesReferencingCondition,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedEncounterResourcesReferencingCondition           *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingCondition,omitempty"`
+	RevIncludedEncounterResourcesReferencingIndication          *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingIndication,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingProblem    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingProblem,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ConditionPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if c.IncludedEncounterResources == nil {
+func (c *ConditionPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if c.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*c.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResources))
-	} else if len(*c.IncludedEncounterResources) == 1 {
-		encounter = &(*c.IncludedEncounterResources)[0]
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*c.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*c.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*c.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (c *ConditionPlusIncludes) GetIncludedAsserterPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedAsserterPractitionerResources == nil {
+func (c *ConditionPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAsserter() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByAsserter == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedAsserterPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedAsserterPractitionerResources))
-	} else if len(*c.IncludedAsserterPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedAsserterPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAsserter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByAsserter))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByAsserter) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByAsserter)[0]
 	}
 	return
 }
 
-func (c *ConditionPlusIncludes) GetIncludedAsserterPatientResource() (patient *Patient, err error) {
-	if c.IncludedAsserterPatientResources == nil {
+func (c *ConditionPlusRelatedResources) GetIncludedPatientResourceReferencedByAsserter() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByAsserter == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedAsserterPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedAsserterPatientResources))
-	} else if len(*c.IncludedAsserterPatientResources) == 1 {
-		patient = &(*c.IncludedAsserterPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByAsserter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByAsserter))
+	} else if len(*c.IncludedPatientResourcesReferencedByAsserter) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByAsserter)[0]
 	}
 	return
 }
 
-func (c *ConditionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *ConditionPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResources))
-	} else if len(*c.IncludedPatientResources) == 1 {
-		patient = &(*c.IncludedPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*c.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (c *ConditionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ConditionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingCondition() (carePlans []CarePlan, err error) {
+	if c.RevIncludedCarePlanResourcesReferencingCondition == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *c.RevIncludedCarePlanResourcesReferencingCondition
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingCondition() (episodeOfCares []EpisodeOfCare, err error) {
+	if c.RevIncludedEpisodeOfCareResourcesReferencingCondition == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *c.RevIncludedEpisodeOfCareResourcesReferencingCondition
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingCondition() (riskAssessments []RiskAssessment, err error) {
+	if c.RevIncludedRiskAssessmentResourcesReferencingCondition == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *c.RevIncludedRiskAssessmentResourcesReferencingCondition
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingCondition() (encounters []Encounter, err error) {
+	if c.RevIncludedEncounterResourcesReferencingCondition == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *c.RevIncludedEncounterResourcesReferencingCondition
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingIndication() (encounters []Encounter, err error) {
+	if c.RevIncludedEncounterResourcesReferencingIndication == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *c.RevIncludedEncounterResourcesReferencingIndication
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingProblem() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingProblem == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingProblem
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ConditionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedEncounterResources != nil {
-		for _, r := range *c.IncludedEncounterResources {
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAsserterPractitionerResources != nil {
-		for _, r := range *c.IncludedAsserterPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByAsserter != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAsserter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedAsserterPatientResources != nil {
-		for _, r := range *c.IncludedAsserterPatientResources {
+	if c.IncludedPatientResourcesReferencedByAsserter != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAsserter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConditionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEpisodeOfCareResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedRiskAssessmentResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEncounterResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedEncounterResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEncounterResourcesReferencingIndication != nil {
+		for _, r := range *c.RevIncludedEncounterResourcesReferencingIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConditionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedByAsserter != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByAsserter != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCarePlanResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedCarePlanResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEpisodeOfCareResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedRiskAssessmentResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEncounterResourcesReferencingCondition != nil {
+		for _, r := range *c.RevIncludedEncounterResourcesReferencingCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedEncounterResourcesReferencingIndication != nil {
+		for _, r := range *c.RevIncludedEncounterResourcesReferencingIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/conformance.go
+++ b/models/conformance.go
@@ -208,44 +208,384 @@ type ConformanceDocumentComponent struct {
 }
 
 type ConformancePlus struct {
-	Conformance             `bson:",inline"`
-	ConformancePlusIncludes `bson:",inline"`
+	Conformance                     `bson:",inline"`
+	ConformancePlusRelatedResources `bson:",inline"`
 }
 
-type ConformancePlusIncludes struct {
-	IncludedProfileResources          *[]StructureDefinition `bson:"_includedProfileResources,omitempty"`
-	IncludedSupportedprofileResources *[]StructureDefinition `bson:"_includedSupportedprofileResources,omitempty"`
+type ConformancePlusRelatedResources struct {
+	IncludedStructureDefinitionResourcesReferencedByProfile          *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedByProfile,omitempty"`
+	IncludedStructureDefinitionResourcesReferencedBySupportedprofile *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedBySupportedprofile,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                  *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref        *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref        *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                          *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref       *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                       *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                      *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference               *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                  *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated           *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment          *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject      *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest            *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger         *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                 *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ConformancePlusIncludes) GetIncludedProfileResource() (structureDefinition *StructureDefinition, err error) {
-	if c.IncludedProfileResources == nil {
+func (c *ConformancePlusRelatedResources) GetIncludedStructureDefinitionResourceReferencedByProfile() (structureDefinition *StructureDefinition, err error) {
+	if c.IncludedStructureDefinitionResourcesReferencedByProfile == nil {
 		err = errors.New("Included structuredefinitions not requested")
-	} else if len(*c.IncludedProfileResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedProfileResources))
-	} else if len(*c.IncludedProfileResources) == 1 {
-		structureDefinition = &(*c.IncludedProfileResources)[0]
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedByProfile) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*c.IncludedStructureDefinitionResourcesReferencedByProfile))
+	} else if len(*c.IncludedStructureDefinitionResourcesReferencedByProfile) == 1 {
+		structureDefinition = &(*c.IncludedStructureDefinitionResourcesReferencedByProfile)[0]
 	}
 	return
 }
 
-func (c *ConformancePlusIncludes) GetIncludedSupportedprofileResources() (structureDefinitions []StructureDefinition, err error) {
-	if c.IncludedSupportedprofileResources == nil {
+func (c *ConformancePlusRelatedResources) GetIncludedStructureDefinitionResourcesReferencedBySupportedprofile() (structureDefinitions []StructureDefinition, err error) {
+	if c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile == nil {
 		err = errors.New("Included structureDefinitions not requested")
 	} else {
-		structureDefinitions = *c.IncludedSupportedprofileResources
+		structureDefinitions = *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile
 	}
 	return
 }
 
-func (c *ConformancePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ConformancePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ConformancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedProfileResources != nil {
-		for _, r := range *c.IncludedProfileResources {
+	if c.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSupportedprofileResources != nil {
-		for _, r := range *c.IncludedSupportedprofileResources {
+	if c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConformancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ConformancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile != nil {
+		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/contract.go
+++ b/models/contract.go
@@ -168,263 +168,688 @@ type ContractComputableLanguageComponent struct {
 }
 
 type ContractPlus struct {
-	Contract             `bson:",inline"`
-	ContractPlusIncludes `bson:",inline"`
+	Contract                     `bson:",inline"`
+	ContractPlusRelatedResources `bson:",inline"`
 }
 
-type ContractPlusIncludes struct {
-	IncludedActorPractitionerResources   *[]Practitioner  `bson:"_includedActorPractitionerResources,omitempty"`
-	IncludedActorGroupResources          *[]Group         `bson:"_includedActorGroupResources,omitempty"`
-	IncludedActorOrganizationResources   *[]Organization  `bson:"_includedActorOrganizationResources,omitempty"`
-	IncludedActorDeviceResources         *[]Device        `bson:"_includedActorDeviceResources,omitempty"`
-	IncludedActorPatientResources        *[]Patient       `bson:"_includedActorPatientResources,omitempty"`
-	IncludedActorSubstanceResources      *[]Substance     `bson:"_includedActorSubstanceResources,omitempty"`
-	IncludedActorContractResources       *[]Contract      `bson:"_includedActorContractResources,omitempty"`
-	IncludedActorRelatedPersonResources  *[]RelatedPerson `bson:"_includedActorRelatedPersonResources,omitempty"`
-	IncludedActorLocationResources       *[]Location      `bson:"_includedActorLocationResources,omitempty"`
-	IncludedSubjectResources             *[]Patient       `bson:"_includedSubjectResources,omitempty"`
-	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedSignerPractitionerResources  *[]Practitioner  `bson:"_includedSignerPractitionerResources,omitempty"`
-	IncludedSignerOrganizationResources  *[]Organization  `bson:"_includedSignerOrganizationResources,omitempty"`
-	IncludedSignerPatientResources       *[]Patient       `bson:"_includedSignerPatientResources,omitempty"`
-	IncludedSignerRelatedPersonResources *[]RelatedPerson `bson:"_includedSignerRelatedPersonResources,omitempty"`
+type ContractPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByActor              *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActor,omitempty"`
+	IncludedGroupResourcesReferencedByActor                     *[]Group                 `bson:"_includedGroupResourcesReferencedByActor,omitempty"`
+	IncludedOrganizationResourcesReferencedByActor              *[]Organization          `bson:"_includedOrganizationResourcesReferencedByActor,omitempty"`
+	IncludedDeviceResourcesReferencedByActor                    *[]Device                `bson:"_includedDeviceResourcesReferencedByActor,omitempty"`
+	IncludedPatientResourcesReferencedByActor                   *[]Patient               `bson:"_includedPatientResourcesReferencedByActor,omitempty"`
+	IncludedSubstanceResourcesReferencedByActor                 *[]Substance             `bson:"_includedSubstanceResourcesReferencedByActor,omitempty"`
+	IncludedContractResourcesReferencedByActor                  *[]Contract              `bson:"_includedContractResourcesReferencedByActor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByActor             *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByActor,omitempty"`
+	IncludedLocationResourcesReferencedByActor                  *[]Location              `bson:"_includedLocationResourcesReferencedByActor,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedBySigner             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySigner,omitempty"`
+	IncludedOrganizationResourcesReferencedBySigner             *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySigner,omitempty"`
+	IncludedPatientResourcesReferencedBySigner                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySigner,omitempty"`
+	IncludedRelatedPersonResourcesReferencedBySigner            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedBySigner,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedContractResourcesReferencingActor                *[]Contract              `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedActorPractitionerResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPractitionerResourceReferencedByActor() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedByActor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedActorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedActorPractitionerResources))
-	} else if len(*c.IncludedActorPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedActorPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedByActor))
+	} else if len(*c.IncludedPractitionerResourcesReferencedByActor) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorGroupResource() (group *Group, err error) {
-	if c.IncludedActorGroupResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedGroupResourceReferencedByActor() (group *Group, err error) {
+	if c.IncludedGroupResourcesReferencedByActor == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*c.IncludedActorGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedActorGroupResources))
-	} else if len(*c.IncludedActorGroupResources) == 1 {
-		group = &(*c.IncludedActorGroupResources)[0]
+	} else if len(*c.IncludedGroupResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*c.IncludedGroupResourcesReferencedByActor))
+	} else if len(*c.IncludedGroupResourcesReferencedByActor) == 1 {
+		group = &(*c.IncludedGroupResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedActorOrganizationResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedOrganizationResourceReferencedByActor() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByActor == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedActorOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedActorOrganizationResources))
-	} else if len(*c.IncludedActorOrganizationResources) == 1 {
-		organization = &(*c.IncludedActorOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedByActor))
+	} else if len(*c.IncludedOrganizationResourcesReferencedByActor) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
-	if c.IncludedActorDeviceResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedDeviceResourceReferencedByActor() (device *Device, err error) {
+	if c.IncludedDeviceResourcesReferencedByActor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*c.IncludedActorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedActorDeviceResources))
-	} else if len(*c.IncludedActorDeviceResources) == 1 {
-		device = &(*c.IncludedActorDeviceResources)[0]
+	} else if len(*c.IncludedDeviceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*c.IncludedDeviceResourcesReferencedByActor))
+	} else if len(*c.IncludedDeviceResourcesReferencedByActor) == 1 {
+		device = &(*c.IncludedDeviceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
-	if c.IncludedActorPatientResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPatientResourceReferencedByActor() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByActor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedActorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedActorPatientResources))
-	} else if len(*c.IncludedActorPatientResources) == 1 {
-		patient = &(*c.IncludedActorPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedByActor))
+	} else if len(*c.IncludedPatientResourcesReferencedByActor) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorSubstanceResource() (substance *Substance, err error) {
-	if c.IncludedActorSubstanceResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedSubstanceResourceReferencedByActor() (substance *Substance, err error) {
+	if c.IncludedSubstanceResourcesReferencedByActor == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*c.IncludedActorSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*c.IncludedActorSubstanceResources))
-	} else if len(*c.IncludedActorSubstanceResources) == 1 {
-		substance = &(*c.IncludedActorSubstanceResources)[0]
+	} else if len(*c.IncludedSubstanceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*c.IncludedSubstanceResourcesReferencedByActor))
+	} else if len(*c.IncludedSubstanceResourcesReferencedByActor) == 1 {
+		substance = &(*c.IncludedSubstanceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorContractResource() (contract *Contract, err error) {
-	if c.IncludedActorContractResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedContractResourceReferencedByActor() (contract *Contract, err error) {
+	if c.IncludedContractResourcesReferencedByActor == nil {
 		err = errors.New("Included contracts not requested")
-	} else if len(*c.IncludedActorContractResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 contract, but found %d", len(*c.IncludedActorContractResources))
-	} else if len(*c.IncludedActorContractResources) == 1 {
-		contract = &(*c.IncludedActorContractResources)[0]
+	} else if len(*c.IncludedContractResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 contract, but found %d", len(*c.IncludedContractResourcesReferencedByActor))
+	} else if len(*c.IncludedContractResourcesReferencedByActor) == 1 {
+		contract = &(*c.IncludedContractResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedActorRelatedPersonResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByActor() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedByActor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedActorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedActorRelatedPersonResources))
-	} else if len(*c.IncludedActorRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedActorRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedByActor))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedByActor) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
-	if c.IncludedActorLocationResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedLocationResourceReferencedByActor() (location *Location, err error) {
+	if c.IncludedLocationResourcesReferencedByActor == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*c.IncludedActorLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*c.IncludedActorLocationResources))
-	} else if len(*c.IncludedActorLocationResources) == 1 {
-		location = &(*c.IncludedActorLocationResources)[0]
+	} else if len(*c.IncludedLocationResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*c.IncludedLocationResourcesReferencedByActor))
+	} else if len(*c.IncludedLocationResourcesReferencedByActor) == 1 {
+		location = &(*c.IncludedLocationResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedSubjectResources() (patients []Patient, err error) {
-	if c.IncludedSubjectResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPatientResourcesReferencedBySubject() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedSubjectResources
+		patients = *c.IncludedPatientResourcesReferencedBySubject
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedPatientResources() (patients []Patient, err error) {
-	if c.IncludedPatientResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPatientResourcesReferencedByPatient() (patients []Patient, err error) {
+	if c.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *c.IncludedPatientResources
+		patients = *c.IncludedPatientResourcesReferencedByPatient
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedSignerPractitionerResource() (practitioner *Practitioner, err error) {
-	if c.IncludedSignerPractitionerResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySigner() (practitioner *Practitioner, err error) {
+	if c.IncludedPractitionerResourcesReferencedBySigner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*c.IncludedSignerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedSignerPractitionerResources))
-	} else if len(*c.IncludedSignerPractitionerResources) == 1 {
-		practitioner = &(*c.IncludedSignerPractitionerResources)[0]
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySigner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*c.IncludedPractitionerResourcesReferencedBySigner))
+	} else if len(*c.IncludedPractitionerResourcesReferencedBySigner) == 1 {
+		practitioner = &(*c.IncludedPractitionerResourcesReferencedBySigner)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedSignerOrganizationResource() (organization *Organization, err error) {
-	if c.IncludedSignerOrganizationResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySigner() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedBySigner == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedSignerOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedSignerOrganizationResources))
-	} else if len(*c.IncludedSignerOrganizationResources) == 1 {
-		organization = &(*c.IncludedSignerOrganizationResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySigner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedBySigner))
+	} else if len(*c.IncludedOrganizationResourcesReferencedBySigner) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedBySigner)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedSignerPatientResource() (patient *Patient, err error) {
-	if c.IncludedSignerPatientResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedPatientResourceReferencedBySigner() (patient *Patient, err error) {
+	if c.IncludedPatientResourcesReferencedBySigner == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*c.IncludedSignerPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedSignerPatientResources))
-	} else if len(*c.IncludedSignerPatientResources) == 1 {
-		patient = &(*c.IncludedSignerPatientResources)[0]
+	} else if len(*c.IncludedPatientResourcesReferencedBySigner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*c.IncludedPatientResourcesReferencedBySigner))
+	} else if len(*c.IncludedPatientResourcesReferencedBySigner) == 1 {
+		patient = &(*c.IncludedPatientResourcesReferencedBySigner)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedSignerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if c.IncludedSignerRelatedPersonResources == nil {
+func (c *ContractPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedBySigner() (relatedPerson *RelatedPerson, err error) {
+	if c.IncludedRelatedPersonResourcesReferencedBySigner == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*c.IncludedSignerRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedSignerRelatedPersonResources))
-	} else if len(*c.IncludedSignerRelatedPersonResources) == 1 {
-		relatedPerson = &(*c.IncludedSignerRelatedPersonResources)[0]
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySigner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*c.IncludedRelatedPersonResourcesReferencedBySigner))
+	} else if len(*c.IncludedRelatedPersonResourcesReferencedBySigner) == 1 {
+		relatedPerson = &(*c.IncludedRelatedPersonResourcesReferencedBySigner)[0]
 	}
 	return
 }
 
-func (c *ContractPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *ContractPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if c.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *c.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *ContractPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedActorPractitionerResources != nil {
-		for _, r := range *c.IncludedActorPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorGroupResources != nil {
-		for _, r := range *c.IncludedActorGroupResources {
+	if c.IncludedGroupResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorOrganizationResources != nil {
-		for _, r := range *c.IncludedActorOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorDeviceResources != nil {
-		for _, r := range *c.IncludedActorDeviceResources {
+	if c.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorPatientResources != nil {
-		for _, r := range *c.IncludedActorPatientResources {
+	if c.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorSubstanceResources != nil {
-		for _, r := range *c.IncludedActorSubstanceResources {
+	if c.IncludedSubstanceResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedSubstanceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorContractResources != nil {
-		for _, r := range *c.IncludedActorContractResources {
+	if c.IncludedContractResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedContractResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorRelatedPersonResources != nil {
-		for _, r := range *c.IncludedActorRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedActorLocationResources != nil {
-		for _, r := range *c.IncludedActorLocationResources {
+	if c.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedLocationResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSubjectResources != nil {
-		for _, r := range *c.IncludedSubjectResources {
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedPatientResources != nil {
-		for _, r := range *c.IncludedPatientResources {
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSignerPractitionerResources != nil {
-		for _, r := range *c.IncludedSignerPractitionerResources {
+	if c.IncludedPractitionerResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySigner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSignerOrganizationResources != nil {
-		for _, r := range *c.IncludedSignerOrganizationResources {
+	if c.IncludedOrganizationResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySigner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSignerPatientResources != nil {
-		for _, r := range *c.IncludedSignerPatientResources {
+	if c.IncludedPatientResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySigner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if c.IncludedSignerRelatedPersonResources != nil {
-		for _, r := range *c.IncludedSignerRelatedPersonResources {
+	if c.IncludedRelatedPersonResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ContractPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *c.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *ContractPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedGroupResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedGroupResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedDeviceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedSubstanceResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedSubstanceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedContractResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedContractResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *c.IncludedLocationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPractitionerResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedPractitionerResourcesReferencedBySigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedOrganizationResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedBySigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedPatientResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedPatientResourcesReferencedBySigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.IncludedRelatedPersonResourcesReferencedBySigner != nil {
+		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *c.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/coverage.go
+++ b/models/coverage.go
@@ -93,29 +93,364 @@ func (x *Coverage) checkResourceType() error {
 }
 
 type CoveragePlus struct {
-	Coverage             `bson:",inline"`
-	CoveragePlusIncludes `bson:",inline"`
+	Coverage                     `bson:",inline"`
+	CoveragePlusRelatedResources `bson:",inline"`
 }
 
-type CoveragePlusIncludes struct {
-	IncludedIssuerResources *[]Organization `bson:"_includedIssuerResources,omitempty"`
+type CoveragePlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByIssuer             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByIssuer,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (c *CoveragePlusIncludes) GetIncludedIssuerResource() (organization *Organization, err error) {
-	if c.IncludedIssuerResources == nil {
+func (c *CoveragePlusRelatedResources) GetIncludedOrganizationResourceReferencedByIssuer() (organization *Organization, err error) {
+	if c.IncludedOrganizationResourcesReferencedByIssuer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*c.IncludedIssuerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedIssuerResources))
-	} else if len(*c.IncludedIssuerResources) == 1 {
-		organization = &(*c.IncludedIssuerResources)[0]
+	} else if len(*c.IncludedOrganizationResourcesReferencedByIssuer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*c.IncludedOrganizationResourcesReferencedByIssuer))
+	} else if len(*c.IncludedOrganizationResourcesReferencedByIssuer) == 1 {
+		organization = &(*c.IncludedOrganizationResourcesReferencedByIssuer)[0]
 	}
 	return
 }
 
-func (c *CoveragePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (c *CoveragePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if c.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *c.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *c.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if c.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *c.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if c.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *c.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if c.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *c.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if c.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *c.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if c.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *c.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *c.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *c.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if c.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *c.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *c.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if c.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *c.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (c *CoveragePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if c.IncludedIssuerResources != nil {
-		for _, r := range *c.IncludedIssuerResources {
+	if c.IncludedOrganizationResourcesReferencedByIssuer != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByIssuer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CoveragePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (c *CoveragePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if c.IncludedOrganizationResourcesReferencedByIssuer != nil {
+		for _, r := range *c.IncludedOrganizationResourcesReferencedByIssuer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *c.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/dataelement.go
+++ b/models/dataelement.go
@@ -105,14 +105,344 @@ type DataElementMappingComponent struct {
 }
 
 type DataElementPlus struct {
-	DataElement             `bson:",inline"`
-	DataElementPlusIncludes `bson:",inline"`
+	DataElement                     `bson:",inline"`
+	DataElementPlusRelatedResources `bson:",inline"`
 }
 
-type DataElementPlusIncludes struct {
+type DataElementPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DataElementPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DataElementPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DataElementPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (d *DataElementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DataElementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/detectedissue.go
+++ b/models/detectedissue.go
@@ -95,63 +95,408 @@ type DetectedIssueMitigationComponent struct {
 }
 
 type DetectedIssuePlus struct {
-	DetectedIssue             `bson:",inline"`
-	DetectedIssuePlusIncludes `bson:",inline"`
+	DetectedIssue                     `bson:",inline"`
+	DetectedIssuePlusRelatedResources `bson:",inline"`
 }
 
-type DetectedIssuePlusIncludes struct {
-	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedAuthorPractitionerResources *[]Practitioner `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorDeviceResources       *[]Device       `bson:"_includedAuthorDeviceResources,omitempty"`
+type DetectedIssuePlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DetectedIssuePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DetectedIssuePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DetectedIssuePlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
-	if d.IncludedAuthorPractitionerResources == nil {
+func (d *DetectedIssuePlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedAuthorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedAuthorPractitionerResources))
-	} else if len(*d.IncludedAuthorPractitionerResources) == 1 {
-		practitioner = &(*d.IncludedAuthorPractitionerResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (d *DetectedIssuePlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
-	if d.IncludedAuthorDeviceResources == nil {
+func (d *DetectedIssuePlusRelatedResources) GetIncludedDeviceResourceReferencedByAuthor() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedAuthorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedAuthorDeviceResources))
-	} else if len(*d.IncludedAuthorDeviceResources) == 1 {
-		device = &(*d.IncludedAuthorDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedByAuthor))
+	} else if len(*d.IncludedDeviceResourcesReferencedByAuthor) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (d *DetectedIssuePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *d.IncludedAuthorPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorDeviceResources != nil {
-		for _, r := range *d.IncludedAuthorDeviceResources {
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DetectedIssuePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/device.go
+++ b/models/device.go
@@ -95,63 +95,1248 @@ func (x *Device) checkResourceType() error {
 }
 
 type DevicePlus struct {
-	Device             `bson:",inline"`
-	DevicePlusIncludes `bson:",inline"`
+	Device                     `bson:",inline"`
+	DevicePlusRelatedResources `bson:",inline"`
 }
 
-type DevicePlusIncludes struct {
-	IncludedPatientResources      *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
-	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+type DevicePlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                   *[]Patient                  `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization         *[]Organization             `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	IncludedLocationResourcesReferencedByLocation                 *[]Location                 `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor               *[]Appointment              `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject                 *[]Account                  `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingAgent                *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingAgent,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget               *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref     *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingSubject        *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingAuthor         *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref     *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedSpecimenResourcesReferencingSubject                *[]Specimen                 `bson:"_revIncludedSpecimenResourcesReferencingSubject,omitempty"`
+	RevIncludedListResourcesReferencingItem                       *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingSubject                    *[]List                     `bson:"_revIncludedListResourcesReferencingSubject,omitempty"`
+	RevIncludedListResourcesReferencingSource                     *[]List                     `bson:"_revIncludedListResourcesReferencingSource,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingSubject       *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthor        *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref    *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSubject                   *[]Order                    `bson:"_revIncludedOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                    *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedOrderResourcesReferencingTarget                    *[]Order                    `bson:"_revIncludedOrderResourcesReferencingTarget,omitempty"`
+	RevIncludedMediaResourcesReferencingSubject                   *[]Media                    `bson:"_revIncludedMediaResourcesReferencingSubject,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingOrderer        *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingOrderer,omitempty"`
+	RevIncludedDeviceUseRequestResourcesReferencingDevice         *[]DeviceUseRequest         `bson:"_revIncludedDeviceUseRequestResourcesReferencingDevice,omitempty"`
+	RevIncludedDeviceMetricResourcesReferencingSource             *[]DeviceMetric             `bson:"_revIncludedDeviceMetricResourcesReferencingSource,omitempty"`
+	RevIncludedFlagResourcesReferencingAuthor                     *[]Flag                     `bson:"_revIncludedFlagResourcesReferencingAuthor,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor       *[]AppointmentResponse      `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedObservationResourcesReferencingSubject             *[]Observation              `bson:"_revIncludedObservationResourcesReferencingSubject,omitempty"`
+	RevIncludedObservationResourcesReferencingDevice              *[]Observation              `bson:"_revIncludedObservationResourcesReferencingDevice,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingDevice *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingDevice,omitempty"`
+	RevIncludedContractResourcesReferencingActor                  *[]Contract                 `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSender     *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRecipient  *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingPerformer        *[]RiskAssessment           `bson:"_revIncludedRiskAssessmentResourcesReferencingPerformer,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                   *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedGroupResourcesReferencingMember                    *[]Group                    `bson:"_revIncludedGroupResourcesReferencingMember,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingSubject        *[]DiagnosticReport         `bson:"_revIncludedDiagnosticReportResourcesReferencingSubject,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingAuthor   *[]ImagingObjectSelection   `bson:"_revIncludedImagingObjectSelectionResourcesReferencingAuthor,omitempty"`
+	RevIncludedDeviceComponentResourcesReferencingSource          *[]DeviceComponent          `bson:"_revIncludedDeviceComponentResourcesReferencingSource,omitempty"`
+	RevIncludedAuditEventResourcesReferencingParticipant          *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference            *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSender            *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient         *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject             *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingAuthor              *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingAuthor,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry               *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingAuthor            *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingAuthor,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated        *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSubject         *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingActorPath1      *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingActorPath1,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingActorPath2      *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingActorPath2,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment       *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingWho               *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingWho,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject   *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingAuthor    *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingAuthor,omitempty"`
+	RevIncludedDeviceUseStatementResourcesReferencingDevice       *[]DeviceUseStatement       `bson:"_revIncludedDeviceUseStatementResourcesReferencingDevice,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest         *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                  *[]Schedule                 `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger      *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData              *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingTarget            *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingTarget,omitempty"`
 }
 
-func (d *DevicePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DevicePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DevicePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if d.IncludedOrganizationResources == nil {
+func (d *DevicePlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*d.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResources))
-	} else if len(*d.IncludedOrganizationResources) == 1 {
-		organization = &(*d.IncludedOrganizationResources)[0]
+	} else if len(*d.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*d.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*d.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (d *DevicePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if d.IncludedLocationResources == nil {
+func (d *DevicePlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if d.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*d.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedLocationResources))
-	} else if len(*d.IncludedLocationResources) == 1 {
-		location = &(*d.IncludedLocationResources)[0]
+	} else if len(*d.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*d.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*d.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (d *DevicePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DevicePlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if d.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *d.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if d.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *d.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingAgent() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingAgent == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingAgent
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingSubject() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingAuthor() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingSubject() (specimen []Specimen, err error) {
+	if d.RevIncludedSpecimenResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *d.RevIncludedSpecimenResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedListResourcesReferencingSubject() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedListResourcesReferencingSource() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingSource
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingSubject() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthor() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedOrderResourcesReferencingSubject() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedOrderResourcesReferencingTarget() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedMediaResourcesReferencingSubject() (media []Media, err error) {
+	if d.RevIncludedMediaResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *d.RevIncludedMediaResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingOrderer() (procedureRequests []ProcedureRequest, err error) {
+	if d.RevIncludedProcedureRequestResourcesReferencingOrderer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *d.RevIncludedProcedureRequestResourcesReferencingOrderer
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDeviceUseRequestResourcesReferencingDevice() (deviceUseRequests []DeviceUseRequest, err error) {
+	if d.RevIncludedDeviceUseRequestResourcesReferencingDevice == nil {
+		err = errors.New("RevIncluded deviceUseRequests not requested")
+	} else {
+		deviceUseRequests = *d.RevIncludedDeviceUseRequestResourcesReferencingDevice
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDeviceMetricResourcesReferencingSource() (deviceMetrics []DeviceMetric, err error) {
+	if d.RevIncludedDeviceMetricResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded deviceMetrics not requested")
+	} else {
+		deviceMetrics = *d.RevIncludedDeviceMetricResourcesReferencingSource
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedFlagResourcesReferencingAuthor() (flags []Flag, err error) {
+	if d.RevIncludedFlagResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *d.RevIncludedFlagResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if d.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *d.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedObservationResourcesReferencingSubject() (observations []Observation, err error) {
+	if d.RevIncludedObservationResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *d.RevIncludedObservationResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedObservationResourcesReferencingDevice() (observations []Observation, err error) {
+	if d.RevIncludedObservationResourcesReferencingDevice == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *d.RevIncludedObservationResourcesReferencingDevice
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingDevice() (medicationAdministrations []MedicationAdministration, err error) {
+	if d.RevIncludedMedicationAdministrationResourcesReferencingDevice == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *d.RevIncludedMedicationAdministrationResourcesReferencingDevice
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if d.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *d.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSender() (communicationRequests []CommunicationRequest, err error) {
+	if d.RevIncludedCommunicationRequestResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *d.RevIncludedCommunicationRequestResourcesReferencingSender
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRecipient() (communicationRequests []CommunicationRequest, err error) {
+	if d.RevIncludedCommunicationRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *d.RevIncludedCommunicationRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingPerformer() (riskAssessments []RiskAssessment, err error) {
+	if d.RevIncludedRiskAssessmentResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *d.RevIncludedRiskAssessmentResourcesReferencingPerformer
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedGroupResourcesReferencingMember() (groups []Group, err error) {
+	if d.RevIncludedGroupResourcesReferencingMember == nil {
+		err = errors.New("RevIncluded groups not requested")
+	} else {
+		groups = *d.RevIncludedGroupResourcesReferencingMember
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingSubject() (diagnosticReports []DiagnosticReport, err error) {
+	if d.RevIncludedDiagnosticReportResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *d.RevIncludedDiagnosticReportResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingAuthor() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDeviceComponentResourcesReferencingSource() (deviceComponents []DeviceComponent, err error) {
+	if d.RevIncludedDeviceComponentResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded deviceComponents not requested")
+	} else {
+		deviceComponents = *d.RevIncludedDeviceComponentResourcesReferencingSource
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingParticipant() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingParticipant
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSender() (communications []Communication, err error) {
+	if d.RevIncludedCommunicationResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *d.RevIncludedCommunicationResourcesReferencingSender
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if d.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *d.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAuthor() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingAuthor() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSubject() (diagnosticOrders []DiagnosticOrder, err error) {
+	if d.RevIncludedDiagnosticOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *d.RevIncludedDiagnosticOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingActorPath1() (diagnosticOrders []DiagnosticOrder, err error) {
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingActorPath2() (diagnosticOrders []DiagnosticOrder, err error) {
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingWho() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingWho == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingWho
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingAuthor() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedDeviceUseStatementResourcesReferencingDevice() (deviceUseStatements []DeviceUseStatement, err error) {
+	if d.RevIncludedDeviceUseStatementResourcesReferencingDevice == nil {
+		err = errors.New("RevIncluded deviceUseStatements not requested")
+	} else {
+		deviceUseStatements = *d.RevIncludedDeviceUseStatementResourcesReferencingDevice
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if d.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *d.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingTarget() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DevicePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedOrganizationResources != nil {
-		for _, r := range *d.IncludedOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedLocationResources != nil {
-		for _, r := range *d.IncludedLocationResources {
+	if d.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DevicePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceUseRequestResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceMetricResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMedicationAdministrationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
+		for _, r := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *d.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceComponentResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *d.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceUseStatementResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DevicePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceUseRequestResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceMetricResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMedicationAdministrationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
+		for _, r := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *d.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceComponentResourcesReferencingSource != nil {
+		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *d.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
+		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceUseStatementResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *d.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/devicecomponent.go
+++ b/models/devicecomponent.go
@@ -95,46 +95,426 @@ type DeviceComponentProductionSpecificationComponent struct {
 }
 
 type DeviceComponentPlus struct {
-	DeviceComponent             `bson:",inline"`
-	DeviceComponentPlusIncludes `bson:",inline"`
+	DeviceComponent                     `bson:",inline"`
+	DeviceComponentPlusRelatedResources `bson:",inline"`
 }
 
-type DeviceComponentPlusIncludes struct {
-	IncludedParentResources *[]DeviceComponent `bson:"_includedParentResources,omitempty"`
-	IncludedSourceResources *[]Device          `bson:"_includedSourceResources,omitempty"`
+type DeviceComponentPlusRelatedResources struct {
+	IncludedDeviceComponentResourcesReferencedByParent          *[]DeviceComponent       `bson:"_includedDeviceComponentResourcesReferencedByParent,omitempty"`
+	IncludedDeviceResourcesReferencedBySource                   *[]Device                `bson:"_includedDeviceResourcesReferencedBySource,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedDeviceMetricResourcesReferencingParent           *[]DeviceMetric          `bson:"_revIncludedDeviceMetricResourcesReferencingParent,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDeviceComponentResourcesReferencingParent        *[]DeviceComponent       `bson:"_revIncludedDeviceComponentResourcesReferencingParent,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DeviceComponentPlusIncludes) GetIncludedParentResource() (deviceComponent *DeviceComponent, err error) {
-	if d.IncludedParentResources == nil {
+func (d *DeviceComponentPlusRelatedResources) GetIncludedDeviceComponentResourceReferencedByParent() (deviceComponent *DeviceComponent, err error) {
+	if d.IncludedDeviceComponentResourcesReferencedByParent == nil {
 		err = errors.New("Included devicecomponents not requested")
-	} else if len(*d.IncludedParentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 deviceComponent, but found %d", len(*d.IncludedParentResources))
-	} else if len(*d.IncludedParentResources) == 1 {
-		deviceComponent = &(*d.IncludedParentResources)[0]
+	} else if len(*d.IncludedDeviceComponentResourcesReferencedByParent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceComponent, but found %d", len(*d.IncludedDeviceComponentResourcesReferencedByParent))
+	} else if len(*d.IncludedDeviceComponentResourcesReferencedByParent) == 1 {
+		deviceComponent = &(*d.IncludedDeviceComponentResourcesReferencedByParent)[0]
 	}
 	return
 }
 
-func (d *DeviceComponentPlusIncludes) GetIncludedSourceResource() (device *Device, err error) {
-	if d.IncludedSourceResources == nil {
+func (d *DeviceComponentPlusRelatedResources) GetIncludedDeviceResourceReferencedBySource() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySource == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSourceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSourceResources))
-	} else if len(*d.IncludedSourceResources) == 1 {
-		device = &(*d.IncludedSourceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySource))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySource) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (d *DeviceComponentPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDeviceMetricResourcesReferencingParent() (deviceMetrics []DeviceMetric, err error) {
+	if d.RevIncludedDeviceMetricResourcesReferencingParent == nil {
+		err = errors.New("RevIncluded deviceMetrics not requested")
+	} else {
+		deviceMetrics = *d.RevIncludedDeviceMetricResourcesReferencingParent
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDeviceComponentResourcesReferencingParent() (deviceComponents []DeviceComponent, err error) {
+	if d.RevIncludedDeviceComponentResourcesReferencingParent == nil {
+		err = errors.New("RevIncluded deviceComponents not requested")
+	} else {
+		deviceComponents = *d.RevIncludedDeviceComponentResourcesReferencingParent
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedParentResources != nil {
-		for _, r := range *d.IncludedParentResources {
+	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
+		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSourceResources != nil {
-		for _, r := range *d.IncludedSourceResources {
+	if d.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceMetricResourcesReferencingParent != nil {
+		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceComponentResourcesReferencingParent != nil {
+		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceComponentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
+		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceMetricResourcesReferencingParent != nil {
+		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDeviceComponentResourcesReferencingParent != nil {
+		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/devicemetric.go
+++ b/models/devicemetric.go
@@ -95,46 +95,406 @@ type DeviceMetricCalibrationComponent struct {
 }
 
 type DeviceMetricPlus struct {
-	DeviceMetric             `bson:",inline"`
-	DeviceMetricPlusIncludes `bson:",inline"`
+	DeviceMetric                     `bson:",inline"`
+	DeviceMetricPlusRelatedResources `bson:",inline"`
 }
 
-type DeviceMetricPlusIncludes struct {
-	IncludedParentResources *[]DeviceComponent `bson:"_includedParentResources,omitempty"`
-	IncludedSourceResources *[]Device          `bson:"_includedSourceResources,omitempty"`
+type DeviceMetricPlusRelatedResources struct {
+	IncludedDeviceComponentResourcesReferencedByParent          *[]DeviceComponent       `bson:"_includedDeviceComponentResourcesReferencedByParent,omitempty"`
+	IncludedDeviceResourcesReferencedBySource                   *[]Device                `bson:"_includedDeviceResourcesReferencedBySource,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedObservationResourcesReferencingDevice            *[]Observation           `bson:"_revIncludedObservationResourcesReferencingDevice,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DeviceMetricPlusIncludes) GetIncludedParentResource() (deviceComponent *DeviceComponent, err error) {
-	if d.IncludedParentResources == nil {
+func (d *DeviceMetricPlusRelatedResources) GetIncludedDeviceComponentResourceReferencedByParent() (deviceComponent *DeviceComponent, err error) {
+	if d.IncludedDeviceComponentResourcesReferencedByParent == nil {
 		err = errors.New("Included devicecomponents not requested")
-	} else if len(*d.IncludedParentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 deviceComponent, but found %d", len(*d.IncludedParentResources))
-	} else if len(*d.IncludedParentResources) == 1 {
-		deviceComponent = &(*d.IncludedParentResources)[0]
+	} else if len(*d.IncludedDeviceComponentResourcesReferencedByParent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceComponent, but found %d", len(*d.IncludedDeviceComponentResourcesReferencedByParent))
+	} else if len(*d.IncludedDeviceComponentResourcesReferencedByParent) == 1 {
+		deviceComponent = &(*d.IncludedDeviceComponentResourcesReferencedByParent)[0]
 	}
 	return
 }
 
-func (d *DeviceMetricPlusIncludes) GetIncludedSourceResource() (device *Device, err error) {
-	if d.IncludedSourceResources == nil {
+func (d *DeviceMetricPlusRelatedResources) GetIncludedDeviceResourceReferencedBySource() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySource == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSourceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSourceResources))
-	} else if len(*d.IncludedSourceResources) == 1 {
-		device = &(*d.IncludedSourceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySource))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySource) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (d *DeviceMetricPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedObservationResourcesReferencingDevice() (observations []Observation, err error) {
+	if d.RevIncludedObservationResourcesReferencingDevice == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *d.RevIncludedObservationResourcesReferencingDevice
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedParentResources != nil {
-		for _, r := range *d.IncludedParentResources {
+	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
+		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSourceResources != nil {
-		for _, r := range *d.IncludedSourceResources {
+	if d.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceMetricPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
+		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedObservationResourcesReferencingDevice != nil {
+		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/deviceuserequest.go
+++ b/models/deviceuserequest.go
@@ -95,63 +95,448 @@ func (x *DeviceUseRequest) checkResourceType() error {
 }
 
 type DeviceUseRequestPlus struct {
-	DeviceUseRequest             `bson:",inline"`
-	DeviceUseRequestPlusIncludes `bson:",inline"`
+	DeviceUseRequest                     `bson:",inline"`
+	DeviceUseRequestPlusRelatedResources `bson:",inline"`
 }
 
-type DeviceUseRequestPlusIncludes struct {
-	IncludedSubjectResources *[]Patient `bson:"_includedSubjectResources,omitempty"`
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
-	IncludedDeviceResources  *[]Device  `bson:"_includedDeviceResources,omitempty"`
+type DeviceUseRequestPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedDeviceResourcesReferencedByDevice                   *[]Device                `bson:"_includedDeviceResourcesReferencedByDevice,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DeviceUseRequestPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
-	if d.IncludedSubjectResources == nil {
+func (d *DeviceUseRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectResources))
-	} else if len(*d.IncludedSubjectResources) == 1 {
-		patient = &(*d.IncludedSubjectResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DeviceUseRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DeviceUseRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DeviceUseRequestPlusIncludes) GetIncludedDeviceResource() (device *Device, err error) {
-	if d.IncludedDeviceResources == nil {
+func (d *DeviceUseRequestPlusRelatedResources) GetIncludedDeviceResourceReferencedByDevice() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByDevice == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResources))
-	} else if len(*d.IncludedDeviceResources) == 1 {
-		device = &(*d.IncludedDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedByDevice) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedByDevice))
+	} else if len(*d.IncludedDeviceResourcesReferencedByDevice) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedByDevice)[0]
 	}
 	return
 }
 
-func (d *DeviceUseRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *d.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedSubjectResources != nil {
-		for _, r := range *d.IncludedSubjectResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedDeviceResources != nil {
-		for _, r := range *d.IncludedDeviceResources {
+	if d.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceUseRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/deviceusestatement.go
+++ b/models/deviceusestatement.go
@@ -91,63 +91,408 @@ func (x *DeviceUseStatement) checkResourceType() error {
 }
 
 type DeviceUseStatementPlus struct {
-	DeviceUseStatement             `bson:",inline"`
-	DeviceUseStatementPlusIncludes `bson:",inline"`
+	DeviceUseStatement                     `bson:",inline"`
+	DeviceUseStatementPlusRelatedResources `bson:",inline"`
 }
 
-type DeviceUseStatementPlusIncludes struct {
-	IncludedSubjectResources *[]Patient `bson:"_includedSubjectResources,omitempty"`
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
-	IncludedDeviceResources  *[]Device  `bson:"_includedDeviceResources,omitempty"`
+type DeviceUseStatementPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedDeviceResourcesReferencedByDevice                   *[]Device                `bson:"_includedDeviceResourcesReferencedByDevice,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DeviceUseStatementPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
-	if d.IncludedSubjectResources == nil {
+func (d *DeviceUseStatementPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectResources))
-	} else if len(*d.IncludedSubjectResources) == 1 {
-		patient = &(*d.IncludedSubjectResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DeviceUseStatementPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DeviceUseStatementPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DeviceUseStatementPlusIncludes) GetIncludedDeviceResource() (device *Device, err error) {
-	if d.IncludedDeviceResources == nil {
+func (d *DeviceUseStatementPlusRelatedResources) GetIncludedDeviceResourceReferencedByDevice() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByDevice == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResources))
-	} else if len(*d.IncludedDeviceResources) == 1 {
-		device = &(*d.IncludedDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedByDevice) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedByDevice))
+	} else if len(*d.IncludedDeviceResourcesReferencedByDevice) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedByDevice)[0]
 	}
 	return
 }
 
-func (d *DeviceUseStatementPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedSubjectResources != nil {
-		for _, r := range *d.IncludedSubjectResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedDeviceResources != nil {
-		for _, r := range *d.IncludedDeviceResources {
+	if d.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DeviceUseStatementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -106,229 +106,724 @@ type DiagnosticOrderItemComponent struct {
 }
 
 type DiagnosticOrderPlus struct {
-	DiagnosticOrder             `bson:",inline"`
-	DiagnosticOrderPlusIncludes `bson:",inline"`
+	DiagnosticOrder                     `bson:",inline"`
+	DiagnosticOrderPlusRelatedResources `bson:",inline"`
 }
 
-type DiagnosticOrderPlusIncludes struct {
-	IncludedSubjectGroupResources           *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources          *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources         *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectLocationResources        *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedEncounterResources              *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
-	IncludedActorPractitionerPath1Resources *[]Practitioner `bson:"_includedActorPractitionerPath1Resources,omitempty"`
-	IncludedActorPractitionerPath2Resources *[]Practitioner `bson:"_includedActorPractitionerPath2Resources,omitempty"`
-	IncludedActorDevicePath1Resources       *[]Device       `bson:"_includedActorDevicePath1Resources,omitempty"`
-	IncludedActorDevicePath2Resources       *[]Device       `bson:"_includedActorDevicePath2Resources,omitempty"`
-	IncludedPatientResources                *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedOrdererResources                *[]Practitioner `bson:"_includedOrdererResources,omitempty"`
-	IncludedSpecimenPath1Resources          *[]Specimen     `bson:"_includedSpecimenPath1Resources,omitempty"`
-	IncludedSpecimenPath2Resources          *[]Specimen     `bson:"_includedSpecimenPath2Resources,omitempty"`
+type DiagnosticOrderPlusRelatedResources struct {
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                *[]Location              `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedPractitionerResourcesReferencedByActorPath1         *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActorPath1,omitempty"`
+	IncludedPractitionerResourcesReferencedByActorPath2         *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActorPath2,omitempty"`
+	IncludedDeviceResourcesReferencedByActorPath1               *[]Device                `bson:"_includedDeviceResourcesReferencedByActorPath1,omitempty"`
+	IncludedDeviceResourcesReferencedByActorPath2               *[]Device                `bson:"_includedDeviceResourcesReferencedByActorPath2,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByOrderer            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByOrderer,omitempty"`
+	IncludedSpecimenResourcesReferencedBySpecimenPath1          *[]Specimen              `bson:"_includedSpecimenResourcesReferencedBySpecimenPath1,omitempty"`
+	IncludedSpecimenResourcesReferencedBySpecimenPath2          *[]Specimen              `bson:"_includedSpecimenResourcesReferencedBySpecimenPath2,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingRequest      *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingRequest,omitempty"`
+	RevIncludedImagingStudyResourcesReferencingOrder            *[]ImagingStudy          `bson:"_revIncludedImagingStudyResourcesReferencingOrder,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if d.IncludedSubjectGroupResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if d.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*d.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
-	} else if len(*d.IncludedSubjectGroupResources) == 1 {
-		group = &(*d.IncludedSubjectGroupResources)[0]
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*d.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if d.IncludedSubjectDeviceResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
-	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
-		device = &(*d.IncludedSubjectDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if d.IncludedSubjectPatientResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
-	} else if len(*d.IncludedSubjectPatientResources) == 1 {
-		patient = &(*d.IncludedSubjectPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if d.IncludedSubjectLocationResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if d.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*d.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedSubjectLocationResources))
-	} else if len(*d.IncludedSubjectLocationResources) == 1 {
-		location = &(*d.IncludedSubjectLocationResources)[0]
+	} else if len(*d.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*d.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*d.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if d.IncludedEncounterResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*d.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
-	} else if len(*d.IncludedEncounterResources) == 1 {
-		encounter = &(*d.IncludedEncounterResources)[0]
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*d.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedActorPractitionerPath1Resource() (practitioner *Practitioner, err error) {
-	if d.IncludedActorPractitionerPath1Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByActorPath1() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByActorPath1 == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedActorPractitionerPath1Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedActorPractitionerPath1Resources))
-	} else if len(*d.IncludedActorPractitionerPath1Resources) == 1 {
-		practitioner = &(*d.IncludedActorPractitionerPath1Resources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByActorPath1) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByActorPath1))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByActorPath1) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByActorPath1)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedActorPractitionerPath2Resource() (practitioner *Practitioner, err error) {
-	if d.IncludedActorPractitionerPath2Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByActorPath2() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByActorPath2 == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedActorPractitionerPath2Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedActorPractitionerPath2Resources))
-	} else if len(*d.IncludedActorPractitionerPath2Resources) == 1 {
-		practitioner = &(*d.IncludedActorPractitionerPath2Resources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByActorPath2) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByActorPath2))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByActorPath2) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByActorPath2)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedActorDevicePath1Resource() (device *Device, err error) {
-	if d.IncludedActorDevicePath1Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedDeviceResourceReferencedByActorPath1() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByActorPath1 == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedActorDevicePath1Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedActorDevicePath1Resources))
-	} else if len(*d.IncludedActorDevicePath1Resources) == 1 {
-		device = &(*d.IncludedActorDevicePath1Resources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedByActorPath1) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedByActorPath1))
+	} else if len(*d.IncludedDeviceResourcesReferencedByActorPath1) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedByActorPath1)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedActorDevicePath2Resource() (device *Device, err error) {
-	if d.IncludedActorDevicePath2Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedDeviceResourceReferencedByActorPath2() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByActorPath2 == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedActorDevicePath2Resources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedActorDevicePath2Resources))
-	} else if len(*d.IncludedActorDevicePath2Resources) == 1 {
-		device = &(*d.IncludedActorDevicePath2Resources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedByActorPath2) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedByActorPath2))
+	} else if len(*d.IncludedDeviceResourcesReferencedByActorPath2) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedByActorPath2)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedOrdererResource() (practitioner *Practitioner, err error) {
-	if d.IncludedOrdererResources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByOrderer() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByOrderer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedOrdererResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedOrdererResources))
-	} else if len(*d.IncludedOrdererResources) == 1 {
-		practitioner = &(*d.IncludedOrdererResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByOrderer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByOrderer))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByOrderer) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByOrderer)[0]
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSpecimenPath1Resources() (specimen []Specimen, err error) {
-	if d.IncludedSpecimenPath1Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedSpecimenResourcesReferencedBySpecimenPath1() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath1 == nil {
 		err = errors.New("Included specimen not requested")
 	} else {
-		specimen = *d.IncludedSpecimenPath1Resources
+		specimen = *d.IncludedSpecimenResourcesReferencedBySpecimenPath1
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedSpecimenPath2Resources() (specimen []Specimen, err error) {
-	if d.IncludedSpecimenPath2Resources == nil {
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedSpecimenResourcesReferencedBySpecimenPath2() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath2 == nil {
 		err = errors.New("Included specimen not requested")
 	} else {
-		specimen = *d.IncludedSpecimenPath2Resources
+		specimen = *d.IncludedSpecimenResourcesReferencedBySpecimenPath2
 	}
 	return
 }
 
-func (d *DiagnosticOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *d.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingRequest() (diagnosticReports []DiagnosticReport, err error) {
+	if d.RevIncludedDiagnosticReportResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *d.RevIncludedDiagnosticReportResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedImagingStudyResourcesReferencingOrder() (imagingStudies []ImagingStudy, err error) {
+	if d.RevIncludedImagingStudyResourcesReferencingOrder == nil {
+		err = errors.New("RevIncluded imagingStudies not requested")
+	} else {
+		imagingStudies = *d.RevIncludedImagingStudyResourcesReferencingOrder
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedSubjectGroupResources != nil {
-		for _, r := range *d.IncludedSubjectGroupResources {
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectDeviceResources != nil {
-		for _, r := range *d.IncludedSubjectDeviceResources {
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectPatientResources != nil {
-		for _, r := range *d.IncludedSubjectPatientResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectLocationResources != nil {
-		for _, r := range *d.IncludedSubjectLocationResources {
+	if d.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedEncounterResources != nil {
-		for _, r := range *d.IncludedEncounterResources {
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedActorPractitionerPath1Resources != nil {
-		for _, r := range *d.IncludedActorPractitionerPath1Resources {
+	if d.IncludedPractitionerResourcesReferencedByActorPath1 != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedActorPractitionerPath2Resources != nil {
-		for _, r := range *d.IncludedActorPractitionerPath2Resources {
+	if d.IncludedPractitionerResourcesReferencedByActorPath2 != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedActorDevicePath1Resources != nil {
-		for _, r := range *d.IncludedActorDevicePath1Resources {
+	if d.IncludedDeviceResourcesReferencedByActorPath1 != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedActorDevicePath2Resources != nil {
-		for _, r := range *d.IncludedActorDevicePath2Resources {
+	if d.IncludedDeviceResourcesReferencedByActorPath2 != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedOrdererResources != nil {
-		for _, r := range *d.IncludedOrdererResources {
+	if d.IncludedPractitionerResourcesReferencedByOrderer != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByOrderer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSpecimenPath1Resources != nil {
-		for _, r := range *d.IncludedSpecimenPath1Resources {
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath1 != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSpecimenPath2Resources != nil {
-		for _, r := range *d.IncludedSpecimenPath2Resources {
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath2 != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedImagingStudyResourcesReferencingOrder != nil {
+		for _, r := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DiagnosticOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByActorPath1 != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByActorPath2 != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByActorPath1 != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByActorPath2 != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByOrderer != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath1 != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenResourcesReferencedBySpecimenPath2 != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedImagingStudyResourcesReferencingOrder != nil {
+		for _, r := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/diagnosticreport.go
+++ b/models/diagnosticreport.go
@@ -102,240 +102,660 @@ type DiagnosticReportImageComponent struct {
 }
 
 type DiagnosticReportPlus struct {
-	DiagnosticReport             `bson:",inline"`
-	DiagnosticReportPlusIncludes `bson:",inline"`
+	DiagnosticReport                     `bson:",inline"`
+	DiagnosticReportPlusRelatedResources `bson:",inline"`
 }
 
-type DiagnosticReportPlusIncludes struct {
-	IncludedImageResources                   *[]Media            `bson:"_includedImageResources,omitempty"`
-	IncludedRequestReferralRequestResources  *[]ReferralRequest  `bson:"_includedRequestReferralRequestResources,omitempty"`
-	IncludedRequestDiagnosticOrderResources  *[]DiagnosticOrder  `bson:"_includedRequestDiagnosticOrderResources,omitempty"`
-	IncludedRequestProcedureRequestResources *[]ProcedureRequest `bson:"_includedRequestProcedureRequestResources,omitempty"`
-	IncludedPerformerPractitionerResources   *[]Practitioner     `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerOrganizationResources   *[]Organization     `bson:"_includedPerformerOrganizationResources,omitempty"`
-	IncludedSubjectGroupResources            *[]Group            `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources           *[]Device           `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources          *[]Patient          `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectLocationResources         *[]Location         `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedEncounterResources               *[]Encounter        `bson:"_includedEncounterResources,omitempty"`
-	IncludedResultResources                  *[]Observation      `bson:"_includedResultResources,omitempty"`
-	IncludedPatientResources                 *[]Patient          `bson:"_includedPatientResources,omitempty"`
-	IncludedSpecimenResources                *[]Specimen         `bson:"_includedSpecimenResources,omitempty"`
+type DiagnosticReportPlusRelatedResources struct {
+	IncludedMediaResourcesReferencedByImage                        *[]Media                 `bson:"_includedMediaResourcesReferencedByImage,omitempty"`
+	IncludedReferralRequestResourcesReferencedByRequest            *[]ReferralRequest       `bson:"_includedReferralRequestResourcesReferencedByRequest,omitempty"`
+	IncludedDiagnosticOrderResourcesReferencedByRequest            *[]DiagnosticOrder       `bson:"_includedDiagnosticOrderResourcesReferencedByRequest,omitempty"`
+	IncludedProcedureRequestResourcesReferencedByRequest           *[]ProcedureRequest      `bson:"_includedProcedureRequestResourcesReferencedByRequest,omitempty"`
+	IncludedPractitionerResourcesReferencedByPerformer             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedOrganizationResourcesReferencedByPerformer             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByPerformer,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                      *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                     *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                    *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                   *[]Location              `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter                *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedObservationResourcesReferencedByResult                 *[]Observation           `bson:"_includedObservationResourcesReferencedByResult,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                    *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedSpecimenResourcesReferencedBySpecimen                  *[]Specimen              `bson:"_includedSpecimenResourcesReferencedBySpecimen,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                        *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref     *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                     *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                    *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference             *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated         *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment        *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject    *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest          *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingInvestigation *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingInvestigation,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData               *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedImageResource() (media *Media, err error) {
-	if d.IncludedImageResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedMediaResourceReferencedByImage() (media *Media, err error) {
+	if d.IncludedMediaResourcesReferencedByImage == nil {
 		err = errors.New("Included media not requested")
-	} else if len(*d.IncludedImageResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 media, but found %d", len(*d.IncludedImageResources))
-	} else if len(*d.IncludedImageResources) == 1 {
-		media = &(*d.IncludedImageResources)[0]
+	} else if len(*d.IncludedMediaResourcesReferencedByImage) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 media, but found %d", len(*d.IncludedMediaResourcesReferencedByImage))
+	} else if len(*d.IncludedMediaResourcesReferencedByImage) == 1 {
+		media = &(*d.IncludedMediaResourcesReferencedByImage)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedRequestReferralRequestResources() (referralRequests []ReferralRequest, err error) {
-	if d.IncludedRequestReferralRequestResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedReferralRequestResourcesReferencedByRequest() (referralRequests []ReferralRequest, err error) {
+	if d.IncludedReferralRequestResourcesReferencedByRequest == nil {
 		err = errors.New("Included referralRequests not requested")
 	} else {
-		referralRequests = *d.IncludedRequestReferralRequestResources
+		referralRequests = *d.IncludedReferralRequestResourcesReferencedByRequest
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedRequestDiagnosticOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
-	if d.IncludedRequestDiagnosticOrderResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedDiagnosticOrderResourcesReferencedByRequest() (diagnosticOrders []DiagnosticOrder, err error) {
+	if d.IncludedDiagnosticOrderResourcesReferencedByRequest == nil {
 		err = errors.New("Included diagnosticOrders not requested")
 	} else {
-		diagnosticOrders = *d.IncludedRequestDiagnosticOrderResources
+		diagnosticOrders = *d.IncludedDiagnosticOrderResourcesReferencedByRequest
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedRequestProcedureRequestResources() (procedureRequests []ProcedureRequest, err error) {
-	if d.IncludedRequestProcedureRequestResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedProcedureRequestResourcesReferencedByRequest() (procedureRequests []ProcedureRequest, err error) {
+	if d.IncludedProcedureRequestResourcesReferencedByRequest == nil {
 		err = errors.New("Included procedureRequests not requested")
 	} else {
-		procedureRequests = *d.IncludedRequestProcedureRequestResources
+		procedureRequests = *d.IncludedProcedureRequestResourcesReferencedByRequest
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
-	if d.IncludedPerformerPractitionerResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPerformer() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedPerformerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPerformerPractitionerResources))
-	} else if len(*d.IncludedPerformerPractitionerResources) == 1 {
-		practitioner = &(*d.IncludedPerformerPractitionerResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByPerformer))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByPerformer) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
-	if d.IncludedPerformerOrganizationResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedOrganizationResourceReferencedByPerformer() (organization *Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByPerformer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*d.IncludedPerformerOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedPerformerOrganizationResources))
-	} else if len(*d.IncludedPerformerOrganizationResources) == 1 {
-		organization = &(*d.IncludedPerformerOrganizationResources)[0]
+	} else if len(*d.IncludedOrganizationResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResourcesReferencedByPerformer))
+	} else if len(*d.IncludedOrganizationResourcesReferencedByPerformer) == 1 {
+		organization = &(*d.IncludedOrganizationResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if d.IncludedSubjectGroupResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if d.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*d.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
-	} else if len(*d.IncludedSubjectGroupResources) == 1 {
-		group = &(*d.IncludedSubjectGroupResources)[0]
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*d.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if d.IncludedSubjectDeviceResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
-	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
-		device = &(*d.IncludedSubjectDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if d.IncludedSubjectPatientResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
-	} else if len(*d.IncludedSubjectPatientResources) == 1 {
-		patient = &(*d.IncludedSubjectPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if d.IncludedSubjectLocationResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if d.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*d.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedSubjectLocationResources))
-	} else if len(*d.IncludedSubjectLocationResources) == 1 {
-		location = &(*d.IncludedSubjectLocationResources)[0]
+	} else if len(*d.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*d.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*d.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*d.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if d.IncludedEncounterResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*d.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
-	} else if len(*d.IncludedEncounterResources) == 1 {
-		encounter = &(*d.IncludedEncounterResources)[0]
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*d.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedResultResources() (observations []Observation, err error) {
-	if d.IncludedResultResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedObservationResourcesReferencedByResult() (observations []Observation, err error) {
+	if d.IncludedObservationResourcesReferencedByResult == nil {
 		err = errors.New("Included observations not requested")
 	} else {
-		observations = *d.IncludedResultResources
+		observations = *d.IncludedObservationResourcesReferencedByResult
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedSpecimenResources() (specimen []Specimen, err error) {
-	if d.IncludedSpecimenResources == nil {
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedSpecimenResourcesReferencedBySpecimen() (specimen []Specimen, err error) {
+	if d.IncludedSpecimenResourcesReferencedBySpecimen == nil {
 		err = errors.New("Included specimen not requested")
 	} else {
-		specimen = *d.IncludedSpecimenResources
+		specimen = *d.IncludedSpecimenResourcesReferencedBySpecimen
 	}
 	return
 }
 
-func (d *DiagnosticReportPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingInvestigation() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingInvestigation == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedImageResources != nil {
-		for _, r := range *d.IncludedImageResources {
+	if d.IncludedMediaResourcesReferencedByImage != nil {
+		for _, r := range *d.IncludedMediaResourcesReferencedByImage {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRequestReferralRequestResources != nil {
-		for _, r := range *d.IncludedRequestReferralRequestResources {
+	if d.IncludedReferralRequestResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedReferralRequestResourcesReferencedByRequest {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRequestDiagnosticOrderResources != nil {
-		for _, r := range *d.IncludedRequestDiagnosticOrderResources {
+	if d.IncludedDiagnosticOrderResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRequestProcedureRequestResources != nil {
-		for _, r := range *d.IncludedRequestProcedureRequestResources {
+	if d.IncludedProcedureRequestResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *d.IncludedPerformerPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPerformerOrganizationResources != nil {
-		for _, r := range *d.IncludedPerformerOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectGroupResources != nil {
-		for _, r := range *d.IncludedSubjectGroupResources {
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectDeviceResources != nil {
-		for _, r := range *d.IncludedSubjectDeviceResources {
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectPatientResources != nil {
-		for _, r := range *d.IncludedSubjectPatientResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectLocationResources != nil {
-		for _, r := range *d.IncludedSubjectLocationResources {
+	if d.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedEncounterResources != nil {
-		for _, r := range *d.IncludedEncounterResources {
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedResultResources != nil {
-		for _, r := range *d.IncludedResultResources {
+	if d.IncludedObservationResourcesReferencedByResult != nil {
+		for _, r := range *d.IncludedObservationResourcesReferencedByResult {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSpecimenResources != nil {
-		for _, r := range *d.IncludedSpecimenResources {
+	if d.IncludedSpecimenResourcesReferencedBySpecimen != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DiagnosticReportPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedMediaResourcesReferencedByImage != nil {
+		for _, r := range *d.IncludedMediaResourcesReferencedByImage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedReferralRequestResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedReferralRequestResourcesReferencedByRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDiagnosticOrderResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedProcedureRequestResourcesReferencedByRequest != nil {
+		for _, r := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedObservationResourcesReferencedByResult != nil {
+		for _, r := range *d.IncludedObservationResourcesReferencedByResult {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedSpecimenResourcesReferencedBySpecimen != nil {
+		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/documentmanifest.go
+++ b/models/documentmanifest.go
@@ -101,232 +101,632 @@ type DocumentManifestRelatedComponent struct {
 }
 
 type DocumentManifestPlus struct {
-	DocumentManifest             `bson:",inline"`
-	DocumentManifestPlusIncludes `bson:",inline"`
+	DocumentManifest                     `bson:",inline"`
+	DocumentManifestPlusRelatedResources `bson:",inline"`
 }
 
-type DocumentManifestPlusIncludes struct {
-	IncludedSubjectPractitionerResources    *[]Practitioner  `bson:"_includedSubjectPractitionerResources,omitempty"`
-	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources          *[]Device        `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedAuthorPractitionerResources     *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorOrganizationResources     *[]Organization  `bson:"_includedAuthorOrganizationResources,omitempty"`
-	IncludedAuthorDeviceResources           *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources          *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources    *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
-	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedRecipientPractitionerResources  *[]Practitioner  `bson:"_includedRecipientPractitionerResources,omitempty"`
-	IncludedRecipientOrganizationResources  *[]Organization  `bson:"_includedRecipientOrganizationResources,omitempty"`
-	IncludedRecipientPatientResources       *[]Patient       `bson:"_includedRecipientPatientResources,omitempty"`
-	IncludedRecipientRelatedPersonResources *[]RelatedPerson `bson:"_includedRecipientRelatedPersonResources,omitempty"`
+type DocumentManifestPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedBySubject            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySubject,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedOrganizationResourcesReferencedByAuthor             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByRecipient          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRecipient,omitempty"`
+	IncludedOrganizationResourcesReferencedByRecipient          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRecipient,omitempty"`
+	IncludedPatientResourcesReferencedByRecipient               *[]Patient               `bson:"_includedPatientResourcesReferencedByRecipient,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByRecipient         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByRecipient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
-	if d.IncludedSubjectPractitionerResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySubject() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedBySubject == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedSubjectPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedSubjectPractitionerResources))
-	} else if len(*d.IncludedSubjectPractitionerResources) == 1 {
-		practitioner = &(*d.IncludedSubjectPractitionerResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedBySubject))
+	} else if len(*d.IncludedPractitionerResourcesReferencedBySubject) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if d.IncludedSubjectGroupResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if d.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*d.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
-	} else if len(*d.IncludedSubjectGroupResources) == 1 {
-		group = &(*d.IncludedSubjectGroupResources)[0]
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*d.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if d.IncludedSubjectDeviceResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
-	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
-		device = &(*d.IncludedSubjectDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if d.IncludedSubjectPatientResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
-	} else if len(*d.IncludedSubjectPatientResources) == 1 {
-		patient = &(*d.IncludedSubjectPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
-	if d.IncludedAuthorPractitionerResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByAuthor() (practitioners []Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *d.IncludedAuthorPractitionerResources
+		practitioners = *d.IncludedPractitionerResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedAuthorOrganizationResources() (organizations []Organization, err error) {
-	if d.IncludedAuthorOrganizationResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByAuthor() (organizations []Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByAuthor == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *d.IncludedAuthorOrganizationResources
+		organizations = *d.IncludedOrganizationResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
-	if d.IncludedAuthorDeviceResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedDeviceResourcesReferencedByAuthor() (devices []Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *d.IncludedAuthorDeviceResources
+		devices = *d.IncludedDeviceResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
-	if d.IncludedAuthorPatientResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPatientResourcesReferencedByAuthor() (patients []Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *d.IncludedAuthorPatientResources
+		patients = *d.IncludedPatientResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if d.IncludedAuthorRelatedPersonResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByAuthor() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *d.IncludedAuthorRelatedPersonResources
+		relatedPeople = *d.IncludedRelatedPersonResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
-	if d.IncludedRecipientPractitionerResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByRecipient() (practitioners []Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByRecipient == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *d.IncludedRecipientPractitionerResources
+		practitioners = *d.IncludedPractitionerResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
-	if d.IncludedRecipientOrganizationResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByRecipient() (organizations []Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByRecipient == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *d.IncludedRecipientOrganizationResources
+		organizations = *d.IncludedOrganizationResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedRecipientPatientResources() (patients []Patient, err error) {
-	if d.IncludedRecipientPatientResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedPatientResourcesReferencedByRecipient() (patients []Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByRecipient == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *d.IncludedRecipientPatientResources
+		patients = *d.IncludedPatientResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedRecipientRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if d.IncludedRecipientRelatedPersonResources == nil {
+func (d *DocumentManifestPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByRecipient() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedRelatedPersonResourcesReferencedByRecipient == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *d.IncludedRecipientRelatedPersonResources
+		relatedPeople = *d.IncludedRelatedPersonResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (d *DocumentManifestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedSubjectPractitionerResources != nil {
-		for _, r := range *d.IncludedSubjectPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectGroupResources != nil {
-		for _, r := range *d.IncludedSubjectGroupResources {
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectDeviceResources != nil {
-		for _, r := range *d.IncludedSubjectDeviceResources {
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectPatientResources != nil {
-		for _, r := range *d.IncludedSubjectPatientResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *d.IncludedAuthorPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorOrganizationResources != nil {
-		for _, r := range *d.IncludedAuthorOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorDeviceResources != nil {
-		for _, r := range *d.IncludedAuthorDeviceResources {
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorPatientResources != nil {
-		for _, r := range *d.IncludedAuthorPatientResources {
+	if d.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *d.IncludedAuthorRelatedPersonResources {
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRecipientPractitionerResources != nil {
-		for _, r := range *d.IncludedRecipientPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRecipientOrganizationResources != nil {
-		for _, r := range *d.IncludedRecipientOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRecipientPatientResources != nil {
-		for _, r := range *d.IncludedRecipientPatientResources {
+	if d.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRecipientRelatedPersonResources != nil {
-		for _, r := range *d.IncludedRecipientRelatedPersonResources {
+	if d.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DocumentManifestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -121,257 +121,682 @@ type DocumentReferenceContextRelatedComponent struct {
 }
 
 type DocumentReferencePlus struct {
-	DocumentReference             `bson:",inline"`
-	DocumentReferencePlusIncludes `bson:",inline"`
+	DocumentReference                     `bson:",inline"`
+	DocumentReferencePlusRelatedResources `bson:",inline"`
 }
 
-type DocumentReferencePlusIncludes struct {
-	IncludedSubjectPractitionerResources       *[]Practitioner      `bson:"_includedSubjectPractitionerResources,omitempty"`
-	IncludedSubjectGroupResources              *[]Group             `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources             *[]Device            `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources            *[]Patient           `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedPatientResources                   *[]Patient           `bson:"_includedPatientResources,omitempty"`
-	IncludedAuthenticatorPractitionerResources *[]Practitioner      `bson:"_includedAuthenticatorPractitionerResources,omitempty"`
-	IncludedAuthenticatorOrganizationResources *[]Organization      `bson:"_includedAuthenticatorOrganizationResources,omitempty"`
-	IncludedCustodianResources                 *[]Organization      `bson:"_includedCustodianResources,omitempty"`
-	IncludedAuthorPractitionerResources        *[]Practitioner      `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorOrganizationResources        *[]Organization      `bson:"_includedAuthorOrganizationResources,omitempty"`
-	IncludedAuthorDeviceResources              *[]Device            `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources             *[]Patient           `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources       *[]RelatedPerson     `bson:"_includedAuthorRelatedPersonResources,omitempty"`
-	IncludedEncounterResources                 *[]Encounter         `bson:"_includedEncounterResources,omitempty"`
-	IncludedRelatestoResources                 *[]DocumentReference `bson:"_includedRelatestoResources,omitempty"`
+type DocumentReferencePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedBySubject            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySubject,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthenticator      *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthenticator,omitempty"`
+	IncludedOrganizationResourcesReferencedByAuthenticator      *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAuthenticator,omitempty"`
+	IncludedOrganizationResourcesReferencedByCustodian          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByCustodian,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedOrganizationResourcesReferencedByAuthor             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedDocumentReferenceResourcesReferencedByRelatesto     *[]DocumentReference     `bson:"_includedDocumentReferenceResourcesReferencedByRelatesto,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatesto   *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatesto,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
-	if d.IncludedSubjectPractitionerResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPractitionerResourceReferencedBySubject() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedBySubject == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedSubjectPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedSubjectPractitionerResources))
-	} else if len(*d.IncludedSubjectPractitionerResources) == 1 {
-		practitioner = &(*d.IncludedSubjectPractitionerResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedBySubject))
+	} else if len(*d.IncludedPractitionerResourcesReferencedBySubject) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if d.IncludedSubjectGroupResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if d.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*d.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedSubjectGroupResources))
-	} else if len(*d.IncludedSubjectGroupResources) == 1 {
-		group = &(*d.IncludedSubjectGroupResources)[0]
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*d.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*d.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*d.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if d.IncludedSubjectDeviceResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if d.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*d.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedSubjectDeviceResources))
-	} else if len(*d.IncludedSubjectDeviceResources) == 1 {
-		device = &(*d.IncludedSubjectDeviceResources)[0]
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*d.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*d.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*d.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if d.IncludedSubjectPatientResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedSubjectPatientResources))
-	} else if len(*d.IncludedSubjectPatientResources) == 1 {
-		patient = &(*d.IncludedSubjectPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*d.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if d.IncludedPatientResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*d.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResources))
-	} else if len(*d.IncludedPatientResources) == 1 {
-		patient = &(*d.IncludedPatientResources)[0]
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*d.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*d.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*d.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthenticatorPractitionerResource() (practitioner *Practitioner, err error) {
-	if d.IncludedAuthenticatorPractitionerResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthenticator() (practitioner *Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByAuthenticator == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*d.IncludedAuthenticatorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedAuthenticatorPractitionerResources))
-	} else if len(*d.IncludedAuthenticatorPractitionerResources) == 1 {
-		practitioner = &(*d.IncludedAuthenticatorPractitionerResources)[0]
+	} else if len(*d.IncludedPractitionerResourcesReferencedByAuthenticator) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*d.IncludedPractitionerResourcesReferencedByAuthenticator))
+	} else if len(*d.IncludedPractitionerResourcesReferencedByAuthenticator) == 1 {
+		practitioner = &(*d.IncludedPractitionerResourcesReferencedByAuthenticator)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthenticatorOrganizationResource() (organization *Organization, err error) {
-	if d.IncludedAuthenticatorOrganizationResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedOrganizationResourceReferencedByAuthenticator() (organization *Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByAuthenticator == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*d.IncludedAuthenticatorOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedAuthenticatorOrganizationResources))
-	} else if len(*d.IncludedAuthenticatorOrganizationResources) == 1 {
-		organization = &(*d.IncludedAuthenticatorOrganizationResources)[0]
+	} else if len(*d.IncludedOrganizationResourcesReferencedByAuthenticator) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResourcesReferencedByAuthenticator))
+	} else if len(*d.IncludedOrganizationResourcesReferencedByAuthenticator) == 1 {
+		organization = &(*d.IncludedOrganizationResourcesReferencedByAuthenticator)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedCustodianResource() (organization *Organization, err error) {
-	if d.IncludedCustodianResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedOrganizationResourceReferencedByCustodian() (organization *Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByCustodian == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*d.IncludedCustodianResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedCustodianResources))
-	} else if len(*d.IncludedCustodianResources) == 1 {
-		organization = &(*d.IncludedCustodianResources)[0]
+	} else if len(*d.IncludedOrganizationResourcesReferencedByCustodian) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*d.IncludedOrganizationResourcesReferencedByCustodian))
+	} else if len(*d.IncludedOrganizationResourcesReferencedByCustodian) == 1 {
+		organization = &(*d.IncludedOrganizationResourcesReferencedByCustodian)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthorPractitionerResources() (practitioners []Practitioner, err error) {
-	if d.IncludedAuthorPractitionerResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPractitionerResourcesReferencedByAuthor() (practitioners []Practitioner, err error) {
+	if d.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *d.IncludedAuthorPractitionerResources
+		practitioners = *d.IncludedPractitionerResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthorOrganizationResources() (organizations []Organization, err error) {
-	if d.IncludedAuthorOrganizationResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedOrganizationResourcesReferencedByAuthor() (organizations []Organization, err error) {
+	if d.IncludedOrganizationResourcesReferencedByAuthor == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *d.IncludedAuthorOrganizationResources
+		organizations = *d.IncludedOrganizationResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthorDeviceResources() (devices []Device, err error) {
-	if d.IncludedAuthorDeviceResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedDeviceResourcesReferencedByAuthor() (devices []Device, err error) {
+	if d.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *d.IncludedAuthorDeviceResources
+		devices = *d.IncludedDeviceResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthorPatientResources() (patients []Patient, err error) {
-	if d.IncludedAuthorPatientResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedPatientResourcesReferencedByAuthor() (patients []Patient, err error) {
+	if d.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *d.IncludedAuthorPatientResources
+		patients = *d.IncludedPatientResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedAuthorRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if d.IncludedAuthorRelatedPersonResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByAuthor() (relatedPeople []RelatedPerson, err error) {
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *d.IncludedAuthorRelatedPersonResources
+		relatedPeople = *d.IncludedRelatedPersonResourcesReferencedByAuthor
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if d.IncludedEncounterResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if d.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*d.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResources))
-	} else if len(*d.IncludedEncounterResources) == 1 {
-		encounter = &(*d.IncludedEncounterResources)[0]
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*d.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*d.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*d.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedRelatestoResource() (documentReference *DocumentReference, err error) {
-	if d.IncludedRelatestoResources == nil {
+func (d *DocumentReferencePlusRelatedResources) GetIncludedDocumentReferenceResourceReferencedByRelatesto() (documentReference *DocumentReference, err error) {
+	if d.IncludedDocumentReferenceResourcesReferencedByRelatesto == nil {
 		err = errors.New("Included documentreferences not requested")
-	} else if len(*d.IncludedRelatestoResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 documentReference, but found %d", len(*d.IncludedRelatestoResources))
-	} else if len(*d.IncludedRelatestoResources) == 1 {
-		documentReference = &(*d.IncludedRelatestoResources)[0]
+	} else if len(*d.IncludedDocumentReferenceResourcesReferencedByRelatesto) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 documentReference, but found %d", len(*d.IncludedDocumentReferenceResourcesReferencedByRelatesto))
+	} else if len(*d.IncludedDocumentReferenceResourcesReferencedByRelatesto) == 1 {
+		documentReference = &(*d.IncludedDocumentReferenceResourcesReferencedByRelatesto)[0]
 	}
 	return
 }
 
-func (d *DocumentReferencePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if d.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *d.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *d.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if d.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *d.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatesto() (documentReferences []DocumentReference, err error) {
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatesto == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if d.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *d.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if d.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *d.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if d.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *d.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if d.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *d.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *d.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *d.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if d.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *d.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *d.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if d.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *d.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if d.IncludedSubjectPractitionerResources != nil {
-		for _, r := range *d.IncludedSubjectPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectGroupResources != nil {
-		for _, r := range *d.IncludedSubjectGroupResources {
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectDeviceResources != nil {
-		for _, r := range *d.IncludedSubjectDeviceResources {
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedSubjectPatientResources != nil {
-		for _, r := range *d.IncludedSubjectPatientResources {
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedPatientResources != nil {
-		for _, r := range *d.IncludedPatientResources {
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthenticatorPractitionerResources != nil {
-		for _, r := range *d.IncludedAuthenticatorPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByAuthenticator != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthenticatorOrganizationResources != nil {
-		for _, r := range *d.IncludedAuthenticatorOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByAuthenticator != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedCustodianResources != nil {
-		for _, r := range *d.IncludedCustodianResources {
+	if d.IncludedOrganizationResourcesReferencedByCustodian != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByCustodian {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *d.IncludedAuthorPractitionerResources {
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorOrganizationResources != nil {
-		for _, r := range *d.IncludedAuthorOrganizationResources {
+	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorDeviceResources != nil {
-		for _, r := range *d.IncludedAuthorDeviceResources {
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorPatientResources != nil {
-		for _, r := range *d.IncludedAuthorPatientResources {
+	if d.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *d.IncludedAuthorRelatedPersonResources {
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedEncounterResources != nil {
-		for _, r := range *d.IncludedEncounterResources {
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if d.IncludedRelatestoResources != nil {
-		for _, r := range *d.IncludedRelatestoResources {
+	if d.IncludedDocumentReferenceResourcesReferencedByRelatesto != nil {
+		for _, r := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatesto != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (d *DocumentReferencePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByAuthenticator != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByAuthenticator != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByCustodian != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByCustodian {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.IncludedDocumentReferenceResourcesReferencedByRelatesto != nil {
+		for _, r := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *d.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDocumentReferenceResourcesReferencingRelatesto != nil {
+		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/eligibilityrequest.go
+++ b/models/eligibilityrequest.go
@@ -86,14 +86,344 @@ func (x *EligibilityRequest) checkResourceType() error {
 }
 
 type EligibilityRequestPlus struct {
-	EligibilityRequest             `bson:",inline"`
-	EligibilityRequestPlusIncludes `bson:",inline"`
+	EligibilityRequest                     `bson:",inline"`
+	EligibilityRequestPlusRelatedResources `bson:",inline"`
 }
 
-type EligibilityRequestPlusIncludes struct {
+type EligibilityRequestPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EligibilityRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EligibilityRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/eligibilityresponse.go
+++ b/models/eligibilityresponse.go
@@ -89,14 +89,344 @@ func (x *EligibilityResponse) checkResourceType() error {
 }
 
 type EligibilityResponsePlus struct {
-	EligibilityResponse             `bson:",inline"`
-	EligibilityResponsePlusIncludes `bson:",inline"`
+	EligibilityResponse                     `bson:",inline"`
+	EligibilityResponsePlusRelatedResources `bson:",inline"`
 }
 
-type EligibilityResponsePlusIncludes struct {
+type EligibilityResponsePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EligibilityResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EligibilityResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -129,221 +129,996 @@ type EncounterLocationComponent struct {
 }
 
 type EncounterPlus struct {
-	Encounter             `bson:",inline"`
-	EncounterPlusIncludes `bson:",inline"`
+	Encounter                     `bson:",inline"`
+	EncounterPlusRelatedResources `bson:",inline"`
 }
 
-type EncounterPlusIncludes struct {
-	IncludedEpisodeofcareResources            *[]EpisodeOfCare   `bson:"_includedEpisodeofcareResources,omitempty"`
-	IncludedIncomingreferralResources         *[]ReferralRequest `bson:"_includedIncomingreferralResources,omitempty"`
-	IncludedPractitionerResources             *[]Practitioner    `bson:"_includedPractitionerResources,omitempty"`
-	IncludedAppointmentResources              *[]Appointment     `bson:"_includedAppointmentResources,omitempty"`
-	IncludedPartofResources                   *[]Encounter       `bson:"_includedPartofResources,omitempty"`
-	IncludedProcedureResources                *[]Procedure       `bson:"_includedProcedureResources,omitempty"`
-	IncludedParticipantPractitionerResources  *[]Practitioner    `bson:"_includedParticipantPractitionerResources,omitempty"`
-	IncludedParticipantRelatedPersonResources *[]RelatedPerson   `bson:"_includedParticipantRelatedPersonResources,omitempty"`
-	IncludedConditionResources                *[]Condition       `bson:"_includedConditionResources,omitempty"`
-	IncludedPatientResources                  *[]Patient         `bson:"_includedPatientResources,omitempty"`
-	IncludedLocationResources                 *[]Location        `bson:"_includedLocationResources,omitempty"`
-	IncludedIndicationConditionResources      *[]Condition       `bson:"_includedIndicationConditionResources,omitempty"`
-	IncludedIndicationProcedureResources      *[]Procedure       `bson:"_includedIndicationProcedureResources,omitempty"`
+type EncounterPlusRelatedResources struct {
+	IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare          *[]EpisodeOfCare            `bson:"_includedEpisodeOfCareResourcesReferencedByEpisodeofcare,omitempty"`
+	IncludedReferralRequestResourcesReferencedByIncomingreferral     *[]ReferralRequest          `bson:"_includedReferralRequestResourcesReferencedByIncomingreferral,omitempty"`
+	IncludedPractitionerResourcesReferencedByPractitioner            *[]Practitioner             `bson:"_includedPractitionerResourcesReferencedByPractitioner,omitempty"`
+	IncludedAppointmentResourcesReferencedByAppointment              *[]Appointment              `bson:"_includedAppointmentResourcesReferencedByAppointment,omitempty"`
+	IncludedEncounterResourcesReferencedByPartof                     *[]Encounter                `bson:"_includedEncounterResourcesReferencedByPartof,omitempty"`
+	IncludedProcedureResourcesReferencedByProcedure                  *[]Procedure                `bson:"_includedProcedureResourcesReferencedByProcedure,omitempty"`
+	IncludedPractitionerResourcesReferencedByParticipant             *[]Practitioner             `bson:"_includedPractitionerResourcesReferencedByParticipant,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByParticipant            *[]RelatedPerson            `bson:"_includedRelatedPersonResourcesReferencedByParticipant,omitempty"`
+	IncludedConditionResourcesReferencedByCondition                  *[]Condition                `bson:"_includedConditionResourcesReferencedByCondition,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                      *[]Patient                  `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedLocationResourcesReferencedByLocation                    *[]Location                 `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	IncludedConditionResourcesReferencedByIndication                 *[]Condition                `bson:"_includedConditionResourcesReferencedByIndication,omitempty"`
+	IncludedProcedureResourcesReferencedByIndication                 *[]Procedure                `bson:"_includedProcedureResourcesReferencedByIndication,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                  *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref        *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref        *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedProcedureResourcesReferencingEncounter                *[]Procedure                `bson:"_revIncludedProcedureResourcesReferencingEncounter,omitempty"`
+	RevIncludedListResourcesReferencingItem                          *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingEncounter                     *[]List                     `bson:"_revIncludedListResourcesReferencingEncounter,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingEncounter        *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingEncounter,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref       *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                       *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedVisionPrescriptionResourcesReferencingEncounter       *[]VisionPrescription       `bson:"_revIncludedVisionPrescriptionResourcesReferencingEncounter,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingEncounter         *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingEncounter,omitempty"`
+	RevIncludedFlagResourcesReferencingEncounter                     *[]Flag                     `bson:"_revIncludedFlagResourcesReferencingEncounter,omitempty"`
+	RevIncludedObservationResourcesReferencingEncounter              *[]Observation              `bson:"_revIncludedObservationResourcesReferencingEncounter,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingEncounter *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingEncounter,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingEncounter     *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingEncounter,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingEncounter           *[]RiskAssessment           `bson:"_revIncludedRiskAssessmentResourcesReferencingEncounter,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                      *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingEncounter         *[]DiagnosticReport         `bson:"_revIncludedDiagnosticReportResourcesReferencingEncounter,omitempty"`
+	RevIncludedNutritionOrderResourcesReferencingEncounter           *[]NutritionOrder           `bson:"_revIncludedNutritionOrderResourcesReferencingEncounter,omitempty"`
+	RevIncludedEncounterResourcesReferencingPartof                   *[]Encounter                `bson:"_revIncludedEncounterResourcesReferencingPartof,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference               *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedMedicationOrderResourcesReferencingEncounter          *[]MedicationOrder          `bson:"_revIncludedMedicationOrderResourcesReferencingEncounter,omitempty"`
+	RevIncludedCommunicationResourcesReferencingEncounter            *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingEncounter,omitempty"`
+	RevIncludedConditionResourcesReferencingEncounter                *[]Condition                `bson:"_revIncludedConditionResourcesReferencingEncounter,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEncounter              *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEncounter,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                  *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated           *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingEncounter          *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingEncounter,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment          *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject      *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingEncounter    *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingEncounter,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest            *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger         *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                 *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EncounterPlusIncludes) GetIncludedEpisodeofcareResources() (episodeOfCares []EpisodeOfCare, err error) {
-	if e.IncludedEpisodeofcareResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedEpisodeOfCareResourcesReferencedByEpisodeofcare() (episodeOfCares []EpisodeOfCare, err error) {
+	if e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare == nil {
 		err = errors.New("Included episodeOfCares not requested")
 	} else {
-		episodeOfCares = *e.IncludedEpisodeofcareResources
+		episodeOfCares = *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedIncomingreferralResources() (referralRequests []ReferralRequest, err error) {
-	if e.IncludedIncomingreferralResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedReferralRequestResourcesReferencedByIncomingreferral() (referralRequests []ReferralRequest, err error) {
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral == nil {
 		err = errors.New("Included referralRequests not requested")
 	} else {
-		referralRequests = *e.IncludedIncomingreferralResources
+		referralRequests = *e.IncludedReferralRequestResourcesReferencedByIncomingreferral
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
-	if e.IncludedPractitionerResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPractitioner() (practitioner *Practitioner, err error) {
+	if e.IncludedPractitionerResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*e.IncludedPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResources))
-	} else if len(*e.IncludedPractitionerResources) == 1 {
-		practitioner = &(*e.IncludedPractitionerResources)[0]
+	} else if len(*e.IncludedPractitionerResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResourcesReferencedByPractitioner))
+	} else if len(*e.IncludedPractitionerResourcesReferencedByPractitioner) == 1 {
+		practitioner = &(*e.IncludedPractitionerResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedAppointmentResource() (appointment *Appointment, err error) {
-	if e.IncludedAppointmentResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedAppointmentResourceReferencedByAppointment() (appointment *Appointment, err error) {
+	if e.IncludedAppointmentResourcesReferencedByAppointment == nil {
 		err = errors.New("Included appointments not requested")
-	} else if len(*e.IncludedAppointmentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*e.IncludedAppointmentResources))
-	} else if len(*e.IncludedAppointmentResources) == 1 {
-		appointment = &(*e.IncludedAppointmentResources)[0]
+	} else if len(*e.IncludedAppointmentResourcesReferencedByAppointment) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 appointment, but found %d", len(*e.IncludedAppointmentResourcesReferencedByAppointment))
+	} else if len(*e.IncludedAppointmentResourcesReferencedByAppointment) == 1 {
+		appointment = &(*e.IncludedAppointmentResourcesReferencedByAppointment)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedPartofResource() (encounter *Encounter, err error) {
-	if e.IncludedPartofResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedEncounterResourceReferencedByPartof() (encounter *Encounter, err error) {
+	if e.IncludedEncounterResourcesReferencedByPartof == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*e.IncludedPartofResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*e.IncludedPartofResources))
-	} else if len(*e.IncludedPartofResources) == 1 {
-		encounter = &(*e.IncludedPartofResources)[0]
+	} else if len(*e.IncludedEncounterResourcesReferencedByPartof) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*e.IncludedEncounterResourcesReferencedByPartof))
+	} else if len(*e.IncludedEncounterResourcesReferencedByPartof) == 1 {
+		encounter = &(*e.IncludedEncounterResourcesReferencedByPartof)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedProcedureResources() (procedures []Procedure, err error) {
-	if e.IncludedProcedureResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedProcedureResourcesReferencedByProcedure() (procedures []Procedure, err error) {
+	if e.IncludedProcedureResourcesReferencedByProcedure == nil {
 		err = errors.New("Included procedures not requested")
 	} else {
-		procedures = *e.IncludedProcedureResources
+		procedures = *e.IncludedProcedureResourcesReferencedByProcedure
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedParticipantPractitionerResource() (practitioner *Practitioner, err error) {
-	if e.IncludedParticipantPractitionerResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedPractitionerResourceReferencedByParticipant() (practitioner *Practitioner, err error) {
+	if e.IncludedPractitionerResourcesReferencedByParticipant == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*e.IncludedParticipantPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedParticipantPractitionerResources))
-	} else if len(*e.IncludedParticipantPractitionerResources) == 1 {
-		practitioner = &(*e.IncludedParticipantPractitionerResources)[0]
+	} else if len(*e.IncludedPractitionerResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResourcesReferencedByParticipant))
+	} else if len(*e.IncludedPractitionerResourcesReferencedByParticipant) == 1 {
+		practitioner = &(*e.IncludedPractitionerResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedParticipantRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if e.IncludedParticipantRelatedPersonResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByParticipant() (relatedPerson *RelatedPerson, err error) {
+	if e.IncludedRelatedPersonResourcesReferencedByParticipant == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*e.IncludedParticipantRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*e.IncludedParticipantRelatedPersonResources))
-	} else if len(*e.IncludedParticipantRelatedPersonResources) == 1 {
-		relatedPerson = &(*e.IncludedParticipantRelatedPersonResources)[0]
+	} else if len(*e.IncludedRelatedPersonResourcesReferencedByParticipant) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*e.IncludedRelatedPersonResourcesReferencedByParticipant))
+	} else if len(*e.IncludedRelatedPersonResourcesReferencedByParticipant) == 1 {
+		relatedPerson = &(*e.IncludedRelatedPersonResourcesReferencedByParticipant)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
-	if e.IncludedConditionResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedConditionResourcesReferencedByCondition() (conditions []Condition, err error) {
+	if e.IncludedConditionResourcesReferencedByCondition == nil {
 		err = errors.New("Included conditions not requested")
 	} else {
-		conditions = *e.IncludedConditionResources
+		conditions = *e.IncludedConditionResourcesReferencedByCondition
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if e.IncludedPatientResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if e.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*e.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResources))
-	} else if len(*e.IncludedPatientResources) == 1 {
-		patient = &(*e.IncludedPatientResources)[0]
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*e.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if e.IncludedLocationResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if e.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*e.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*e.IncludedLocationResources))
-	} else if len(*e.IncludedLocationResources) == 1 {
-		location = &(*e.IncludedLocationResources)[0]
+	} else if len(*e.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*e.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*e.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*e.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedIndicationConditionResources() (conditions []Condition, err error) {
-	if e.IncludedIndicationConditionResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedConditionResourcesReferencedByIndication() (conditions []Condition, err error) {
+	if e.IncludedConditionResourcesReferencedByIndication == nil {
 		err = errors.New("Included conditions not requested")
 	} else {
-		conditions = *e.IncludedIndicationConditionResources
+		conditions = *e.IncludedConditionResourcesReferencedByIndication
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedIndicationProcedureResources() (procedures []Procedure, err error) {
-	if e.IncludedIndicationProcedureResources == nil {
+func (e *EncounterPlusRelatedResources) GetIncludedProcedureResourcesReferencedByIndication() (procedures []Procedure, err error) {
+	if e.IncludedProcedureResourcesReferencedByIndication == nil {
 		err = errors.New("Included procedures not requested")
 	} else {
-		procedures = *e.IncludedIndicationProcedureResources
+		procedures = *e.IncludedProcedureResourcesReferencedByIndication
 	}
 	return
 }
 
-func (e *EncounterPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EncounterPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingEncounter() (procedures []Procedure, err error) {
+	if e.RevIncludedProcedureResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *e.RevIncludedProcedureResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedListResourcesReferencingEncounter() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingEncounter() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedVisionPrescriptionResourcesReferencingEncounter() (visionPrescriptions []VisionPrescription, err error) {
+	if e.RevIncludedVisionPrescriptionResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded visionPrescriptions not requested")
+	} else {
+		visionPrescriptions = *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingEncounter() (procedureRequests []ProcedureRequest, err error) {
+	if e.RevIncludedProcedureRequestResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *e.RevIncludedProcedureRequestResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedFlagResourcesReferencingEncounter() (flags []Flag, err error) {
+	if e.RevIncludedFlagResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *e.RevIncludedFlagResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedObservationResourcesReferencingEncounter() (observations []Observation, err error) {
+	if e.RevIncludedObservationResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *e.RevIncludedObservationResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingEncounter() (medicationAdministrations []MedicationAdministration, err error) {
+	if e.RevIncludedMedicationAdministrationResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingEncounter() (communicationRequests []CommunicationRequest, err error) {
+	if e.RevIncludedCommunicationRequestResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *e.RevIncludedCommunicationRequestResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingEncounter() (riskAssessments []RiskAssessment, err error) {
+	if e.RevIncludedRiskAssessmentResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *e.RevIncludedRiskAssessmentResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingEncounter() (diagnosticReports []DiagnosticReport, err error) {
+	if e.RevIncludedDiagnosticReportResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *e.RevIncludedDiagnosticReportResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedNutritionOrderResourcesReferencingEncounter() (nutritionOrders []NutritionOrder, err error) {
+	if e.RevIncludedNutritionOrderResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded nutritionOrders not requested")
+	} else {
+		nutritionOrders = *e.RevIncludedNutritionOrderResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingPartof() (encounters []Encounter, err error) {
+	if e.RevIncludedEncounterResourcesReferencingPartof == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *e.RevIncludedEncounterResourcesReferencingPartof
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedMedicationOrderResourcesReferencingEncounter() (medicationOrders []MedicationOrder, err error) {
+	if e.RevIncludedMedicationOrderResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded medicationOrders not requested")
+	} else {
+		medicationOrders = *e.RevIncludedMedicationOrderResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingEncounter() (communications []Communication, err error) {
+	if e.RevIncludedCommunicationResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *e.RevIncludedCommunicationResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedConditionResourcesReferencingEncounter() (conditions []Condition, err error) {
+	if e.RevIncludedConditionResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded conditions not requested")
+	} else {
+		conditions = *e.RevIncludedConditionResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEncounter() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingEncounter() (diagnosticOrders []DiagnosticOrder, err error) {
+	if e.RevIncludedDiagnosticOrderResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingEncounter() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EncounterPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if e.IncludedEpisodeofcareResources != nil {
-		for _, r := range *e.IncludedEpisodeofcareResources {
+	if e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare != nil {
+		for _, r := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedIncomingreferralResources != nil {
-		for _, r := range *e.IncludedIncomingreferralResources {
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
+		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedPractitionerResources != nil {
-		for _, r := range *e.IncludedPractitionerResources {
+	if e.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedAppointmentResources != nil {
-		for _, r := range *e.IncludedAppointmentResources {
+	if e.IncludedAppointmentResourcesReferencedByAppointment != nil {
+		for _, r := range *e.IncludedAppointmentResourcesReferencedByAppointment {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedPartofResources != nil {
-		for _, r := range *e.IncludedPartofResources {
+	if e.IncludedEncounterResourcesReferencedByPartof != nil {
+		for _, r := range *e.IncludedEncounterResourcesReferencedByPartof {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedProcedureResources != nil {
-		for _, r := range *e.IncludedProcedureResources {
+	if e.IncludedProcedureResourcesReferencedByProcedure != nil {
+		for _, r := range *e.IncludedProcedureResourcesReferencedByProcedure {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedParticipantPractitionerResources != nil {
-		for _, r := range *e.IncludedParticipantPractitionerResources {
+	if e.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedParticipantRelatedPersonResources != nil {
-		for _, r := range *e.IncludedParticipantRelatedPersonResources {
+	if e.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedConditionResources != nil {
-		for _, r := range *e.IncludedConditionResources {
+	if e.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedPatientResources != nil {
-		for _, r := range *e.IncludedPatientResources {
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedLocationResources != nil {
-		for _, r := range *e.IncludedLocationResources {
+	if e.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *e.IncludedLocationResourcesReferencedByLocation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedIndicationConditionResources != nil {
-		for _, r := range *e.IncludedIndicationConditionResources {
+	if e.IncludedConditionResourcesReferencedByIndication != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByIndication {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedIndicationProcedureResources != nil {
-		for _, r := range *e.IncludedIndicationProcedureResources {
+	if e.IncludedProcedureResourcesReferencedByIndication != nil {
+		for _, r := range *e.IncludedProcedureResourcesReferencedByIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EncounterPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcedureResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedProcedureResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedVisionPrescriptionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcedureRequestResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedFlagResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedFlagResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedObservationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedObservationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMedicationAdministrationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCommunicationRequestResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedRiskAssessmentResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDiagnosticReportResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedNutritionOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedEncounterResourcesReferencingPartof != nil {
+		for _, r := range *e.RevIncludedEncounterResourcesReferencingPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMedicationOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCommunicationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedConditionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedConditionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDiagnosticOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EncounterPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare != nil {
+		for _, r := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
+		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedAppointmentResourcesReferencedByAppointment != nil {
+		for _, r := range *e.IncludedAppointmentResourcesReferencedByAppointment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedEncounterResourcesReferencedByPartof != nil {
+		for _, r := range *e.IncludedEncounterResourcesReferencedByPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedProcedureResourcesReferencedByProcedure != nil {
+		for _, r := range *e.IncludedProcedureResourcesReferencedByProcedure {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPractitionerResourcesReferencedByParticipant != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
+		for _, r := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *e.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedConditionResourcesReferencedByIndication != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedProcedureResourcesReferencedByIndication != nil {
+		for _, r := range *e.IncludedProcedureResourcesReferencedByIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcedureResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedProcedureResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedVisionPrescriptionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcedureRequestResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedFlagResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedFlagResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedObservationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedObservationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMedicationAdministrationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCommunicationRequestResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedRiskAssessmentResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDiagnosticReportResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedNutritionOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedEncounterResourcesReferencingPartof != nil {
+		for _, r := range *e.RevIncludedEncounterResourcesReferencingPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMedicationOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCommunicationResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedConditionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedConditionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDiagnosticOrderResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/enrollmentrequest.go
+++ b/models/enrollmentrequest.go
@@ -89,46 +89,386 @@ func (x *EnrollmentRequest) checkResourceType() error {
 }
 
 type EnrollmentRequestPlus struct {
-	EnrollmentRequest             `bson:",inline"`
-	EnrollmentRequestPlusIncludes `bson:",inline"`
+	EnrollmentRequest                     `bson:",inline"`
+	EnrollmentRequestPlusRelatedResources `bson:",inline"`
 }
 
-type EnrollmentRequestPlusIncludes struct {
-	IncludedSubjectResources *[]Patient `bson:"_includedSubjectResources,omitempty"`
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+type EnrollmentRequestPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EnrollmentRequestPlusIncludes) GetIncludedSubjectResource() (patient *Patient, err error) {
-	if e.IncludedSubjectResources == nil {
+func (e *EnrollmentRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if e.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*e.IncludedSubjectResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedSubjectResources))
-	} else if len(*e.IncludedSubjectResources) == 1 {
-		patient = &(*e.IncludedSubjectResources)[0]
+	} else if len(*e.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*e.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*e.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (e *EnrollmentRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if e.IncludedPatientResources == nil {
+func (e *EnrollmentRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if e.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*e.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResources))
-	} else if len(*e.IncludedPatientResources) == 1 {
-		patient = &(*e.IncludedPatientResources)[0]
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*e.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (e *EnrollmentRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if e.IncludedSubjectResources != nil {
-		for _, r := range *e.IncludedSubjectResources {
+	if e.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedPatientResources != nil {
-		for _, r := range *e.IncludedPatientResources {
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EnrollmentRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/enrollmentresponse.go
+++ b/models/enrollmentresponse.go
@@ -89,14 +89,344 @@ func (x *EnrollmentResponse) checkResourceType() error {
 }
 
 type EnrollmentResponsePlus struct {
-	EnrollmentResponse             `bson:",inline"`
-	EnrollmentResponsePlusIncludes `bson:",inline"`
+	EnrollmentResponse                     `bson:",inline"`
+	EnrollmentResponsePlusRelatedResources `bson:",inline"`
 }
 
-type EnrollmentResponsePlusIncludes struct {
+type EnrollmentResponsePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EnrollmentResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EnrollmentResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -101,127 +101,512 @@ type EpisodeOfCareCareTeamComponent struct {
 }
 
 type EpisodeOfCarePlus struct {
-	EpisodeOfCare             `bson:",inline"`
-	EpisodeOfCarePlusIncludes `bson:",inline"`
+	EpisodeOfCare                     `bson:",inline"`
+	EpisodeOfCarePlusRelatedResources `bson:",inline"`
 }
 
-type EpisodeOfCarePlusIncludes struct {
-	IncludedConditionResources              *[]Condition       `bson:"_includedConditionResources,omitempty"`
-	IncludedIncomingreferralResources       *[]ReferralRequest `bson:"_includedIncomingreferralResources,omitempty"`
-	IncludedPatientResources                *[]Patient         `bson:"_includedPatientResources,omitempty"`
-	IncludedOrganizationResources           *[]Organization    `bson:"_includedOrganizationResources,omitempty"`
-	IncludedTeammemberPractitionerResources *[]Practitioner    `bson:"_includedTeammemberPractitionerResources,omitempty"`
-	IncludedTeammemberOrganizationResources *[]Organization    `bson:"_includedTeammemberOrganizationResources,omitempty"`
-	IncludedCaremanagerResources            *[]Practitioner    `bson:"_includedCaremanagerResources,omitempty"`
+type EpisodeOfCarePlusRelatedResources struct {
+	IncludedConditionResourcesReferencedByCondition              *[]Condition             `bson:"_includedConditionResourcesReferencedByCondition,omitempty"`
+	IncludedReferralRequestResourcesReferencedByIncomingreferral *[]ReferralRequest       `bson:"_includedReferralRequestResourcesReferencedByIncomingreferral,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                  *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization        *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	IncludedPractitionerResourcesReferencedByTeammember          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByTeammember,omitempty"`
+	IncludedOrganizationResourcesReferencedByTeammember          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByTeammember,omitempty"`
+	IncludedPractitionerResourcesReferencedByCaremanager         *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByCaremanager,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget              *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                      *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref   *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                   *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                  *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedEncounterResourcesReferencingEpisodeofcare        *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingEpisodeofcare,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference           *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject            *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated       *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment      *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject  *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest        *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData             *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedConditionResources() (conditions []Condition, err error) {
-	if e.IncludedConditionResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedConditionResourcesReferencedByCondition() (conditions []Condition, err error) {
+	if e.IncludedConditionResourcesReferencedByCondition == nil {
 		err = errors.New("Included conditions not requested")
 	} else {
-		conditions = *e.IncludedConditionResources
+		conditions = *e.IncludedConditionResourcesReferencedByCondition
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedIncomingreferralResources() (referralRequests []ReferralRequest, err error) {
-	if e.IncludedIncomingreferralResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedReferralRequestResourcesReferencedByIncomingreferral() (referralRequests []ReferralRequest, err error) {
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral == nil {
 		err = errors.New("Included referralRequests not requested")
 	} else {
-		referralRequests = *e.IncludedIncomingreferralResources
+		referralRequests = *e.IncludedReferralRequestResourcesReferencedByIncomingreferral
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if e.IncludedPatientResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if e.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*e.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResources))
-	} else if len(*e.IncludedPatientResources) == 1 {
-		patient = &(*e.IncludedPatientResources)[0]
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*e.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*e.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*e.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if e.IncludedOrganizationResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if e.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*e.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedOrganizationResources))
-	} else if len(*e.IncludedOrganizationResources) == 1 {
-		organization = &(*e.IncludedOrganizationResources)[0]
+	} else if len(*e.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*e.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*e.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedTeammemberPractitionerResource() (practitioner *Practitioner, err error) {
-	if e.IncludedTeammemberPractitionerResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedPractitionerResourceReferencedByTeammember() (practitioner *Practitioner, err error) {
+	if e.IncludedPractitionerResourcesReferencedByTeammember == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*e.IncludedTeammemberPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedTeammemberPractitionerResources))
-	} else if len(*e.IncludedTeammemberPractitionerResources) == 1 {
-		practitioner = &(*e.IncludedTeammemberPractitionerResources)[0]
+	} else if len(*e.IncludedPractitionerResourcesReferencedByTeammember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResourcesReferencedByTeammember))
+	} else if len(*e.IncludedPractitionerResourcesReferencedByTeammember) == 1 {
+		practitioner = &(*e.IncludedPractitionerResourcesReferencedByTeammember)[0]
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedTeammemberOrganizationResource() (organization *Organization, err error) {
-	if e.IncludedTeammemberOrganizationResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedOrganizationResourceReferencedByTeammember() (organization *Organization, err error) {
+	if e.IncludedOrganizationResourcesReferencedByTeammember == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*e.IncludedTeammemberOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedTeammemberOrganizationResources))
-	} else if len(*e.IncludedTeammemberOrganizationResources) == 1 {
-		organization = &(*e.IncludedTeammemberOrganizationResources)[0]
+	} else if len(*e.IncludedOrganizationResourcesReferencedByTeammember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*e.IncludedOrganizationResourcesReferencedByTeammember))
+	} else if len(*e.IncludedOrganizationResourcesReferencedByTeammember) == 1 {
+		organization = &(*e.IncludedOrganizationResourcesReferencedByTeammember)[0]
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedCaremanagerResource() (practitioner *Practitioner, err error) {
-	if e.IncludedCaremanagerResources == nil {
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedPractitionerResourceReferencedByCaremanager() (practitioner *Practitioner, err error) {
+	if e.IncludedPractitionerResourcesReferencedByCaremanager == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*e.IncludedCaremanagerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedCaremanagerResources))
-	} else if len(*e.IncludedCaremanagerResources) == 1 {
-		practitioner = &(*e.IncludedCaremanagerResources)[0]
+	} else if len(*e.IncludedPractitionerResourcesReferencedByCaremanager) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*e.IncludedPractitionerResourcesReferencedByCaremanager))
+	} else if len(*e.IncludedPractitionerResourcesReferencedByCaremanager) == 1 {
+		practitioner = &(*e.IncludedPractitionerResourcesReferencedByCaremanager)[0]
 	}
 	return
 }
 
-func (e *EpisodeOfCarePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedEncounterResourcesReferencingEpisodeofcare() (encounters []Encounter, err error) {
+	if e.RevIncludedEncounterResourcesReferencingEpisodeofcare == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *e.RevIncludedEncounterResourcesReferencingEpisodeofcare
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if e.IncludedConditionResources != nil {
-		for _, r := range *e.IncludedConditionResources {
+	if e.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedIncomingreferralResources != nil {
-		for _, r := range *e.IncludedIncomingreferralResources {
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
+		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedPatientResources != nil {
-		for _, r := range *e.IncludedPatientResources {
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedOrganizationResources != nil {
-		for _, r := range *e.IncludedOrganizationResources {
+	if e.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *e.IncludedOrganizationResourcesReferencedByOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedTeammemberPractitionerResources != nil {
-		for _, r := range *e.IncludedTeammemberPractitionerResources {
+	if e.IncludedPractitionerResourcesReferencedByTeammember != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByTeammember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedTeammemberOrganizationResources != nil {
-		for _, r := range *e.IncludedTeammemberOrganizationResources {
+	if e.IncludedOrganizationResourcesReferencedByTeammember != nil {
+		for _, r := range *e.IncludedOrganizationResourcesReferencedByTeammember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if e.IncludedCaremanagerResources != nil {
-		for _, r := range *e.IncludedCaremanagerResources {
+	if e.IncludedPractitionerResourcesReferencedByCaremanager != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedEncounterResourcesReferencingEpisodeofcare != nil {
+		for _, r := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *EpisodeOfCarePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
+		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *e.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPractitionerResourcesReferencedByTeammember != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedOrganizationResourcesReferencedByTeammember != nil {
+		for _, r := range *e.IncludedOrganizationResourcesReferencedByTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.IncludedPractitionerResourcesReferencedByCaremanager != nil {
+		for _, r := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedEncounterResourcesReferencingEpisodeofcare != nil {
+		for _, r := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/explanationofbenefit.go
+++ b/models/explanationofbenefit.go
@@ -89,14 +89,344 @@ func (x *ExplanationOfBenefit) checkResourceType() error {
 }
 
 type ExplanationOfBenefitPlus struct {
-	ExplanationOfBenefit             `bson:",inline"`
-	ExplanationOfBenefitPlusIncludes `bson:",inline"`
+	ExplanationOfBenefit                     `bson:",inline"`
+	ExplanationOfBenefitPlusRelatedResources `bson:",inline"`
 }
 
-type ExplanationOfBenefitPlusIncludes struct {
+type ExplanationOfBenefitPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (e *ExplanationOfBenefitPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if e.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *e.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *e.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if e.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *e.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if e.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *e.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if e.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *e.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if e.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *e.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if e.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *e.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *e.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *e.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if e.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *e.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *e.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if e.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *e.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (e *ExplanationOfBenefitPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *e.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/familymemberhistory.go
+++ b/models/familymemberhistory.go
@@ -109,29 +109,384 @@ type FamilyMemberHistoryConditionComponent struct {
 }
 
 type FamilyMemberHistoryPlus struct {
-	FamilyMemberHistory             `bson:",inline"`
-	FamilyMemberHistoryPlusIncludes `bson:",inline"`
+	FamilyMemberHistory                     `bson:",inline"`
+	FamilyMemberHistoryPlusRelatedResources `bson:",inline"`
 }
 
-type FamilyMemberHistoryPlusIncludes struct {
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+type FamilyMemberHistoryPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                    *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                        *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref     *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                     *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                    *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference             *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated         *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment        *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject    *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest          *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingInvestigation *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingInvestigation,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData               *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (f *FamilyMemberHistoryPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if f.IncludedPatientResources == nil {
+func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if f.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*f.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResources))
-	} else if len(*f.IncludedPatientResources) == 1 {
-		patient = &(*f.IncludedPatientResources)[0]
+	} else if len(*f.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*f.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*f.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (f *FamilyMemberHistoryPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if f.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *f.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *f.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *f.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if f.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *f.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if f.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *f.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if f.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *f.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if f.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *f.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if f.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *f.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if f.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *f.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *f.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *f.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if f.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *f.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *f.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingInvestigation() (clinicalImpressions []ClinicalImpression, err error) {
+	if f.RevIncludedClinicalImpressionResourcesReferencingInvestigation == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if f.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *f.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if f.IncludedPatientResources != nil {
-		for _, r := range *f.IncludedPatientResources {
+	if f.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *f.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if f.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *f.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/flag.go
+++ b/models/flag.go
@@ -87,199 +87,584 @@ func (x *Flag) checkResourceType() error {
 }
 
 type FlagPlus struct {
-	Flag             `bson:",inline"`
-	FlagPlusIncludes `bson:",inline"`
+	Flag                     `bson:",inline"`
+	FlagPlusRelatedResources `bson:",inline"`
 }
 
-type FlagPlusIncludes struct {
-	IncludedSubjectPractitionerResources *[]Practitioner `bson:"_includedSubjectPractitionerResources,omitempty"`
-	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectOrganizationResources *[]Organization `bson:"_includedSubjectOrganizationResources,omitempty"`
-	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectLocationResources     *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedAuthorPractitionerResources  *[]Practitioner `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorOrganizationResources  *[]Organization `bson:"_includedAuthorOrganizationResources,omitempty"`
-	IncludedAuthorDeviceResources        *[]Device       `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources       *[]Patient      `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedEncounterResources           *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type FlagPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedBySubject            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySubject,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedOrganizationResourcesReferencedBySubject            *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                *[]Location              `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedOrganizationResourcesReferencedByAuthor             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (f *FlagPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
-	if f.IncludedSubjectPractitionerResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySubject() (practitioner *Practitioner, err error) {
+	if f.IncludedPractitionerResourcesReferencedBySubject == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*f.IncludedSubjectPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedSubjectPractitionerResources))
-	} else if len(*f.IncludedSubjectPractitionerResources) == 1 {
-		practitioner = &(*f.IncludedSubjectPractitionerResources)[0]
+	} else if len(*f.IncludedPractitionerResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedPractitionerResourcesReferencedBySubject))
+	} else if len(*f.IncludedPractitionerResourcesReferencedBySubject) == 1 {
+		practitioner = &(*f.IncludedPractitionerResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if f.IncludedSubjectGroupResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if f.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*f.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*f.IncludedSubjectGroupResources))
-	} else if len(*f.IncludedSubjectGroupResources) == 1 {
-		group = &(*f.IncludedSubjectGroupResources)[0]
+	} else if len(*f.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*f.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*f.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*f.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
-	if f.IncludedSubjectOrganizationResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySubject() (organization *Organization, err error) {
+	if f.IncludedOrganizationResourcesReferencedBySubject == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*f.IncludedSubjectOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedSubjectOrganizationResources))
-	} else if len(*f.IncludedSubjectOrganizationResources) == 1 {
-		organization = &(*f.IncludedSubjectOrganizationResources)[0]
+	} else if len(*f.IncludedOrganizationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedOrganizationResourcesReferencedBySubject))
+	} else if len(*f.IncludedOrganizationResourcesReferencedBySubject) == 1 {
+		organization = &(*f.IncludedOrganizationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if f.IncludedSubjectPatientResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if f.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*f.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedSubjectPatientResources))
-	} else if len(*f.IncludedSubjectPatientResources) == 1 {
-		patient = &(*f.IncludedSubjectPatientResources)[0]
+	} else if len(*f.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*f.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*f.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if f.IncludedSubjectLocationResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if f.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*f.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*f.IncludedSubjectLocationResources))
-	} else if len(*f.IncludedSubjectLocationResources) == 1 {
-		location = &(*f.IncludedSubjectLocationResources)[0]
+	} else if len(*f.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*f.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*f.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*f.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if f.IncludedPatientResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if f.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*f.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResources))
-	} else if len(*f.IncludedPatientResources) == 1 {
-		patient = &(*f.IncludedPatientResources)[0]
+	} else if len(*f.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*f.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*f.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
-	if f.IncludedAuthorPractitionerResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if f.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*f.IncludedAuthorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedAuthorPractitionerResources))
-	} else if len(*f.IncludedAuthorPractitionerResources) == 1 {
-		practitioner = &(*f.IncludedAuthorPractitionerResources)[0]
+	} else if len(*f.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*f.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*f.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*f.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedAuthorOrganizationResource() (organization *Organization, err error) {
-	if f.IncludedAuthorOrganizationResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedOrganizationResourceReferencedByAuthor() (organization *Organization, err error) {
+	if f.IncludedOrganizationResourcesReferencedByAuthor == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*f.IncludedAuthorOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedAuthorOrganizationResources))
-	} else if len(*f.IncludedAuthorOrganizationResources) == 1 {
-		organization = &(*f.IncludedAuthorOrganizationResources)[0]
+	} else if len(*f.IncludedOrganizationResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*f.IncludedOrganizationResourcesReferencedByAuthor))
+	} else if len(*f.IncludedOrganizationResourcesReferencedByAuthor) == 1 {
+		organization = &(*f.IncludedOrganizationResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
-	if f.IncludedAuthorDeviceResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedDeviceResourceReferencedByAuthor() (device *Device, err error) {
+	if f.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*f.IncludedAuthorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*f.IncludedAuthorDeviceResources))
-	} else if len(*f.IncludedAuthorDeviceResources) == 1 {
-		device = &(*f.IncludedAuthorDeviceResources)[0]
+	} else if len(*f.IncludedDeviceResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*f.IncludedDeviceResourcesReferencedByAuthor))
+	} else if len(*f.IncludedDeviceResourcesReferencedByAuthor) == 1 {
+		device = &(*f.IncludedDeviceResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
-	if f.IncludedAuthorPatientResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedPatientResourceReferencedByAuthor() (patient *Patient, err error) {
+	if f.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*f.IncludedAuthorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedAuthorPatientResources))
-	} else if len(*f.IncludedAuthorPatientResources) == 1 {
-		patient = &(*f.IncludedAuthorPatientResources)[0]
+	} else if len(*f.IncludedPatientResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*f.IncludedPatientResourcesReferencedByAuthor))
+	} else if len(*f.IncludedPatientResourcesReferencedByAuthor) == 1 {
+		patient = &(*f.IncludedPatientResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if f.IncludedEncounterResources == nil {
+func (f *FlagPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if f.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*f.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*f.IncludedEncounterResources))
-	} else if len(*f.IncludedEncounterResources) == 1 {
-		encounter = &(*f.IncludedEncounterResources)[0]
+	} else if len(*f.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*f.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*f.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*f.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (f *FlagPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (f *FlagPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if f.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *f.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *f.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *f.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if f.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *f.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if f.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *f.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if f.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *f.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if f.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *f.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if f.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *f.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if f.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *f.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *f.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *f.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if f.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *f.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *f.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if f.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *f.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (f *FlagPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if f.IncludedSubjectPractitionerResources != nil {
-		for _, r := range *f.IncludedSubjectPractitionerResources {
+	if f.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedPractitionerResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedSubjectGroupResources != nil {
-		for _, r := range *f.IncludedSubjectGroupResources {
+	if f.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedSubjectOrganizationResources != nil {
-		for _, r := range *f.IncludedSubjectOrganizationResources {
+	if f.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedOrganizationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedSubjectPatientResources != nil {
-		for _, r := range *f.IncludedSubjectPatientResources {
+	if f.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedSubjectLocationResources != nil {
-		for _, r := range *f.IncludedSubjectLocationResources {
+	if f.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedPatientResources != nil {
-		for _, r := range *f.IncludedPatientResources {
+	if f.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *f.IncludedAuthorPractitionerResources {
+	if f.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedAuthorOrganizationResources != nil {
-		for _, r := range *f.IncludedAuthorOrganizationResources {
+	if f.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedOrganizationResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedAuthorDeviceResources != nil {
-		for _, r := range *f.IncludedAuthorDeviceResources {
+	if f.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedAuthorPatientResources != nil {
-		for _, r := range *f.IncludedAuthorPatientResources {
+	if f.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if f.IncludedEncounterResources != nil {
-		for _, r := range *f.IncludedEncounterResources {
+	if f.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *f.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (f *FlagPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *f.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (f *FlagPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if f.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedPractitionerResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedOrganizationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *f.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedOrganizationResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *f.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *f.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *f.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/goal.go
+++ b/models/goal.go
@@ -100,80 +100,450 @@ type GoalOutcomeComponent struct {
 }
 
 type GoalPlus struct {
-	Goal             `bson:",inline"`
-	GoalPlusIncludes `bson:",inline"`
+	Goal                     `bson:",inline"`
+	GoalPlusRelatedResources `bson:",inline"`
 }
 
-type GoalPlusIncludes struct {
-	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectOrganizationResources *[]Organization `bson:"_includedSubjectOrganizationResources,omitempty"`
-	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
+type GoalPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedOrganizationResourcesReferencedBySubject            *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingGoal                 *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingGoal,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (g *GoalPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if g.IncludedPatientResources == nil {
+func (g *GoalPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if g.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*g.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedPatientResources))
-	} else if len(*g.IncludedPatientResources) == 1 {
-		patient = &(*g.IncludedPatientResources)[0]
+	} else if len(*g.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*g.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*g.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (g *GoalPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if g.IncludedSubjectGroupResources == nil {
+func (g *GoalPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if g.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*g.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*g.IncludedSubjectGroupResources))
-	} else if len(*g.IncludedSubjectGroupResources) == 1 {
-		group = &(*g.IncludedSubjectGroupResources)[0]
+	} else if len(*g.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*g.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*g.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*g.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (g *GoalPlusIncludes) GetIncludedSubjectOrganizationResource() (organization *Organization, err error) {
-	if g.IncludedSubjectOrganizationResources == nil {
+func (g *GoalPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySubject() (organization *Organization, err error) {
+	if g.IncludedOrganizationResourcesReferencedBySubject == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*g.IncludedSubjectOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*g.IncludedSubjectOrganizationResources))
-	} else if len(*g.IncludedSubjectOrganizationResources) == 1 {
-		organization = &(*g.IncludedSubjectOrganizationResources)[0]
+	} else if len(*g.IncludedOrganizationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*g.IncludedOrganizationResourcesReferencedBySubject))
+	} else if len(*g.IncludedOrganizationResourcesReferencedBySubject) == 1 {
+		organization = &(*g.IncludedOrganizationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (g *GoalPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if g.IncludedSubjectPatientResources == nil {
+func (g *GoalPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if g.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*g.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedSubjectPatientResources))
-	} else if len(*g.IncludedSubjectPatientResources) == 1 {
-		patient = &(*g.IncludedSubjectPatientResources)[0]
+	} else if len(*g.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*g.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*g.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (g *GoalPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (g *GoalPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if g.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *g.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *g.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *g.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingGoal() (carePlans []CarePlan, err error) {
+	if g.RevIncludedCarePlanResourcesReferencingGoal == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *g.RevIncludedCarePlanResourcesReferencingGoal
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if g.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *g.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if g.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *g.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if g.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *g.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if g.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *g.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if g.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *g.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if g.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *g.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *g.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *g.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if g.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *g.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *g.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if g.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *g.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (g *GoalPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if g.IncludedPatientResources != nil {
-		for _, r := range *g.IncludedPatientResources {
+	if g.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedSubjectGroupResources != nil {
-		for _, r := range *g.IncludedSubjectGroupResources {
+	if g.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedSubjectOrganizationResources != nil {
-		for _, r := range *g.IncludedSubjectOrganizationResources {
+	if g.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedOrganizationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedSubjectPatientResources != nil {
-		for _, r := range *g.IncludedSubjectPatientResources {
+	if g.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (g *GoalPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCarePlanResourcesReferencingGoal != nil {
+		for _, r := range *g.RevIncludedCarePlanResourcesReferencingGoal {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (g *GoalPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedOrganizationResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedOrganizationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCarePlanResourcesReferencingGoal != nil {
+		for _, r := range *g.RevIncludedCarePlanResourcesReferencingGoal {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/group.go
+++ b/models/group.go
@@ -103,97 +103,792 @@ type GroupMemberComponent struct {
 }
 
 type GroupPlus struct {
-	Group             `bson:",inline"`
-	GroupPlusIncludes `bson:",inline"`
+	Group                     `bson:",inline"`
+	GroupPlusRelatedResources `bson:",inline"`
 }
 
-type GroupPlusIncludes struct {
-	IncludedMemberPractitionerResources *[]Practitioner `bson:"_includedMemberPractitionerResources,omitempty"`
-	IncludedMemberDeviceResources       *[]Device       `bson:"_includedMemberDeviceResources,omitempty"`
-	IncludedMemberMedicationResources   *[]Medication   `bson:"_includedMemberMedicationResources,omitempty"`
-	IncludedMemberPatientResources      *[]Patient      `bson:"_includedMemberPatientResources,omitempty"`
-	IncludedMemberSubstanceResources    *[]Substance    `bson:"_includedMemberSubstanceResources,omitempty"`
+type GroupPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByMember             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByMember,omitempty"`
+	IncludedDeviceResourcesReferencedByMember                   *[]Device                `bson:"_includedDeviceResourcesReferencedByMember,omitempty"`
+	IncludedMedicationResourcesReferencedByMember               *[]Medication            `bson:"_includedMedicationResourcesReferencedByMember,omitempty"`
+	IncludedPatientResourcesReferencedByMember                  *[]Patient               `bson:"_includedPatientResourcesReferencedByMember,omitempty"`
+	IncludedSubstanceResourcesReferencedByMember                *[]Substance             `bson:"_includedSubstanceResourcesReferencedByMember,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingSubject      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedSpecimenResourcesReferencingSubject              *[]Specimen              `bson:"_revIncludedSpecimenResourcesReferencingSubject,omitempty"`
+	RevIncludedCarePlanResourcesReferencingSubject              *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingSubject,omitempty"`
+	RevIncludedGoalResourcesReferencingSubject                  *[]Goal                  `bson:"_revIncludedGoalResourcesReferencingSubject,omitempty"`
+	RevIncludedProcedureResourcesReferencingSubject             *[]Procedure             `bson:"_revIncludedProcedureResourcesReferencingSubject,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingSubject                  *[]List                  `bson:"_revIncludedListResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingSubject     *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSubject                 *[]Order                 `bson:"_revIncludedOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedMediaResourcesReferencingSubject                 *[]Media                 `bson:"_revIncludedMediaResourcesReferencingSubject,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingSubject      *[]ProcedureRequest      `bson:"_revIncludedProcedureRequestResourcesReferencingSubject,omitempty"`
+	RevIncludedFlagResourcesReferencingSubject                  *[]Flag                  `bson:"_revIncludedFlagResourcesReferencingSubject,omitempty"`
+	RevIncludedObservationResourcesReferencingSubject           *[]Observation           `bson:"_revIncludedObservationResourcesReferencingSubject,omitempty"`
+	RevIncludedContractResourcesReferencingActor                *[]Contract              `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingSubject        *[]RiskAssessment        `bson:"_revIncludedRiskAssessmentResourcesReferencingSubject,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingSubject      *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient       *[]Communication         `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSubject       *[]DiagnosticOrder       `bson:"_revIncludedDiagnosticOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (g *GroupPlusIncludes) GetIncludedMemberPractitionerResource() (practitioner *Practitioner, err error) {
-	if g.IncludedMemberPractitionerResources == nil {
+func (g *GroupPlusRelatedResources) GetIncludedPractitionerResourceReferencedByMember() (practitioner *Practitioner, err error) {
+	if g.IncludedPractitionerResourcesReferencedByMember == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*g.IncludedMemberPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*g.IncludedMemberPractitionerResources))
-	} else if len(*g.IncludedMemberPractitionerResources) == 1 {
-		practitioner = &(*g.IncludedMemberPractitionerResources)[0]
+	} else if len(*g.IncludedPractitionerResourcesReferencedByMember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*g.IncludedPractitionerResourcesReferencedByMember))
+	} else if len(*g.IncludedPractitionerResourcesReferencedByMember) == 1 {
+		practitioner = &(*g.IncludedPractitionerResourcesReferencedByMember)[0]
 	}
 	return
 }
 
-func (g *GroupPlusIncludes) GetIncludedMemberDeviceResource() (device *Device, err error) {
-	if g.IncludedMemberDeviceResources == nil {
+func (g *GroupPlusRelatedResources) GetIncludedDeviceResourceReferencedByMember() (device *Device, err error) {
+	if g.IncludedDeviceResourcesReferencedByMember == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*g.IncludedMemberDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*g.IncludedMemberDeviceResources))
-	} else if len(*g.IncludedMemberDeviceResources) == 1 {
-		device = &(*g.IncludedMemberDeviceResources)[0]
+	} else if len(*g.IncludedDeviceResourcesReferencedByMember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*g.IncludedDeviceResourcesReferencedByMember))
+	} else if len(*g.IncludedDeviceResourcesReferencedByMember) == 1 {
+		device = &(*g.IncludedDeviceResourcesReferencedByMember)[0]
 	}
 	return
 }
 
-func (g *GroupPlusIncludes) GetIncludedMemberMedicationResource() (medication *Medication, err error) {
-	if g.IncludedMemberMedicationResources == nil {
+func (g *GroupPlusRelatedResources) GetIncludedMedicationResourceReferencedByMember() (medication *Medication, err error) {
+	if g.IncludedMedicationResourcesReferencedByMember == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*g.IncludedMemberMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*g.IncludedMemberMedicationResources))
-	} else if len(*g.IncludedMemberMedicationResources) == 1 {
-		medication = &(*g.IncludedMemberMedicationResources)[0]
+	} else if len(*g.IncludedMedicationResourcesReferencedByMember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*g.IncludedMedicationResourcesReferencedByMember))
+	} else if len(*g.IncludedMedicationResourcesReferencedByMember) == 1 {
+		medication = &(*g.IncludedMedicationResourcesReferencedByMember)[0]
 	}
 	return
 }
 
-func (g *GroupPlusIncludes) GetIncludedMemberPatientResource() (patient *Patient, err error) {
-	if g.IncludedMemberPatientResources == nil {
+func (g *GroupPlusRelatedResources) GetIncludedPatientResourceReferencedByMember() (patient *Patient, err error) {
+	if g.IncludedPatientResourcesReferencedByMember == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*g.IncludedMemberPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedMemberPatientResources))
-	} else if len(*g.IncludedMemberPatientResources) == 1 {
-		patient = &(*g.IncludedMemberPatientResources)[0]
+	} else if len(*g.IncludedPatientResourcesReferencedByMember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*g.IncludedPatientResourcesReferencedByMember))
+	} else if len(*g.IncludedPatientResourcesReferencedByMember) == 1 {
+		patient = &(*g.IncludedPatientResourcesReferencedByMember)[0]
 	}
 	return
 }
 
-func (g *GroupPlusIncludes) GetIncludedMemberSubstanceResource() (substance *Substance, err error) {
-	if g.IncludedMemberSubstanceResources == nil {
+func (g *GroupPlusRelatedResources) GetIncludedSubstanceResourceReferencedByMember() (substance *Substance, err error) {
+	if g.IncludedSubstanceResourcesReferencedByMember == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*g.IncludedMemberSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*g.IncludedMemberSubstanceResources))
-	} else if len(*g.IncludedMemberSubstanceResources) == 1 {
-		substance = &(*g.IncludedMemberSubstanceResources)[0]
+	} else if len(*g.IncludedSubstanceResourcesReferencedByMember) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*g.IncludedSubstanceResourcesReferencedByMember))
+	} else if len(*g.IncludedSubstanceResourcesReferencedByMember) == 1 {
+		substance = &(*g.IncludedSubstanceResourcesReferencedByMember)[0]
 	}
 	return
 }
 
-func (g *GroupPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (g *GroupPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if g.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *g.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *g.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingSubject() (documentManifests []DocumentManifest, err error) {
+	if g.RevIncludedDocumentManifestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *g.RevIncludedDocumentManifestResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *g.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingSubject() (specimen []Specimen, err error) {
+	if g.RevIncludedSpecimenResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *g.RevIncludedSpecimenResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingSubject() (carePlans []CarePlan, err error) {
+	if g.RevIncludedCarePlanResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *g.RevIncludedCarePlanResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedGoalResourcesReferencingSubject() (goals []Goal, err error) {
+	if g.RevIncludedGoalResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded goals not requested")
+	} else {
+		goals = *g.RevIncludedGoalResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingSubject() (procedures []Procedure, err error) {
+	if g.RevIncludedProcedureResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *g.RevIncludedProcedureResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if g.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *g.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedListResourcesReferencingSubject() (lists []List, err error) {
+	if g.RevIncludedListResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *g.RevIncludedListResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingSubject() (documentReferences []DocumentReference, err error) {
+	if g.RevIncludedDocumentReferenceResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *g.RevIncludedDocumentReferenceResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedOrderResourcesReferencingSubject() (orders []Order, err error) {
+	if g.RevIncludedOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *g.RevIncludedOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if g.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *g.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedMediaResourcesReferencingSubject() (media []Media, err error) {
+	if g.RevIncludedMediaResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *g.RevIncludedMediaResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingSubject() (procedureRequests []ProcedureRequest, err error) {
+	if g.RevIncludedProcedureRequestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *g.RevIncludedProcedureRequestResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedFlagResourcesReferencingSubject() (flags []Flag, err error) {
+	if g.RevIncludedFlagResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *g.RevIncludedFlagResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedObservationResourcesReferencingSubject() (observations []Observation, err error) {
+	if g.RevIncludedObservationResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *g.RevIncludedObservationResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if g.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *g.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingSubject() (riskAssessments []RiskAssessment, err error) {
+	if g.RevIncludedRiskAssessmentResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *g.RevIncludedRiskAssessmentResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if g.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *g.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingSubject() (diagnosticReports []DiagnosticReport, err error) {
+	if g.RevIncludedDiagnosticReportResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *g.RevIncludedDiagnosticReportResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if g.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *g.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if g.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *g.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if g.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *g.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if g.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *g.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *g.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSubject() (diagnosticOrders []DiagnosticOrder, err error) {
+	if g.RevIncludedDiagnosticOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *g.RevIncludedDiagnosticOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *g.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if g.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *g.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *g.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if g.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *g.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (g *GroupPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if g.IncludedMemberPractitionerResources != nil {
-		for _, r := range *g.IncludedMemberPractitionerResources {
+	if g.IncludedPractitionerResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedPractitionerResourcesReferencedByMember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedMemberDeviceResources != nil {
-		for _, r := range *g.IncludedMemberDeviceResources {
+	if g.IncludedDeviceResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedDeviceResourcesReferencedByMember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedMemberMedicationResources != nil {
-		for _, r := range *g.IncludedMemberMedicationResources {
+	if g.IncludedMedicationResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedMedicationResourcesReferencedByMember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedMemberPatientResources != nil {
-		for _, r := range *g.IncludedMemberPatientResources {
+	if g.IncludedPatientResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedByMember {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if g.IncludedMemberSubstanceResources != nil {
-		for _, r := range *g.IncludedMemberSubstanceResources {
+	if g.IncludedSubstanceResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedSubstanceResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (g *GroupPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCarePlanResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCarePlanResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcedureResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedProcedureResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *g.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (g *GroupPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if g.IncludedPractitionerResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedPractitionerResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedDeviceResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedDeviceResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedMedicationResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedMedicationResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedPatientResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedPatientResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.IncludedSubstanceResourcesReferencedByMember != nil {
+		for _, r := range *g.IncludedSubstanceResourcesReferencedByMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCarePlanResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCarePlanResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcedureResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedProcedureResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *g.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/healthcareservice.go
+++ b/models/healthcareservice.go
@@ -118,46 +118,466 @@ type HealthcareServiceNotAvailableComponent struct {
 }
 
 type HealthcareServicePlus struct {
-	HealthcareService             `bson:",inline"`
-	HealthcareServicePlusIncludes `bson:",inline"`
+	HealthcareService                     `bson:",inline"`
+	HealthcareServicePlusRelatedResources `bson:",inline"`
 }
 
-type HealthcareServicePlusIncludes struct {
-	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
-	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+type HealthcareServicePlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByOrganization       *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	IncludedLocationResourcesReferencedByLocation               *[]Location              `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor             *[]Appointment           `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject               *[]Account               `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor     *[]AppointmentResponse   `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                *[]Schedule              `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (h *HealthcareServicePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if h.IncludedOrganizationResources == nil {
+func (h *HealthcareServicePlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if h.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*h.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*h.IncludedOrganizationResources))
-	} else if len(*h.IncludedOrganizationResources) == 1 {
-		organization = &(*h.IncludedOrganizationResources)[0]
+	} else if len(*h.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*h.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*h.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*h.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (h *HealthcareServicePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if h.IncludedLocationResources == nil {
+func (h *HealthcareServicePlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if h.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*h.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*h.IncludedLocationResources))
-	} else if len(*h.IncludedLocationResources) == 1 {
-		location = &(*h.IncludedLocationResources)[0]
+	} else if len(*h.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*h.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*h.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*h.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (h *HealthcareServicePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if h.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *h.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if h.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *h.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if h.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *h.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if h.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *h.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if h.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *h.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if h.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *h.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if h.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if h.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *h.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if h.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *h.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if h.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *h.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if h.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *h.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if h.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *h.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if h.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *h.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if h.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *h.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if h.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *h.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if h.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if h.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *h.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if h.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *h.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if h.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *h.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if h.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *h.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if h.IncludedOrganizationResources != nil {
-		for _, r := range *h.IncludedOrganizationResources {
+	if h.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *h.IncludedOrganizationResourcesReferencedByOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if h.IncludedLocationResources != nil {
-		for _, r := range *h.IncludedLocationResources {
+	if h.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *h.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if h.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *h.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *h.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *h.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *h.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *h.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *h.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (h *HealthcareServicePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if h.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *h.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *h.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *h.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *h.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *h.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *h.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *h.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *h.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if h.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *h.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -111,114 +111,474 @@ type ImagingObjectSelectionFramesComponent struct {
 }
 
 type ImagingObjectSelectionPlus struct {
-	ImagingObjectSelection             `bson:",inline"`
-	ImagingObjectSelectionPlusIncludes `bson:",inline"`
+	ImagingObjectSelection                     `bson:",inline"`
+	ImagingObjectSelectionPlusRelatedResources `bson:",inline"`
 }
 
-type ImagingObjectSelectionPlusIncludes struct {
-	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorOrganizationResources  *[]Organization  `bson:"_includedAuthorOrganizationResources,omitempty"`
-	IncludedAuthorDeviceResources        *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
-	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
+type ImagingObjectSelectionPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedOrganizationResourcesReferencedByAuthor             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                   *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                  *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
-	if i.IncludedAuthorPractitionerResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if i.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*i.IncludedAuthorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedAuthorPractitionerResources))
-	} else if len(*i.IncludedAuthorPractitionerResources) == 1 {
-		practitioner = &(*i.IncludedAuthorPractitionerResources)[0]
+	} else if len(*i.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*i.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*i.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorOrganizationResource() (organization *Organization, err error) {
-	if i.IncludedAuthorOrganizationResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedOrganizationResourceReferencedByAuthor() (organization *Organization, err error) {
+	if i.IncludedOrganizationResourcesReferencedByAuthor == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*i.IncludedAuthorOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedAuthorOrganizationResources))
-	} else if len(*i.IncludedAuthorOrganizationResources) == 1 {
-		organization = &(*i.IncludedAuthorOrganizationResources)[0]
+	} else if len(*i.IncludedOrganizationResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedOrganizationResourcesReferencedByAuthor))
+	} else if len(*i.IncludedOrganizationResourcesReferencedByAuthor) == 1 {
+		organization = &(*i.IncludedOrganizationResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
-	if i.IncludedAuthorDeviceResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedDeviceResourceReferencedByAuthor() (device *Device, err error) {
+	if i.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*i.IncludedAuthorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*i.IncludedAuthorDeviceResources))
-	} else if len(*i.IncludedAuthorDeviceResources) == 1 {
-		device = &(*i.IncludedAuthorDeviceResources)[0]
+	} else if len(*i.IncludedDeviceResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*i.IncludedDeviceResourcesReferencedByAuthor))
+	} else if len(*i.IncludedDeviceResourcesReferencedByAuthor) == 1 {
+		device = &(*i.IncludedDeviceResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
-	if i.IncludedAuthorPatientResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedPatientResourceReferencedByAuthor() (patient *Patient, err error) {
+	if i.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*i.IncludedAuthorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedAuthorPatientResources))
-	} else if len(*i.IncludedAuthorPatientResources) == 1 {
-		patient = &(*i.IncludedAuthorPatientResources)[0]
+	} else if len(*i.IncludedPatientResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResourcesReferencedByAuthor))
+	} else if len(*i.IncludedPatientResourcesReferencedByAuthor) == 1 {
+		patient = &(*i.IncludedPatientResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if i.IncludedAuthorRelatedPersonResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByAuthor() (relatedPerson *RelatedPerson, err error) {
+	if i.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*i.IncludedAuthorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*i.IncludedAuthorRelatedPersonResources))
-	} else if len(*i.IncludedAuthorRelatedPersonResources) == 1 {
-		relatedPerson = &(*i.IncludedAuthorRelatedPersonResources)[0]
+	} else if len(*i.IncludedRelatedPersonResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*i.IncludedRelatedPersonResourcesReferencedByAuthor))
+	} else if len(*i.IncludedRelatedPersonResourcesReferencedByAuthor) == 1 {
+		relatedPerson = &(*i.IncludedRelatedPersonResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if i.IncludedPatientResources == nil {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if i.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*i.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
-	} else if len(*i.IncludedPatientResources) == 1 {
-		patient = &(*i.IncludedPatientResources)[0]
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*i.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (i *ImagingObjectSelectionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if i.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *i.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if i.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *i.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if i.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *i.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if i.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *i.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if i.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *i.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *i.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *i.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if i.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *i.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *i.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if i.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *i.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if i.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *i.IncludedAuthorPractitionerResources {
+	if i.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedAuthorOrganizationResources != nil {
-		for _, r := range *i.IncludedAuthorOrganizationResources {
+	if i.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedOrganizationResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedAuthorDeviceResources != nil {
-		for _, r := range *i.IncludedAuthorDeviceResources {
+	if i.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedAuthorPatientResources != nil {
-		for _, r := range *i.IncludedAuthorPatientResources {
+	if i.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *i.IncludedAuthorRelatedPersonResources {
+	if i.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedPatientResources != nil {
-		for _, r := range *i.IncludedPatientResources {
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedOrganizationResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedOrganizationResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/imagingstudy.go
+++ b/models/imagingstudy.go
@@ -118,44 +118,384 @@ type ImagingStudySeriesInstanceComponent struct {
 }
 
 type ImagingStudyPlus struct {
-	ImagingStudy             `bson:",inline"`
-	ImagingStudyPlusIncludes `bson:",inline"`
+	ImagingStudy                     `bson:",inline"`
+	ImagingStudyPlusRelatedResources `bson:",inline"`
 }
 
-type ImagingStudyPlusIncludes struct {
-	IncludedPatientResources *[]Patient         `bson:"_includedPatientResources,omitempty"`
-	IncludedOrderResources   *[]DiagnosticOrder `bson:"_includedOrderResources,omitempty"`
+type ImagingStudyPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedDiagnosticOrderResourcesReferencedByOrder           *[]DiagnosticOrder       `bson:"_includedDiagnosticOrderResourcesReferencedByOrder,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (i *ImagingStudyPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if i.IncludedPatientResources == nil {
+func (i *ImagingStudyPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if i.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*i.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
-	} else if len(*i.IncludedPatientResources) == 1 {
-		patient = &(*i.IncludedPatientResources)[0]
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*i.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (i *ImagingStudyPlusIncludes) GetIncludedOrderResources() (diagnosticOrders []DiagnosticOrder, err error) {
-	if i.IncludedOrderResources == nil {
+func (i *ImagingStudyPlusRelatedResources) GetIncludedDiagnosticOrderResourcesReferencedByOrder() (diagnosticOrders []DiagnosticOrder, err error) {
+	if i.IncludedDiagnosticOrderResourcesReferencedByOrder == nil {
 		err = errors.New("Included diagnosticOrders not requested")
 	} else {
-		diagnosticOrders = *i.IncludedOrderResources
+		diagnosticOrders = *i.IncludedDiagnosticOrderResourcesReferencedByOrder
 	}
 	return
 }
 
-func (i *ImagingStudyPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if i.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *i.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if i.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *i.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if i.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *i.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if i.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *i.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if i.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *i.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *i.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *i.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if i.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *i.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *i.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if i.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *i.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if i.IncludedPatientResources != nil {
-		for _, r := range *i.IncludedPatientResources {
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedOrderResources != nil {
-		for _, r := range *i.IncludedOrderResources {
+	if i.IncludedDiagnosticOrderResourcesReferencedByOrder != nil {
+		for _, r := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImagingStudyPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedDiagnosticOrderResourcesReferencedByOrder != nil {
+		for _, r := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/immunization.go
+++ b/models/immunization.go
@@ -122,114 +122,494 @@ type ImmunizationVaccinationProtocolComponent struct {
 }
 
 type ImmunizationPlus struct {
-	Immunization             `bson:",inline"`
-	ImmunizationPlusIncludes `bson:",inline"`
+	Immunization                     `bson:",inline"`
+	ImmunizationPlusRelatedResources `bson:",inline"`
 }
 
-type ImmunizationPlusIncludes struct {
-	IncludedRequesterResources    *[]Practitioner `bson:"_includedRequesterResources,omitempty"`
-	IncludedPerformerResources    *[]Practitioner `bson:"_includedPerformerResources,omitempty"`
-	IncludedReactionResources     *[]Observation  `bson:"_includedReactionResources,omitempty"`
-	IncludedManufacturerResources *[]Organization `bson:"_includedManufacturerResources,omitempty"`
-	IncludedPatientResources      *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+type ImmunizationPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByRequester               *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByRequester,omitempty"`
+	IncludedPractitionerResourcesReferencedByPerformer               *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedObservationResourcesReferencedByReaction                 *[]Observation                `bson:"_includedObservationResourcesReferencedByReaction,omitempty"`
+	IncludedOrganizationResourcesReferencedByManufacturer            *[]Organization               `bson:"_includedOrganizationResourcesReferencedByManufacturer,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                      *[]Patient                    `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedLocationResourcesReferencedByLocation                    *[]Location                   `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                  *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref        *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref        *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                          *[]List                       `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref       *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                       *[]Order                      `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                      *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference               *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                  *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated           *[]DetectedIssue              `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment          *[]OrderResponse              `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject      *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest            *[]ProcessResponse            `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger         *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                 *[]MessageHeader              `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedImmunizationRecommendationResourcesReferencingSupport *[]ImmunizationRecommendation `bson:"_revIncludedImmunizationRecommendationResourcesReferencingSupport,omitempty"`
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedRequesterResource() (practitioner *Practitioner, err error) {
-	if i.IncludedRequesterResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedPractitionerResourceReferencedByRequester() (practitioner *Practitioner, err error) {
+	if i.IncludedPractitionerResourcesReferencedByRequester == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*i.IncludedRequesterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedRequesterResources))
-	} else if len(*i.IncludedRequesterResources) == 1 {
-		practitioner = &(*i.IncludedRequesterResources)[0]
+	} else if len(*i.IncludedPractitionerResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedPractitionerResourcesReferencedByRequester))
+	} else if len(*i.IncludedPractitionerResourcesReferencedByRequester) == 1 {
+		practitioner = &(*i.IncludedPractitionerResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedPerformerResource() (practitioner *Practitioner, err error) {
-	if i.IncludedPerformerResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPerformer() (practitioner *Practitioner, err error) {
+	if i.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*i.IncludedPerformerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedPerformerResources))
-	} else if len(*i.IncludedPerformerResources) == 1 {
-		practitioner = &(*i.IncludedPerformerResources)[0]
+	} else if len(*i.IncludedPractitionerResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*i.IncludedPractitionerResourcesReferencedByPerformer))
+	} else if len(*i.IncludedPractitionerResourcesReferencedByPerformer) == 1 {
+		practitioner = &(*i.IncludedPractitionerResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedReactionResource() (observation *Observation, err error) {
-	if i.IncludedReactionResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedObservationResourceReferencedByReaction() (observation *Observation, err error) {
+	if i.IncludedObservationResourcesReferencedByReaction == nil {
 		err = errors.New("Included observations not requested")
-	} else if len(*i.IncludedReactionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*i.IncludedReactionResources))
-	} else if len(*i.IncludedReactionResources) == 1 {
-		observation = &(*i.IncludedReactionResources)[0]
+	} else if len(*i.IncludedObservationResourcesReferencedByReaction) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*i.IncludedObservationResourcesReferencedByReaction))
+	} else if len(*i.IncludedObservationResourcesReferencedByReaction) == 1 {
+		observation = &(*i.IncludedObservationResourcesReferencedByReaction)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedManufacturerResource() (organization *Organization, err error) {
-	if i.IncludedManufacturerResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedOrganizationResourceReferencedByManufacturer() (organization *Organization, err error) {
+	if i.IncludedOrganizationResourcesReferencedByManufacturer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*i.IncludedManufacturerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedManufacturerResources))
-	} else if len(*i.IncludedManufacturerResources) == 1 {
-		organization = &(*i.IncludedManufacturerResources)[0]
+	} else if len(*i.IncludedOrganizationResourcesReferencedByManufacturer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*i.IncludedOrganizationResourcesReferencedByManufacturer))
+	} else if len(*i.IncludedOrganizationResourcesReferencedByManufacturer) == 1 {
+		organization = &(*i.IncludedOrganizationResourcesReferencedByManufacturer)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if i.IncludedPatientResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if i.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*i.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
-	} else if len(*i.IncludedPatientResources) == 1 {
-		patient = &(*i.IncludedPatientResources)[0]
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*i.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if i.IncludedLocationResources == nil {
+func (i *ImmunizationPlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if i.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*i.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*i.IncludedLocationResources))
-	} else if len(*i.IncludedLocationResources) == 1 {
-		location = &(*i.IncludedLocationResources)[0]
+	} else if len(*i.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*i.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*i.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*i.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (i *ImmunizationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if i.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *i.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if i.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *i.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if i.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *i.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if i.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *i.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if i.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *i.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *i.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *i.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if i.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *i.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *i.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if i.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *i.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedImmunizationRecommendationResourcesReferencingSupport() (immunizationRecommendations []ImmunizationRecommendation, err error) {
+	if i.RevIncludedImmunizationRecommendationResourcesReferencingSupport == nil {
+		err = errors.New("RevIncluded immunizationRecommendations not requested")
+	} else {
+		immunizationRecommendations = *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport
+	}
+	return
+}
+
+func (i *ImmunizationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if i.IncludedRequesterResources != nil {
-		for _, r := range *i.IncludedRequesterResources {
+	if i.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedPerformerResources != nil {
-		for _, r := range *i.IncludedPerformerResources {
+	if i.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedReactionResources != nil {
-		for _, r := range *i.IncludedReactionResources {
+	if i.IncludedObservationResourcesReferencedByReaction != nil {
+		for _, r := range *i.IncludedObservationResourcesReferencedByReaction {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedManufacturerResources != nil {
-		for _, r := range *i.IncludedManufacturerResources {
+	if i.IncludedOrganizationResourcesReferencedByManufacturer != nil {
+		for _, r := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedPatientResources != nil {
-		for _, r := range *i.IncludedPatientResources {
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedLocationResources != nil {
-		for _, r := range *i.IncludedLocationResources {
+	if i.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *i.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImmunizationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedImmunizationRecommendationResourcesReferencingSupport != nil {
+		for _, r := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImmunizationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *i.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedObservationResourcesReferencedByReaction != nil {
+		for _, r := range *i.IncludedObservationResourcesReferencedByReaction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedOrganizationResourcesReferencedByManufacturer != nil {
+		for _, r := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *i.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedImmunizationRecommendationResourcesReferencingSupport != nil {
+		for _, r := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -105,74 +105,424 @@ type ImmunizationRecommendationRecommendationProtocolComponent struct {
 }
 
 type ImmunizationRecommendationPlus struct {
-	ImmunizationRecommendation             `bson:",inline"`
-	ImmunizationRecommendationPlusIncludes `bson:",inline"`
+	ImmunizationRecommendation                     `bson:",inline"`
+	ImmunizationRecommendationPlusRelatedResources `bson:",inline"`
 }
 
-type ImmunizationRecommendationPlusIncludes struct {
-	IncludedPatientResources                       *[]Patient            `bson:"_includedPatientResources,omitempty"`
-	IncludedInformationAllergyIntoleranceResources *[]AllergyIntolerance `bson:"_includedInformationAllergyIntoleranceResources,omitempty"`
-	IncludedInformationObservationResources        *[]Observation        `bson:"_includedInformationObservationResources,omitempty"`
-	IncludedSupportResources                       *[]Immunization       `bson:"_includedSupportResources,omitempty"`
+type ImmunizationRecommendationPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedAllergyIntoleranceResourcesReferencedByInformation  *[]AllergyIntolerance    `bson:"_includedAllergyIntoleranceResourcesReferencedByInformation,omitempty"`
+	IncludedObservationResourcesReferencedByInformation         *[]Observation           `bson:"_includedObservationResourcesReferencedByInformation,omitempty"`
+	IncludedImmunizationResourcesReferencedBySupport            *[]Immunization          `bson:"_includedImmunizationResourcesReferencedBySupport,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (i *ImmunizationRecommendationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if i.IncludedPatientResources == nil {
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if i.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*i.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResources))
-	} else if len(*i.IncludedPatientResources) == 1 {
-		patient = &(*i.IncludedPatientResources)[0]
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*i.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*i.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*i.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (i *ImmunizationRecommendationPlusIncludes) GetIncludedInformationAllergyIntoleranceResources() (allergyIntolerances []AllergyIntolerance, err error) {
-	if i.IncludedInformationAllergyIntoleranceResources == nil {
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedAllergyIntoleranceResourcesReferencedByInformation() (allergyIntolerances []AllergyIntolerance, err error) {
+	if i.IncludedAllergyIntoleranceResourcesReferencedByInformation == nil {
 		err = errors.New("Included allergyIntolerances not requested")
 	} else {
-		allergyIntolerances = *i.IncludedInformationAllergyIntoleranceResources
+		allergyIntolerances = *i.IncludedAllergyIntoleranceResourcesReferencedByInformation
 	}
 	return
 }
 
-func (i *ImmunizationRecommendationPlusIncludes) GetIncludedInformationObservationResources() (observations []Observation, err error) {
-	if i.IncludedInformationObservationResources == nil {
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedObservationResourcesReferencedByInformation() (observations []Observation, err error) {
+	if i.IncludedObservationResourcesReferencedByInformation == nil {
 		err = errors.New("Included observations not requested")
 	} else {
-		observations = *i.IncludedInformationObservationResources
+		observations = *i.IncludedObservationResourcesReferencedByInformation
 	}
 	return
 }
 
-func (i *ImmunizationRecommendationPlusIncludes) GetIncludedSupportResources() (immunizations []Immunization, err error) {
-	if i.IncludedSupportResources == nil {
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedImmunizationResourcesReferencedBySupport() (immunizations []Immunization, err error) {
+	if i.IncludedImmunizationResourcesReferencedBySupport == nil {
 		err = errors.New("Included immunizations not requested")
 	} else {
-		immunizations = *i.IncludedSupportResources
+		immunizations = *i.IncludedImmunizationResourcesReferencedBySupport
 	}
 	return
 }
 
-func (i *ImmunizationRecommendationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if i.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *i.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if i.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *i.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if i.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *i.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if i.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *i.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if i.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *i.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *i.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *i.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if i.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *i.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *i.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if i.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *i.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if i.IncludedPatientResources != nil {
-		for _, r := range *i.IncludedPatientResources {
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedInformationAllergyIntoleranceResources != nil {
-		for _, r := range *i.IncludedInformationAllergyIntoleranceResources {
+	if i.IncludedAllergyIntoleranceResourcesReferencedByInformation != nil {
+		for _, r := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedInformationObservationResources != nil {
-		for _, r := range *i.IncludedInformationObservationResources {
+	if i.IncludedObservationResourcesReferencedByInformation != nil {
+		for _, r := range *i.IncludedObservationResourcesReferencedByInformation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if i.IncludedSupportResources != nil {
-		for _, r := range *i.IncludedSupportResources {
+	if i.IncludedImmunizationResourcesReferencedBySupport != nil {
+		for _, r := range *i.IncludedImmunizationResourcesReferencedBySupport {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedAllergyIntoleranceResourcesReferencedByInformation != nil {
+		for _, r := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedObservationResourcesReferencedByInformation != nil {
+		for _, r := range *i.IncludedObservationResourcesReferencedByInformation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.IncludedImmunizationResourcesReferencedBySupport != nil {
+		for _, r := range *i.IncludedImmunizationResourcesReferencedBySupport {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/implementationguide.go
+++ b/models/implementationguide.go
@@ -137,14 +137,344 @@ type ImplementationGuidePageComponent struct {
 }
 
 type ImplementationGuidePlus struct {
-	ImplementationGuide             `bson:",inline"`
-	ImplementationGuidePlusIncludes `bson:",inline"`
+	ImplementationGuide                     `bson:",inline"`
+	ImplementationGuidePlusRelatedResources `bson:",inline"`
 }
 
-type ImplementationGuidePlusIncludes struct {
+type ImplementationGuidePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (i *ImplementationGuidePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if i.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *i.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *i.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if i.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *i.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if i.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *i.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if i.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *i.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if i.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *i.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if i.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *i.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *i.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *i.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if i.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *i.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *i.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if i.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *i.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (i *ImplementationGuidePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *i.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/list.go
+++ b/models/list.go
@@ -99,165 +99,540 @@ type ListEntryComponent struct {
 }
 
 type ListPlus struct {
-	List             `bson:",inline"`
-	ListPlusIncludes `bson:",inline"`
+	List                     `bson:",inline"`
+	ListPlusRelatedResources `bson:",inline"`
 }
 
-type ListPlusIncludes struct {
-	IncludedSubjectGroupResources       *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources      *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources     *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectLocationResources    *[]Location     `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
-	IncludedSourceDeviceResources       *[]Device       `bson:"_includedSourceDeviceResources,omitempty"`
-	IncludedSourcePatientResources      *[]Patient      `bson:"_includedSourcePatientResources,omitempty"`
-	IncludedEncounterResources          *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type ListPlusRelatedResources struct {
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                *[]Location              `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedBySource             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySource,omitempty"`
+	IncludedDeviceResourcesReferencedBySource                   *[]Device                `bson:"_includedDeviceResourcesReferencedBySource,omitempty"`
+	IncludedPatientResourcesReferencedBySource                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySource,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (l *ListPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if l.IncludedSubjectGroupResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if l.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*l.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*l.IncludedSubjectGroupResources))
-	} else if len(*l.IncludedSubjectGroupResources) == 1 {
-		group = &(*l.IncludedSubjectGroupResources)[0]
+	} else if len(*l.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*l.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*l.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*l.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if l.IncludedSubjectDeviceResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if l.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*l.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedSubjectDeviceResources))
-	} else if len(*l.IncludedSubjectDeviceResources) == 1 {
-		device = &(*l.IncludedSubjectDeviceResources)[0]
+	} else if len(*l.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*l.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*l.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if l.IncludedSubjectPatientResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if l.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*l.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedSubjectPatientResources))
-	} else if len(*l.IncludedSubjectPatientResources) == 1 {
-		patient = &(*l.IncludedSubjectPatientResources)[0]
+	} else if len(*l.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*l.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*l.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if l.IncludedSubjectLocationResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if l.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*l.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*l.IncludedSubjectLocationResources))
-	} else if len(*l.IncludedSubjectLocationResources) == 1 {
-		location = &(*l.IncludedSubjectLocationResources)[0]
+	} else if len(*l.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*l.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*l.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*l.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if l.IncludedPatientResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if l.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*l.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedPatientResources))
-	} else if len(*l.IncludedPatientResources) == 1 {
-		patient = &(*l.IncludedPatientResources)[0]
+	} else if len(*l.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*l.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*l.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
-	if l.IncludedSourcePractitionerResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySource() (practitioner *Practitioner, err error) {
+	if l.IncludedPractitionerResourcesReferencedBySource == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*l.IncludedSourcePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*l.IncludedSourcePractitionerResources))
-	} else if len(*l.IncludedSourcePractitionerResources) == 1 {
-		practitioner = &(*l.IncludedSourcePractitionerResources)[0]
+	} else if len(*l.IncludedPractitionerResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*l.IncludedPractitionerResourcesReferencedBySource))
+	} else if len(*l.IncludedPractitionerResourcesReferencedBySource) == 1 {
+		practitioner = &(*l.IncludedPractitionerResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSourceDeviceResource() (device *Device, err error) {
-	if l.IncludedSourceDeviceResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedDeviceResourceReferencedBySource() (device *Device, err error) {
+	if l.IncludedDeviceResourcesReferencedBySource == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*l.IncludedSourceDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedSourceDeviceResources))
-	} else if len(*l.IncludedSourceDeviceResources) == 1 {
-		device = &(*l.IncludedSourceDeviceResources)[0]
+	} else if len(*l.IncludedDeviceResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*l.IncludedDeviceResourcesReferencedBySource))
+	} else if len(*l.IncludedDeviceResourcesReferencedBySource) == 1 {
+		device = &(*l.IncludedDeviceResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
-	if l.IncludedSourcePatientResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedPatientResourceReferencedBySource() (patient *Patient, err error) {
+	if l.IncludedPatientResourcesReferencedBySource == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*l.IncludedSourcePatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedSourcePatientResources))
-	} else if len(*l.IncludedSourcePatientResources) == 1 {
-		patient = &(*l.IncludedSourcePatientResources)[0]
+	} else if len(*l.IncludedPatientResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*l.IncludedPatientResourcesReferencedBySource))
+	} else if len(*l.IncludedPatientResourcesReferencedBySource) == 1 {
+		patient = &(*l.IncludedPatientResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if l.IncludedEncounterResources == nil {
+func (l *ListPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if l.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*l.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*l.IncludedEncounterResources))
-	} else if len(*l.IncludedEncounterResources) == 1 {
-		encounter = &(*l.IncludedEncounterResources)[0]
+	} else if len(*l.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*l.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*l.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*l.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (l *ListPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (l *ListPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if l.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *l.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *l.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *l.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if l.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *l.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if l.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *l.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if l.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *l.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if l.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *l.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if l.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *l.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if l.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *l.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *l.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *l.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if l.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *l.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *l.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if l.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *l.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (l *ListPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if l.IncludedSubjectGroupResources != nil {
-		for _, r := range *l.IncludedSubjectGroupResources {
+	if l.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSubjectDeviceResources != nil {
-		for _, r := range *l.IncludedSubjectDeviceResources {
+	if l.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSubjectPatientResources != nil {
-		for _, r := range *l.IncludedSubjectPatientResources {
+	if l.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSubjectLocationResources != nil {
-		for _, r := range *l.IncludedSubjectLocationResources {
+	if l.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedPatientResources != nil {
-		for _, r := range *l.IncludedPatientResources {
+	if l.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSourcePractitionerResources != nil {
-		for _, r := range *l.IncludedSourcePractitionerResources {
+	if l.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedPractitionerResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSourceDeviceResources != nil {
-		for _, r := range *l.IncludedSourceDeviceResources {
+	if l.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedDeviceResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedSourcePatientResources != nil {
-		for _, r := range *l.IncludedSourcePatientResources {
+	if l.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedEncounterResources != nil {
-		for _, r := range *l.IncludedEncounterResources {
+	if l.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *l.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (l *ListPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (l *ListPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if l.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *l.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedPractitionerResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedDeviceResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedDeviceResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *l.IncludedPatientResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *l.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/location.go
+++ b/models/location.go
@@ -97,46 +97,806 @@ type LocationPositionComponent struct {
 }
 
 type LocationPlus struct {
-	Location             `bson:",inline"`
-	LocationPlusIncludes `bson:",inline"`
+	Location                     `bson:",inline"`
+	LocationPlusRelatedResources `bson:",inline"`
 }
 
-type LocationPlusIncludes struct {
-	IncludedPartofResources       *[]Location     `bson:"_includedPartofResources,omitempty"`
-	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
+type LocationPlusRelatedResources struct {
+	IncludedLocationResourcesReferencedByPartof                  *[]Location              `bson:"_includedLocationResourcesReferencedByPartof,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization        *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor              *[]Appointment           `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResourcesReferencingLocation           *[]Appointment           `bson:"_revIncludedAppointmentResourcesReferencingLocation,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject                *[]Account               `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingLocation            *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingLocation,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget              *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedProcedureResourcesReferencingLocation             *[]Procedure             `bson:"_revIncludedProcedureResourcesReferencingLocation,omitempty"`
+	RevIncludedListResourcesReferencingItem                      *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingSubject                   *[]List                  `bson:"_revIncludedListResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref   *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                   *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedImmunizationResourcesReferencingLocation          *[]Immunization          `bson:"_revIncludedImmunizationResourcesReferencingLocation,omitempty"`
+	RevIncludedDeviceResourcesReferencingLocation                *[]Device                `bson:"_revIncludedDeviceResourcesReferencingLocation,omitempty"`
+	RevIncludedFlagResourcesReferencingSubject                   *[]Flag                  `bson:"_revIncludedFlagResourcesReferencingSubject,omitempty"`
+	RevIncludedPractitionerResourcesReferencingLocation          *[]Practitioner          `bson:"_revIncludedPractitionerResourcesReferencingLocation,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor      *[]AppointmentResponse   `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingLocation   *[]AppointmentResponse   `bson:"_revIncludedAppointmentResponseResourcesReferencingLocation,omitempty"`
+	RevIncludedObservationResourcesReferencingSubject            *[]Observation           `bson:"_revIncludedObservationResourcesReferencingSubject,omitempty"`
+	RevIncludedContractResourcesReferencingActor                 *[]Contract              `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                  *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingDestination *[]MedicationDispense    `bson:"_revIncludedMedicationDispenseResourcesReferencingDestination,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingSubject       *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingSubject,omitempty"`
+	RevIncludedHealthcareServiceResourcesReferencingLocation     *[]HealthcareService     `bson:"_revIncludedHealthcareServiceResourcesReferencingLocation,omitempty"`
+	RevIncludedEncounterResourcesReferencingLocation             *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingLocation,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference           *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject            *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated       *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSubject        *[]DiagnosticOrder       `bson:"_revIncludedDiagnosticOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment      *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject  *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest        *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                 *[]Schedule              `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData             *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedLocationResourcesReferencingPartof                *[]Location              `bson:"_revIncludedLocationResourcesReferencingPartof,omitempty"`
 }
 
-func (l *LocationPlusIncludes) GetIncludedPartofResource() (location *Location, err error) {
-	if l.IncludedPartofResources == nil {
+func (l *LocationPlusRelatedResources) GetIncludedLocationResourceReferencedByPartof() (location *Location, err error) {
+	if l.IncludedLocationResourcesReferencedByPartof == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*l.IncludedPartofResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*l.IncludedPartofResources))
-	} else if len(*l.IncludedPartofResources) == 1 {
-		location = &(*l.IncludedPartofResources)[0]
+	} else if len(*l.IncludedLocationResourcesReferencedByPartof) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*l.IncludedLocationResourcesReferencedByPartof))
+	} else if len(*l.IncludedLocationResourcesReferencedByPartof) == 1 {
+		location = &(*l.IncludedLocationResourcesReferencedByPartof)[0]
 	}
 	return
 }
 
-func (l *LocationPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if l.IncludedOrganizationResources == nil {
+func (l *LocationPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if l.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*l.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*l.IncludedOrganizationResources))
-	} else if len(*l.IncludedOrganizationResources) == 1 {
-		organization = &(*l.IncludedOrganizationResources)[0]
+	} else if len(*l.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*l.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*l.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*l.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (l *LocationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (l *LocationPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if l.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *l.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingLocation() (appointments []Appointment, err error) {
+	if l.RevIncludedAppointmentResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *l.RevIncludedAppointmentResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if l.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *l.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingLocation() (provenances []Provenance, err error) {
+	if l.RevIncludedProvenanceResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *l.RevIncludedProvenanceResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if l.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *l.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *l.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *l.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingLocation() (procedures []Procedure, err error) {
+	if l.RevIncludedProcedureResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *l.RevIncludedProcedureResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if l.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *l.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedListResourcesReferencingSubject() (lists []List, err error) {
+	if l.RevIncludedListResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *l.RevIncludedListResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if l.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *l.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingLocation() (immunizations []Immunization, err error) {
+	if l.RevIncludedImmunizationResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *l.RevIncludedImmunizationResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDeviceResourcesReferencingLocation() (devices []Device, err error) {
+	if l.RevIncludedDeviceResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded devices not requested")
+	} else {
+		devices = *l.RevIncludedDeviceResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedFlagResourcesReferencingSubject() (flags []Flag, err error) {
+	if l.RevIncludedFlagResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *l.RevIncludedFlagResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedPractitionerResourcesReferencingLocation() (practitioners []Practitioner, err error) {
+	if l.RevIncludedPractitionerResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded practitioners not requested")
+	} else {
+		practitioners = *l.RevIncludedPractitionerResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if l.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *l.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingLocation() (appointmentResponses []AppointmentResponse, err error) {
+	if l.RevIncludedAppointmentResponseResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *l.RevIncludedAppointmentResponseResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedObservationResourcesReferencingSubject() (observations []Observation, err error) {
+	if l.RevIncludedObservationResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *l.RevIncludedObservationResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if l.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *l.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if l.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *l.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingDestination() (medicationDispenses []MedicationDispense, err error) {
+	if l.RevIncludedMedicationDispenseResourcesReferencingDestination == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *l.RevIncludedMedicationDispenseResourcesReferencingDestination
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingSubject() (diagnosticReports []DiagnosticReport, err error) {
+	if l.RevIncludedDiagnosticReportResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *l.RevIncludedDiagnosticReportResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedHealthcareServiceResourcesReferencingLocation() (healthcareServices []HealthcareService, err error) {
+	if l.RevIncludedHealthcareServiceResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded healthcareServices not requested")
+	} else {
+		healthcareServices = *l.RevIncludedHealthcareServiceResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingLocation() (encounters []Encounter, err error) {
+	if l.RevIncludedEncounterResourcesReferencingLocation == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *l.RevIncludedEncounterResourcesReferencingLocation
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if l.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *l.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if l.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *l.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if l.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *l.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *l.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSubject() (diagnosticOrders []DiagnosticOrder, err error) {
+	if l.RevIncludedDiagnosticOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *l.RevIncludedDiagnosticOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *l.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if l.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *l.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if l.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *l.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *l.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if l.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *l.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedLocationResourcesReferencingPartof() (locations []Location, err error) {
+	if l.RevIncludedLocationResourcesReferencingPartof == nil {
+		err = errors.New("RevIncluded locations not requested")
+	} else {
+		locations = *l.RevIncludedLocationResourcesReferencingPartof
+	}
+	return
+}
+
+func (l *LocationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if l.IncludedPartofResources != nil {
-		for _, r := range *l.IncludedPartofResources {
+	if l.IncludedLocationResourcesReferencedByPartof != nil {
+		for _, r := range *l.IncludedLocationResourcesReferencedByPartof {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if l.IncludedOrganizationResources != nil {
-		for _, r := range *l.IncludedOrganizationResources {
+	if l.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *l.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (l *LocationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if l.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedAppointmentResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProvenanceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcedureResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedProcedureResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedImmunizationResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedImmunizationResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDeviceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedDeviceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedPractitionerResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedPractitionerResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResponseResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMedicationDispenseResourcesReferencingDestination != nil {
+		for _, r := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedHealthcareServiceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedEncounterResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedEncounterResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedLocationResourcesReferencingPartof != nil {
+		for _, r := range *l.RevIncludedLocationResourcesReferencingPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (l *LocationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if l.IncludedLocationResourcesReferencedByPartof != nil {
+		for _, r := range *l.IncludedLocationResourcesReferencedByPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *l.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedAppointmentResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProvenanceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcedureResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedProcedureResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedImmunizationResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedImmunizationResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDeviceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedDeviceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedPractitionerResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedPractitionerResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAppointmentResponseResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMedicationDispenseResourcesReferencingDestination != nil {
+		for _, r := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedHealthcareServiceResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedEncounterResourcesReferencingLocation != nil {
+		for _, r := range *l.RevIncludedEncounterResourcesReferencingLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *l.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if l.RevIncludedLocationResourcesReferencingPartof != nil {
+		for _, r := range *l.RevIncludedLocationResourcesReferencingPartof {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/media.go
+++ b/models/media.go
@@ -91,131 +91,516 @@ func (x *Media) checkResourceType() error {
 }
 
 type MediaPlus struct {
-	Media             `bson:",inline"`
-	MediaPlusIncludes `bson:",inline"`
+	Media                     `bson:",inline"`
+	MediaPlusRelatedResources `bson:",inline"`
 }
 
-type MediaPlusIncludes struct {
-	IncludedSubjectPractitionerResources *[]Practitioner `bson:"_includedSubjectPractitionerResources,omitempty"`
-	IncludedSubjectGroupResources        *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectSpecimenResources     *[]Specimen     `bson:"_includedSubjectSpecimenResources,omitempty"`
-	IncludedSubjectDeviceResources       *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources      *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedPatientResources             *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedOperatorResources            *[]Practitioner `bson:"_includedOperatorResources,omitempty"`
+type MediaPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedBySubject            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySubject,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedSpecimenResourcesReferencedBySubject                *[]Specimen              `bson:"_includedSpecimenResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByOperator           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByOperator,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingImage        *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingImage,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MediaPlusIncludes) GetIncludedSubjectPractitionerResource() (practitioner *Practitioner, err error) {
-	if m.IncludedSubjectPractitionerResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySubject() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedBySubject == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedSubjectPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedSubjectPractitionerResources))
-	} else if len(*m.IncludedSubjectPractitionerResources) == 1 {
-		practitioner = &(*m.IncludedSubjectPractitionerResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedBySubject))
+	} else if len(*m.IncludedPractitionerResourcesReferencedBySubject) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if m.IncludedSubjectGroupResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if m.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*m.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*m.IncludedSubjectGroupResources))
-	} else if len(*m.IncludedSubjectGroupResources) == 1 {
-		group = &(*m.IncludedSubjectGroupResources)[0]
+	} else if len(*m.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*m.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*m.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*m.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedSubjectSpecimenResource() (specimen *Specimen, err error) {
-	if m.IncludedSubjectSpecimenResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedSpecimenResourceReferencedBySubject() (specimen *Specimen, err error) {
+	if m.IncludedSpecimenResourcesReferencedBySubject == nil {
 		err = errors.New("Included specimen not requested")
-	} else if len(*m.IncludedSubjectSpecimenResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*m.IncludedSubjectSpecimenResources))
-	} else if len(*m.IncludedSubjectSpecimenResources) == 1 {
-		specimen = &(*m.IncludedSubjectSpecimenResources)[0]
+	} else if len(*m.IncludedSpecimenResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*m.IncludedSpecimenResourcesReferencedBySubject))
+	} else if len(*m.IncludedSpecimenResourcesReferencedBySubject) == 1 {
+		specimen = &(*m.IncludedSpecimenResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if m.IncludedSubjectDeviceResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if m.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*m.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedSubjectDeviceResources))
-	} else if len(*m.IncludedSubjectDeviceResources) == 1 {
-		device = &(*m.IncludedSubjectDeviceResources)[0]
+	} else if len(*m.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*m.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*m.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if m.IncludedSubjectPatientResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedSubjectPatientResources))
-	} else if len(*m.IncludedSubjectPatientResources) == 1 {
-		patient = &(*m.IncludedSubjectPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*m.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if m.IncludedPatientResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
-	} else if len(*m.IncludedPatientResources) == 1 {
-		patient = &(*m.IncludedPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedOperatorResource() (practitioner *Practitioner, err error) {
-	if m.IncludedOperatorResources == nil {
+func (m *MediaPlusRelatedResources) GetIncludedPractitionerResourceReferencedByOperator() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByOperator == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedOperatorResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedOperatorResources))
-	} else if len(*m.IncludedOperatorResources) == 1 {
-		practitioner = &(*m.IncludedOperatorResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByOperator) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByOperator))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByOperator) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByOperator)[0]
 	}
 	return
 }
 
-func (m *MediaPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MediaPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingImage() (diagnosticReports []DiagnosticReport, err error) {
+	if m.RevIncludedDiagnosticReportResourcesReferencingImage == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *m.RevIncludedDiagnosticReportResourcesReferencingImage
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MediaPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedSubjectPractitionerResources != nil {
-		for _, r := range *m.IncludedSubjectPractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSubjectGroupResources != nil {
-		for _, r := range *m.IncludedSubjectGroupResources {
+	if m.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSubjectSpecimenResources != nil {
-		for _, r := range *m.IncludedSubjectSpecimenResources {
+	if m.IncludedSpecimenResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedSpecimenResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSubjectDeviceResources != nil {
-		for _, r := range *m.IncludedSubjectDeviceResources {
+	if m.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSubjectPatientResources != nil {
-		for _, r := range *m.IncludedSubjectPatientResources {
+	if m.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPatientResources != nil {
-		for _, r := range *m.IncludedPatientResources {
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedOperatorResources != nil {
-		for _, r := range *m.IncludedOperatorResources {
+	if m.IncludedPractitionerResourcesReferencedByOperator != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByOperator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MediaPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDiagnosticReportResourcesReferencingImage != nil {
+		for _, r := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MediaPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPractitionerResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSpecimenResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedSpecimenResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByOperator != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByOperator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDiagnosticReportResourcesReferencingImage != nil {
+		for _, r := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/medication.go
+++ b/models/medication.go
@@ -110,80 +110,570 @@ type MedicationPackageContentComponent struct {
 }
 
 type MedicationPlus struct {
-	Medication             `bson:",inline"`
-	MedicationPlusIncludes `bson:",inline"`
+	Medication                     `bson:",inline"`
+	MedicationPlusRelatedResources `bson:",inline"`
 }
 
-type MedicationPlusIncludes struct {
-	IncludedIngredientMedicationResources *[]Medication   `bson:"_includedIngredientMedicationResources,omitempty"`
-	IncludedIngredientSubstanceResources  *[]Substance    `bson:"_includedIngredientSubstanceResources,omitempty"`
-	IncludedContentResources              *[]Medication   `bson:"_includedContentResources,omitempty"`
-	IncludedManufacturerResources         *[]Organization `bson:"_includedManufacturerResources,omitempty"`
+type MedicationPlusRelatedResources struct {
+	IncludedMedicationResourcesReferencedByIngredient                 *[]Medication               `bson:"_includedMedicationResourcesReferencedByIngredient,omitempty"`
+	IncludedSubstanceResourcesReferencedByIngredient                  *[]Substance                `bson:"_includedSubstanceResourcesReferencedByIngredient,omitempty"`
+	IncludedMedicationResourcesReferencedByContent                    *[]Medication               `bson:"_includedMedicationResourcesReferencedByContent,omitempty"`
+	IncludedOrganizationResourcesReferencedByManufacturer             *[]Organization             `bson:"_includedOrganizationResourcesReferencedByManufacturer,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                   *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref         *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref         *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedMedicationResourcesReferencingIngredient               *[]Medication               `bson:"_revIncludedMedicationResourcesReferencingIngredient,omitempty"`
+	RevIncludedMedicationResourcesReferencingContent                  *[]Medication               `bson:"_revIncludedMedicationResourcesReferencingContent,omitempty"`
+	RevIncludedListResourcesReferencingItem                           *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref        *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                        *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingMedication *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingMedication,omitempty"`
+	RevIncludedMedicationStatementResourcesReferencingMedication      *[]MedicationStatement      `bson:"_revIncludedMedicationStatementResourcesReferencingMedication,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                       *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedGroupResourcesReferencingMember                        *[]Group                    `bson:"_revIncludedGroupResourcesReferencingMember,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingMedication       *[]MedicationDispense       `bson:"_revIncludedMedicationDispenseResourcesReferencingMedication,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedMedicationOrderResourcesReferencingMedication          *[]MedicationOrder          `bson:"_revIncludedMedicationOrderResourcesReferencingMedication,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                 *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                   *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated            *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment           *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject       *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest             *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger          *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                  *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MedicationPlusIncludes) GetIncludedIngredientMedicationResource() (medication *Medication, err error) {
-	if m.IncludedIngredientMedicationResources == nil {
+func (m *MedicationPlusRelatedResources) GetIncludedMedicationResourceReferencedByIngredient() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByIngredient == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedIngredientMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedIngredientMedicationResources))
-	} else if len(*m.IncludedIngredientMedicationResources) == 1 {
-		medication = &(*m.IncludedIngredientMedicationResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByIngredient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByIngredient))
+	} else if len(*m.IncludedMedicationResourcesReferencedByIngredient) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByIngredient)[0]
 	}
 	return
 }
 
-func (m *MedicationPlusIncludes) GetIncludedIngredientSubstanceResource() (substance *Substance, err error) {
-	if m.IncludedIngredientSubstanceResources == nil {
+func (m *MedicationPlusRelatedResources) GetIncludedSubstanceResourceReferencedByIngredient() (substance *Substance, err error) {
+	if m.IncludedSubstanceResourcesReferencedByIngredient == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*m.IncludedIngredientSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*m.IncludedIngredientSubstanceResources))
-	} else if len(*m.IncludedIngredientSubstanceResources) == 1 {
-		substance = &(*m.IncludedIngredientSubstanceResources)[0]
+	} else if len(*m.IncludedSubstanceResourcesReferencedByIngredient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*m.IncludedSubstanceResourcesReferencedByIngredient))
+	} else if len(*m.IncludedSubstanceResourcesReferencedByIngredient) == 1 {
+		substance = &(*m.IncludedSubstanceResourcesReferencedByIngredient)[0]
 	}
 	return
 }
 
-func (m *MedicationPlusIncludes) GetIncludedContentResource() (medication *Medication, err error) {
-	if m.IncludedContentResources == nil {
+func (m *MedicationPlusRelatedResources) GetIncludedMedicationResourceReferencedByContent() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByContent == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedContentResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedContentResources))
-	} else if len(*m.IncludedContentResources) == 1 {
-		medication = &(*m.IncludedContentResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByContent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByContent))
+	} else if len(*m.IncludedMedicationResourcesReferencedByContent) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByContent)[0]
 	}
 	return
 }
 
-func (m *MedicationPlusIncludes) GetIncludedManufacturerResource() (organization *Organization, err error) {
-	if m.IncludedManufacturerResources == nil {
+func (m *MedicationPlusRelatedResources) GetIncludedOrganizationResourceReferencedByManufacturer() (organization *Organization, err error) {
+	if m.IncludedOrganizationResourcesReferencedByManufacturer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*m.IncludedManufacturerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedManufacturerResources))
-	} else if len(*m.IncludedManufacturerResources) == 1 {
-		organization = &(*m.IncludedManufacturerResources)[0]
+	} else if len(*m.IncludedOrganizationResourcesReferencedByManufacturer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedOrganizationResourcesReferencedByManufacturer))
+	} else if len(*m.IncludedOrganizationResourcesReferencedByManufacturer) == 1 {
+		organization = &(*m.IncludedOrganizationResourcesReferencedByManufacturer)[0]
 	}
 	return
 }
 
-func (m *MedicationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MedicationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationResourcesReferencingIngredient() (medications []Medication, err error) {
+	if m.RevIncludedMedicationResourcesReferencingIngredient == nil {
+		err = errors.New("RevIncluded medications not requested")
+	} else {
+		medications = *m.RevIncludedMedicationResourcesReferencingIngredient
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationResourcesReferencingContent() (medications []Medication, err error) {
+	if m.RevIncludedMedicationResourcesReferencingContent == nil {
+		err = errors.New("RevIncluded medications not requested")
+	} else {
+		medications = *m.RevIncludedMedicationResourcesReferencingContent
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingMedication() (medicationAdministrations []MedicationAdministration, err error) {
+	if m.RevIncludedMedicationAdministrationResourcesReferencingMedication == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *m.RevIncludedMedicationAdministrationResourcesReferencingMedication
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationStatementResourcesReferencingMedication() (medicationStatements []MedicationStatement, err error) {
+	if m.RevIncludedMedicationStatementResourcesReferencingMedication == nil {
+		err = errors.New("RevIncluded medicationStatements not requested")
+	} else {
+		medicationStatements = *m.RevIncludedMedicationStatementResourcesReferencingMedication
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedGroupResourcesReferencingMember() (groups []Group, err error) {
+	if m.RevIncludedGroupResourcesReferencingMember == nil {
+		err = errors.New("RevIncluded groups not requested")
+	} else {
+		groups = *m.RevIncludedGroupResourcesReferencingMember
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingMedication() (medicationDispenses []MedicationDispense, err error) {
+	if m.RevIncludedMedicationDispenseResourcesReferencingMedication == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *m.RevIncludedMedicationDispenseResourcesReferencingMedication
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMedicationOrderResourcesReferencingMedication() (medicationOrders []MedicationOrder, err error) {
+	if m.RevIncludedMedicationOrderResourcesReferencingMedication == nil {
+		err = errors.New("RevIncluded medicationOrders not requested")
+	} else {
+		medicationOrders = *m.RevIncludedMedicationOrderResourcesReferencingMedication
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MedicationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedIngredientMedicationResources != nil {
-		for _, r := range *m.IncludedIngredientMedicationResources {
+	if m.IncludedMedicationResourcesReferencedByIngredient != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByIngredient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedIngredientSubstanceResources != nil {
-		for _, r := range *m.IncludedIngredientSubstanceResources {
+	if m.IncludedSubstanceResourcesReferencedByIngredient != nil {
+		for _, r := range *m.IncludedSubstanceResourcesReferencedByIngredient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedContentResources != nil {
-		for _, r := range *m.IncludedContentResources {
+	if m.IncludedMedicationResourcesReferencedByContent != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByContent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedManufacturerResources != nil {
-		for _, r := range *m.IncludedManufacturerResources {
+	if m.IncludedOrganizationResourcesReferencedByManufacturer != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationResourcesReferencingIngredient != nil {
+		for _, r := range *m.RevIncludedMedicationResourcesReferencingIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationResourcesReferencingContent != nil {
+		for _, r := range *m.RevIncludedMedicationResourcesReferencingContent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationAdministrationResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationStatementResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *m.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationDispenseResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationOrderResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedMedicationResourcesReferencedByIngredient != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedSubstanceResourcesReferencedByIngredient != nil {
+		for _, r := range *m.IncludedSubstanceResourcesReferencedByIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResourcesReferencedByContent != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByContent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedOrganizationResourcesReferencedByManufacturer != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationResourcesReferencingIngredient != nil {
+		for _, r := range *m.RevIncludedMedicationResourcesReferencingIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationResourcesReferencingContent != nil {
+		for _, r := range *m.RevIncludedMedicationResourcesReferencingContent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationAdministrationResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationStatementResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *m.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationDispenseResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationOrderResourcesReferencingMedication != nil {
+		for _, r := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -106,146 +106,516 @@ type MedicationAdministrationDosageComponent struct {
 }
 
 type MedicationAdministrationPlus struct {
-	MedicationAdministration             `bson:",inline"`
-	MedicationAdministrationPlusIncludes `bson:",inline"`
+	MedicationAdministration                     `bson:",inline"`
+	MedicationAdministrationPlusRelatedResources `bson:",inline"`
 }
 
-type MedicationAdministrationPlusIncludes struct {
-	IncludedPrescriptionResources              *[]MedicationOrder `bson:"_includedPrescriptionResources,omitempty"`
-	IncludedPractitionerPractitionerResources  *[]Practitioner    `bson:"_includedPractitionerPractitionerResources,omitempty"`
-	IncludedPractitionerPatientResources       *[]Patient         `bson:"_includedPractitionerPatientResources,omitempty"`
-	IncludedPractitionerRelatedPersonResources *[]RelatedPerson   `bson:"_includedPractitionerRelatedPersonResources,omitempty"`
-	IncludedPatientResources                   *[]Patient         `bson:"_includedPatientResources,omitempty"`
-	IncludedMedicationResources                *[]Medication      `bson:"_includedMedicationResources,omitempty"`
-	IncludedEncounterResources                 *[]Encounter       `bson:"_includedEncounterResources,omitempty"`
-	IncludedDeviceResources                    *[]Device          `bson:"_includedDeviceResources,omitempty"`
+type MedicationAdministrationPlusRelatedResources struct {
+	IncludedMedicationOrderResourcesReferencedByPrescription    *[]MedicationOrder       `bson:"_includedMedicationOrderResourcesReferencedByPrescription,omitempty"`
+	IncludedPractitionerResourcesReferencedByPractitioner       *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPractitioner,omitempty"`
+	IncludedPatientResourcesReferencedByPractitioner            *[]Patient               `bson:"_includedPatientResourcesReferencedByPractitioner,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByPractitioner      *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByPractitioner,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedMedicationResourcesReferencedByMedication           *[]Medication            `bson:"_includedMedicationResourcesReferencedByMedication,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedDeviceResourcesReferencedByDevice                   *[]Device                `bson:"_includedDeviceResourcesReferencedByDevice,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedPrescriptionResource() (medicationOrder *MedicationOrder, err error) {
-	if m.IncludedPrescriptionResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedMedicationOrderResourceReferencedByPrescription() (medicationOrder *MedicationOrder, err error) {
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription == nil {
 		err = errors.New("Included medicationorders not requested")
-	} else if len(*m.IncludedPrescriptionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*m.IncludedPrescriptionResources))
-	} else if len(*m.IncludedPrescriptionResources) == 1 {
-		medicationOrder = &(*m.IncludedPrescriptionResources)[0]
+	} else if len(*m.IncludedMedicationOrderResourcesReferencedByPrescription) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medicationOrder, but found %d", len(*m.IncludedMedicationOrderResourcesReferencedByPrescription))
+	} else if len(*m.IncludedMedicationOrderResourcesReferencedByPrescription) == 1 {
+		medicationOrder = &(*m.IncludedMedicationOrderResourcesReferencedByPrescription)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerPractitionerResource() (practitioner *Practitioner, err error) {
-	if m.IncludedPractitionerPractitionerResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPractitioner() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedPractitionerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerPractitionerResources))
-	} else if len(*m.IncludedPractitionerPractitionerResources) == 1 {
-		practitioner = &(*m.IncludedPractitionerPractitionerResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByPractitioner))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByPractitioner) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerPatientResource() (patient *Patient, err error) {
-	if m.IncludedPractitionerPatientResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedPatientResourceReferencedByPractitioner() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPractitionerPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPractitionerPatientResources))
-	} else if len(*m.IncludedPractitionerPatientResources) == 1 {
-		patient = &(*m.IncludedPractitionerPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPractitioner))
+	} else if len(*m.IncludedPatientResourcesReferencedByPractitioner) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedPractitionerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if m.IncludedPractitionerRelatedPersonResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByPractitioner() (relatedPerson *RelatedPerson, err error) {
+	if m.IncludedRelatedPersonResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*m.IncludedPractitionerRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedPractitionerRelatedPersonResources))
-	} else if len(*m.IncludedPractitionerRelatedPersonResources) == 1 {
-		relatedPerson = &(*m.IncludedPractitionerRelatedPersonResources)[0]
+	} else if len(*m.IncludedRelatedPersonResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedRelatedPersonResourcesReferencedByPractitioner))
+	} else if len(*m.IncludedRelatedPersonResourcesReferencedByPractitioner) == 1 {
+		relatedPerson = &(*m.IncludedRelatedPersonResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if m.IncludedPatientResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
-	} else if len(*m.IncludedPatientResources) == 1 {
-		patient = &(*m.IncludedPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
-	if m.IncludedMedicationResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedMedicationResourceReferencedByMedication() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByMedication == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
-	} else if len(*m.IncludedMedicationResources) == 1 {
-		medication = &(*m.IncludedMedicationResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByMedication))
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByMedication)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if m.IncludedEncounterResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if m.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*m.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResources))
-	} else if len(*m.IncludedEncounterResources) == 1 {
-		encounter = &(*m.IncludedEncounterResources)[0]
+	} else if len(*m.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*m.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*m.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedDeviceResources() (devices []Device, err error) {
-	if m.IncludedDeviceResources == nil {
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedDeviceResourcesReferencedByDevice() (devices []Device, err error) {
+	if m.IncludedDeviceResourcesReferencedByDevice == nil {
 		err = errors.New("Included devices not requested")
 	} else {
-		devices = *m.IncludedDeviceResources
+		devices = *m.IncludedDeviceResourcesReferencedByDevice
 	}
 	return
 }
 
-func (m *MedicationAdministrationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedPrescriptionResources != nil {
-		for _, r := range *m.IncludedPrescriptionResources {
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
+		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPractitionerPractitionerResources != nil {
-		for _, r := range *m.IncludedPractitionerPractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPractitionerPatientResources != nil {
-		for _, r := range *m.IncludedPractitionerPatientResources {
+	if m.IncludedPatientResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPractitionerRelatedPersonResources != nil {
-		for _, r := range *m.IncludedPractitionerRelatedPersonResources {
+	if m.IncludedRelatedPersonResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPatientResources != nil {
-		for _, r := range *m.IncludedPatientResources {
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedMedicationResources != nil {
-		for _, r := range *m.IncludedMedicationResources {
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedEncounterResources != nil {
-		for _, r := range *m.IncludedEncounterResources {
+	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedDeviceResources != nil {
-		for _, r := range *m.IncludedDeviceResources {
+	if m.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationAdministrationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
+		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedRelatedPersonResourcesReferencedByPractitioner != nil {
+		for _, r := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -119,140 +119,510 @@ type MedicationDispenseSubstitutionComponent struct {
 }
 
 type MedicationDispensePlus struct {
-	MedicationDispense             `bson:",inline"`
-	MedicationDispensePlusIncludes `bson:",inline"`
+	MedicationDispense                     `bson:",inline"`
+	MedicationDispensePlusRelatedResources `bson:",inline"`
 }
 
-type MedicationDispensePlusIncludes struct {
-	IncludedReceiverPractitionerResources *[]Practitioner    `bson:"_includedReceiverPractitionerResources,omitempty"`
-	IncludedReceiverPatientResources      *[]Patient         `bson:"_includedReceiverPatientResources,omitempty"`
-	IncludedDestinationResources          *[]Location        `bson:"_includedDestinationResources,omitempty"`
-	IncludedMedicationResources           *[]Medication      `bson:"_includedMedicationResources,omitempty"`
-	IncludedResponsiblepartyResources     *[]Practitioner    `bson:"_includedResponsiblepartyResources,omitempty"`
-	IncludedDispenserResources            *[]Practitioner    `bson:"_includedDispenserResources,omitempty"`
-	IncludedPrescriptionResources         *[]MedicationOrder `bson:"_includedPrescriptionResources,omitempty"`
-	IncludedPatientResources              *[]Patient         `bson:"_includedPatientResources,omitempty"`
+type MedicationDispensePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByReceiver           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByReceiver,omitempty"`
+	IncludedPatientResourcesReferencedByReceiver                *[]Patient               `bson:"_includedPatientResourcesReferencedByReceiver,omitempty"`
+	IncludedLocationResourcesReferencedByDestination            *[]Location              `bson:"_includedLocationResourcesReferencedByDestination,omitempty"`
+	IncludedMedicationResourcesReferencedByMedication           *[]Medication            `bson:"_includedMedicationResourcesReferencedByMedication,omitempty"`
+	IncludedPractitionerResourcesReferencedByResponsibleparty   *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByResponsibleparty,omitempty"`
+	IncludedPractitionerResourcesReferencedByDispenser          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByDispenser,omitempty"`
+	IncludedMedicationOrderResourcesReferencedByPrescription    *[]MedicationOrder       `bson:"_includedMedicationOrderResourcesReferencedByPrescription,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedReceiverPractitionerResources() (practitioners []Practitioner, err error) {
-	if m.IncludedReceiverPractitionerResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedPractitionerResourcesReferencedByReceiver() (practitioners []Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByReceiver == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *m.IncludedReceiverPractitionerResources
+		practitioners = *m.IncludedPractitionerResourcesReferencedByReceiver
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedReceiverPatientResources() (patients []Patient, err error) {
-	if m.IncludedReceiverPatientResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedPatientResourcesReferencedByReceiver() (patients []Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByReceiver == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *m.IncludedReceiverPatientResources
+		patients = *m.IncludedPatientResourcesReferencedByReceiver
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedDestinationResource() (location *Location, err error) {
-	if m.IncludedDestinationResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedLocationResourceReferencedByDestination() (location *Location, err error) {
+	if m.IncludedLocationResourcesReferencedByDestination == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*m.IncludedDestinationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*m.IncludedDestinationResources))
-	} else if len(*m.IncludedDestinationResources) == 1 {
-		location = &(*m.IncludedDestinationResources)[0]
+	} else if len(*m.IncludedLocationResourcesReferencedByDestination) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*m.IncludedLocationResourcesReferencedByDestination))
+	} else if len(*m.IncludedLocationResourcesReferencedByDestination) == 1 {
+		location = &(*m.IncludedLocationResourcesReferencedByDestination)[0]
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
-	if m.IncludedMedicationResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedMedicationResourceReferencedByMedication() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByMedication == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
-	} else if len(*m.IncludedMedicationResources) == 1 {
-		medication = &(*m.IncludedMedicationResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByMedication))
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByMedication)[0]
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedResponsiblepartyResources() (practitioners []Practitioner, err error) {
-	if m.IncludedResponsiblepartyResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedPractitionerResourcesReferencedByResponsibleparty() (practitioners []Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByResponsibleparty == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *m.IncludedResponsiblepartyResources
+		practitioners = *m.IncludedPractitionerResourcesReferencedByResponsibleparty
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedDispenserResource() (practitioner *Practitioner, err error) {
-	if m.IncludedDispenserResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedPractitionerResourceReferencedByDispenser() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByDispenser == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedDispenserResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedDispenserResources))
-	} else if len(*m.IncludedDispenserResources) == 1 {
-		practitioner = &(*m.IncludedDispenserResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByDispenser) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByDispenser))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByDispenser) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByDispenser)[0]
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedPrescriptionResources() (medicationOrders []MedicationOrder, err error) {
-	if m.IncludedPrescriptionResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedMedicationOrderResourcesReferencedByPrescription() (medicationOrders []MedicationOrder, err error) {
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription == nil {
 		err = errors.New("Included medicationOrders not requested")
 	} else {
-		medicationOrders = *m.IncludedPrescriptionResources
+		medicationOrders = *m.IncludedMedicationOrderResourcesReferencedByPrescription
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if m.IncludedPatientResources == nil {
+func (m *MedicationDispensePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
-	} else if len(*m.IncludedPatientResources) == 1 {
-		patient = &(*m.IncludedPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (m *MedicationDispensePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedReceiverPractitionerResources != nil {
-		for _, r := range *m.IncludedReceiverPractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedReceiverPatientResources != nil {
-		for _, r := range *m.IncludedReceiverPatientResources {
+	if m.IncludedPatientResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByReceiver {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedDestinationResources != nil {
-		for _, r := range *m.IncludedDestinationResources {
+	if m.IncludedLocationResourcesReferencedByDestination != nil {
+		for _, r := range *m.IncludedLocationResourcesReferencedByDestination {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedMedicationResources != nil {
-		for _, r := range *m.IncludedMedicationResources {
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedResponsiblepartyResources != nil {
-		for _, r := range *m.IncludedResponsiblepartyResources {
+	if m.IncludedPractitionerResourcesReferencedByResponsibleparty != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedDispenserResources != nil {
-		for _, r := range *m.IncludedDispenserResources {
+	if m.IncludedPractitionerResourcesReferencedByDispenser != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByDispenser {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPrescriptionResources != nil {
-		for _, r := range *m.IncludedPrescriptionResources {
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
+		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPatientResources != nil {
-		for _, r := range *m.IncludedPatientResources {
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationDispensePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedLocationResourcesReferencedByDestination != nil {
+		for _, r := range *m.IncludedLocationResourcesReferencedByDestination {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByResponsibleparty != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByDispenser != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByDispenser {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
+		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/medicationorder.go
+++ b/models/medicationorder.go
@@ -127,80 +127,530 @@ type MedicationOrderSubstitutionComponent struct {
 }
 
 type MedicationOrderPlus struct {
-	MedicationOrder             `bson:",inline"`
-	MedicationOrderPlusIncludes `bson:",inline"`
+	MedicationOrder                     `bson:",inline"`
+	MedicationOrderPlusRelatedResources `bson:",inline"`
 }
 
-type MedicationOrderPlusIncludes struct {
-	IncludedPrescriberResources *[]Practitioner `bson:"_includedPrescriberResources,omitempty"`
-	IncludedPatientResources    *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedMedicationResources *[]Medication   `bson:"_includedMedicationResources,omitempty"`
-	IncludedEncounterResources  *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type MedicationOrderPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByPrescriber                 *[]Practitioner             `bson:"_includedPractitionerResourcesReferencedByPrescriber,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                         *[]Patient                  `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedMedicationResourcesReferencedByMedication                   *[]Medication               `bson:"_includedMedicationResourcesReferencedByMedication,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter                     *[]Encounter                `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                     *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference            *[]CarePlan                 `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                             *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref          *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                          *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingPrescription *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingPrescription,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                         *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingPrescription       *[]MedicationDispense       `bson:"_revIncludedMedicationDispenseResourcesReferencingPrescription,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                  *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                   *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                     *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated              *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment             *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject         *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest               *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger            *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction             *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan               *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                    *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MedicationOrderPlusIncludes) GetIncludedPrescriberResource() (practitioner *Practitioner, err error) {
-	if m.IncludedPrescriberResources == nil {
+func (m *MedicationOrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPrescriber() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByPrescriber == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedPrescriberResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPrescriberResources))
-	} else if len(*m.IncludedPrescriberResources) == 1 {
-		practitioner = &(*m.IncludedPrescriberResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByPrescriber) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByPrescriber))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByPrescriber) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByPrescriber)[0]
 	}
 	return
 }
 
-func (m *MedicationOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if m.IncludedPatientResources == nil {
+func (m *MedicationOrderPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
-	} else if len(*m.IncludedPatientResources) == 1 {
-		patient = &(*m.IncludedPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (m *MedicationOrderPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
-	if m.IncludedMedicationResources == nil {
+func (m *MedicationOrderPlusRelatedResources) GetIncludedMedicationResourceReferencedByMedication() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByMedication == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
-	} else if len(*m.IncludedMedicationResources) == 1 {
-		medication = &(*m.IncludedMedicationResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByMedication))
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByMedication)[0]
 	}
 	return
 }
 
-func (m *MedicationOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if m.IncludedEncounterResources == nil {
+func (m *MedicationOrderPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if m.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*m.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResources))
-	} else if len(*m.IncludedEncounterResources) == 1 {
-		encounter = &(*m.IncludedEncounterResources)[0]
+	} else if len(*m.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*m.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*m.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*m.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (m *MedicationOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if m.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *m.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingPrescription() (medicationAdministrations []MedicationAdministration, err error) {
+	if m.RevIncludedMedicationAdministrationResourcesReferencingPrescription == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingPrescription() (medicationDispenses []MedicationDispense, err error) {
+	if m.RevIncludedMedicationDispenseResourcesReferencingPrescription == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *m.RevIncludedMedicationDispenseResourcesReferencingPrescription
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedPrescriberResources != nil {
-		for _, r := range *m.IncludedPrescriberResources {
+	if m.IncludedPractitionerResourcesReferencedByPrescriber != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedPatientResources != nil {
-		for _, r := range *m.IncludedPatientResources {
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedMedicationResources != nil {
-		for _, r := range *m.IncludedMedicationResources {
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedEncounterResources != nil {
-		for _, r := range *m.IncludedEncounterResources {
+	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationAdministrationResourcesReferencingPrescription != nil {
+		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationDispenseResourcesReferencingPrescription != nil {
+		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPractitionerResourcesReferencedByPrescriber != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationAdministrationResourcesReferencingPrescription != nil {
+		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMedicationDispenseResourcesReferencingPrescription != nil {
+		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -111,97 +111,452 @@ type MedicationStatementDosageComponent struct {
 }
 
 type MedicationStatementPlus struct {
-	MedicationStatement             `bson:",inline"`
-	MedicationStatementPlusIncludes `bson:",inline"`
+	MedicationStatement                     `bson:",inline"`
+	MedicationStatementPlusRelatedResources `bson:",inline"`
 }
 
-type MedicationStatementPlusIncludes struct {
-	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedMedicationResources          *[]Medication    `bson:"_includedMedicationResources,omitempty"`
-	IncludedSourcePractitionerResources  *[]Practitioner  `bson:"_includedSourcePractitionerResources,omitempty"`
-	IncludedSourcePatientResources       *[]Patient       `bson:"_includedSourcePatientResources,omitempty"`
-	IncludedSourceRelatedPersonResources *[]RelatedPerson `bson:"_includedSourceRelatedPersonResources,omitempty"`
+type MedicationStatementPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedMedicationResourcesReferencedByMedication           *[]Medication            `bson:"_includedMedicationResourcesReferencedByMedication,omitempty"`
+	IncludedPractitionerResourcesReferencedBySource             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySource,omitempty"`
+	IncludedPatientResourcesReferencedBySource                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySource,omitempty"`
+	IncludedRelatedPersonResourcesReferencedBySource            *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedBySource,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if m.IncludedPatientResources == nil {
+func (m *MedicationStatementPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResources))
-	} else if len(*m.IncludedPatientResources) == 1 {
-		patient = &(*m.IncludedPatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*m.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedMedicationResource() (medication *Medication, err error) {
-	if m.IncludedMedicationResources == nil {
+func (m *MedicationStatementPlusRelatedResources) GetIncludedMedicationResourceReferencedByMedication() (medication *Medication, err error) {
+	if m.IncludedMedicationResourcesReferencedByMedication == nil {
 		err = errors.New("Included medications not requested")
-	} else if len(*m.IncludedMedicationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResources))
-	} else if len(*m.IncludedMedicationResources) == 1 {
-		medication = &(*m.IncludedMedicationResources)[0]
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 medication, but found %d", len(*m.IncludedMedicationResourcesReferencedByMedication))
+	} else if len(*m.IncludedMedicationResourcesReferencedByMedication) == 1 {
+		medication = &(*m.IncludedMedicationResourcesReferencedByMedication)[0]
 	}
 	return
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
-	if m.IncludedSourcePractitionerResources == nil {
+func (m *MedicationStatementPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySource() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedBySource == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedSourcePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedSourcePractitionerResources))
-	} else if len(*m.IncludedSourcePractitionerResources) == 1 {
-		practitioner = &(*m.IncludedSourcePractitionerResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedBySource))
+	} else if len(*m.IncludedPractitionerResourcesReferencedBySource) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
-	if m.IncludedSourcePatientResources == nil {
+func (m *MedicationStatementPlusRelatedResources) GetIncludedPatientResourceReferencedBySource() (patient *Patient, err error) {
+	if m.IncludedPatientResourcesReferencedBySource == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*m.IncludedSourcePatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedSourcePatientResources))
-	} else if len(*m.IncludedSourcePatientResources) == 1 {
-		patient = &(*m.IncludedSourcePatientResources)[0]
+	} else if len(*m.IncludedPatientResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*m.IncludedPatientResourcesReferencedBySource))
+	} else if len(*m.IncludedPatientResourcesReferencedBySource) == 1 {
+		patient = &(*m.IncludedPatientResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedSourceRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if m.IncludedSourceRelatedPersonResources == nil {
+func (m *MedicationStatementPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedBySource() (relatedPerson *RelatedPerson, err error) {
+	if m.IncludedRelatedPersonResourcesReferencedBySource == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*m.IncludedSourceRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedSourceRelatedPersonResources))
-	} else if len(*m.IncludedSourceRelatedPersonResources) == 1 {
-		relatedPerson = &(*m.IncludedSourceRelatedPersonResources)[0]
+	} else if len(*m.IncludedRelatedPersonResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*m.IncludedRelatedPersonResourcesReferencedBySource))
+	} else if len(*m.IncludedRelatedPersonResourcesReferencedBySource) == 1 {
+		relatedPerson = &(*m.IncludedRelatedPersonResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (m *MedicationStatementPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedPatientResources != nil {
-		for _, r := range *m.IncludedPatientResources {
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedMedicationResources != nil {
-		for _, r := range *m.IncludedMedicationResources {
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSourcePractitionerResources != nil {
-		for _, r := range *m.IncludedSourcePractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSourcePatientResources != nil {
-		for _, r := range *m.IncludedSourcePatientResources {
+	if m.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedSourceRelatedPersonResources != nil {
-		for _, r := range *m.IncludedSourceRelatedPersonResources {
+	if m.IncludedRelatedPersonResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedRelatedPersonResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MedicationStatementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedMedicationResourcesReferencedByMedication != nil {
+		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedPatientResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedRelatedPersonResourcesReferencedBySource != nil {
+		for _, r := range *m.IncludedRelatedPersonResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/messageheader.go
+++ b/models/messageheader.go
@@ -110,131 +110,516 @@ type MessageHeaderMessageDestinationComponent struct {
 }
 
 type MessageHeaderPlus struct {
-	MessageHeader             `bson:",inline"`
-	MessageHeaderPlusIncludes `bson:",inline"`
+	MessageHeader                     `bson:",inline"`
+	MessageHeaderPlusRelatedResources `bson:",inline"`
 }
 
-type MessageHeaderPlusIncludes struct {
-	IncludedReceiverPractitionerResources    *[]Practitioner `bson:"_includedReceiverPractitionerResources,omitempty"`
-	IncludedReceiverOrganizationResources    *[]Organization `bson:"_includedReceiverOrganizationResources,omitempty"`
-	IncludedAuthorResources                  *[]Practitioner `bson:"_includedAuthorResources,omitempty"`
-	IncludedTargetResources                  *[]Device       `bson:"_includedTargetResources,omitempty"`
-	IncludedResponsiblePractitionerResources *[]Practitioner `bson:"_includedResponsiblePractitionerResources,omitempty"`
-	IncludedResponsibleOrganizationResources *[]Organization `bson:"_includedResponsibleOrganizationResources,omitempty"`
-	IncludedEntererResources                 *[]Practitioner `bson:"_includedEntererResources,omitempty"`
+type MessageHeaderPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByReceiver           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByReceiver,omitempty"`
+	IncludedOrganizationResourcesReferencedByReceiver           *[]Organization          `bson:"_includedOrganizationResourcesReferencedByReceiver,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByTarget                   *[]Device                `bson:"_includedDeviceResourcesReferencedByTarget,omitempty"`
+	IncludedPractitionerResourcesReferencedByResponsible        *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByResponsible,omitempty"`
+	IncludedOrganizationResourcesReferencedByResponsible        *[]Organization          `bson:"_includedOrganizationResourcesReferencedByResponsible,omitempty"`
+	IncludedPractitionerResourcesReferencedByEnterer            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByEnterer,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedBundleResourcesReferencingMessage                *[]Bundle                `bson:"_revIncludedBundleResourcesReferencingMessage,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedReceiverPractitionerResource() (practitioner *Practitioner, err error) {
-	if m.IncludedReceiverPractitionerResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByReceiver() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByReceiver == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedReceiverPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedReceiverPractitionerResources))
-	} else if len(*m.IncludedReceiverPractitionerResources) == 1 {
-		practitioner = &(*m.IncludedReceiverPractitionerResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByReceiver) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByReceiver))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByReceiver) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByReceiver)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedReceiverOrganizationResource() (organization *Organization, err error) {
-	if m.IncludedReceiverOrganizationResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedOrganizationResourceReferencedByReceiver() (organization *Organization, err error) {
+	if m.IncludedOrganizationResourcesReferencedByReceiver == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*m.IncludedReceiverOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedReceiverOrganizationResources))
-	} else if len(*m.IncludedReceiverOrganizationResources) == 1 {
-		organization = &(*m.IncludedReceiverOrganizationResources)[0]
+	} else if len(*m.IncludedOrganizationResourcesReferencedByReceiver) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedOrganizationResourcesReferencedByReceiver))
+	} else if len(*m.IncludedOrganizationResourcesReferencedByReceiver) == 1 {
+		organization = &(*m.IncludedOrganizationResourcesReferencedByReceiver)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedAuthorResource() (practitioner *Practitioner, err error) {
-	if m.IncludedAuthorResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedAuthorResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedAuthorResources))
-	} else if len(*m.IncludedAuthorResources) == 1 {
-		practitioner = &(*m.IncludedAuthorResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedTargetResource() (device *Device, err error) {
-	if m.IncludedTargetResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedDeviceResourceReferencedByTarget() (device *Device, err error) {
+	if m.IncludedDeviceResourcesReferencedByTarget == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*m.IncludedTargetResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedTargetResources))
-	} else if len(*m.IncludedTargetResources) == 1 {
-		device = &(*m.IncludedTargetResources)[0]
+	} else if len(*m.IncludedDeviceResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*m.IncludedDeviceResourcesReferencedByTarget))
+	} else if len(*m.IncludedDeviceResourcesReferencedByTarget) == 1 {
+		device = &(*m.IncludedDeviceResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedResponsiblePractitionerResource() (practitioner *Practitioner, err error) {
-	if m.IncludedResponsiblePractitionerResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByResponsible() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByResponsible == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedResponsiblePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedResponsiblePractitionerResources))
-	} else if len(*m.IncludedResponsiblePractitionerResources) == 1 {
-		practitioner = &(*m.IncludedResponsiblePractitionerResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByResponsible) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByResponsible))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByResponsible) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByResponsible)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedResponsibleOrganizationResource() (organization *Organization, err error) {
-	if m.IncludedResponsibleOrganizationResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedOrganizationResourceReferencedByResponsible() (organization *Organization, err error) {
+	if m.IncludedOrganizationResourcesReferencedByResponsible == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*m.IncludedResponsibleOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedResponsibleOrganizationResources))
-	} else if len(*m.IncludedResponsibleOrganizationResources) == 1 {
-		organization = &(*m.IncludedResponsibleOrganizationResources)[0]
+	} else if len(*m.IncludedOrganizationResourcesReferencedByResponsible) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*m.IncludedOrganizationResourcesReferencedByResponsible))
+	} else if len(*m.IncludedOrganizationResourcesReferencedByResponsible) == 1 {
+		organization = &(*m.IncludedOrganizationResourcesReferencedByResponsible)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedEntererResource() (practitioner *Practitioner, err error) {
-	if m.IncludedEntererResources == nil {
+func (m *MessageHeaderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByEnterer() (practitioner *Practitioner, err error) {
+	if m.IncludedPractitionerResourcesReferencedByEnterer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*m.IncludedEntererResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedEntererResources))
-	} else if len(*m.IncludedEntererResources) == 1 {
-		practitioner = &(*m.IncludedEntererResources)[0]
+	} else if len(*m.IncludedPractitionerResourcesReferencedByEnterer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*m.IncludedPractitionerResourcesReferencedByEnterer))
+	} else if len(*m.IncludedPractitionerResourcesReferencedByEnterer) == 1 {
+		practitioner = &(*m.IncludedPractitionerResourcesReferencedByEnterer)[0]
 	}
 	return
 }
 
-func (m *MessageHeaderPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if m.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *m.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *m.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if m.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *m.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if m.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *m.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if m.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *m.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if m.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *m.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if m.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *m.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *m.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedBundleResourcesReferencingMessage() (bundles []Bundle, err error) {
+	if m.RevIncludedBundleResourcesReferencingMessage == nil {
+		err = errors.New("RevIncluded bundles not requested")
+	} else {
+		bundles = *m.RevIncludedBundleResourcesReferencingMessage
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *m.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if m.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *m.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *m.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if m.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *m.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if m.IncludedReceiverPractitionerResources != nil {
-		for _, r := range *m.IncludedReceiverPractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedReceiverOrganizationResources != nil {
-		for _, r := range *m.IncludedReceiverOrganizationResources {
+	if m.IncludedOrganizationResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByReceiver {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedAuthorResources != nil {
-		for _, r := range *m.IncludedAuthorResources {
+	if m.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedTargetResources != nil {
-		for _, r := range *m.IncludedTargetResources {
+	if m.IncludedDeviceResourcesReferencedByTarget != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedByTarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedResponsiblePractitionerResources != nil {
-		for _, r := range *m.IncludedResponsiblePractitionerResources {
+	if m.IncludedPractitionerResourcesReferencedByResponsible != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsible {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedResponsibleOrganizationResources != nil {
-		for _, r := range *m.IncludedResponsibleOrganizationResources {
+	if m.IncludedOrganizationResourcesReferencedByResponsible != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByResponsible {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if m.IncludedEntererResources != nil {
-		for _, r := range *m.IncludedEntererResources {
+	if m.IncludedPractitionerResourcesReferencedByEnterer != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByEnterer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBundleResourcesReferencingMessage != nil {
+		for _, r := range *m.RevIncludedBundleResourcesReferencingMessage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (m *MessageHeaderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedOrganizationResourcesReferencedByReceiver != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedDeviceResourcesReferencedByTarget != nil {
+		for _, r := range *m.IncludedDeviceResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByResponsible != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedOrganizationResourcesReferencedByResponsible != nil {
+		for _, r := range *m.IncludedOrganizationResourcesReferencedByResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.IncludedPractitionerResourcesReferencedByEnterer != nil {
+		for _, r := range *m.IncludedPractitionerResourcesReferencedByEnterer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *m.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedBundleResourcesReferencingMessage != nil {
+		for _, r := range *m.RevIncludedBundleResourcesReferencingMessage {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/namingsystem.go
+++ b/models/namingsystem.go
@@ -104,29 +104,384 @@ type NamingSystemUniqueIdComponent struct {
 }
 
 type NamingSystemPlus struct {
-	NamingSystem             `bson:",inline"`
-	NamingSystemPlusIncludes `bson:",inline"`
+	NamingSystem                     `bson:",inline"`
+	NamingSystemPlusRelatedResources `bson:",inline"`
 }
 
-type NamingSystemPlusIncludes struct {
-	IncludedReplacedbyResources *[]NamingSystem `bson:"_includedReplacedbyResources,omitempty"`
+type NamingSystemPlusRelatedResources struct {
+	IncludedNamingSystemResourcesReferencedByReplacedby         *[]NamingSystem          `bson:"_includedNamingSystemResourcesReferencedByReplacedby,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedNamingSystemResourcesReferencingReplacedby       *[]NamingSystem          `bson:"_revIncludedNamingSystemResourcesReferencingReplacedby,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (n *NamingSystemPlusIncludes) GetIncludedReplacedbyResource() (namingSystem *NamingSystem, err error) {
-	if n.IncludedReplacedbyResources == nil {
+func (n *NamingSystemPlusRelatedResources) GetIncludedNamingSystemResourceReferencedByReplacedby() (namingSystem *NamingSystem, err error) {
+	if n.IncludedNamingSystemResourcesReferencedByReplacedby == nil {
 		err = errors.New("Included namingsystems not requested")
-	} else if len(*n.IncludedReplacedbyResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 namingSystem, but found %d", len(*n.IncludedReplacedbyResources))
-	} else if len(*n.IncludedReplacedbyResources) == 1 {
-		namingSystem = &(*n.IncludedReplacedbyResources)[0]
+	} else if len(*n.IncludedNamingSystemResourcesReferencedByReplacedby) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 namingSystem, but found %d", len(*n.IncludedNamingSystemResourcesReferencedByReplacedby))
+	} else if len(*n.IncludedNamingSystemResourcesReferencedByReplacedby) == 1 {
+		namingSystem = &(*n.IncludedNamingSystemResourcesReferencedByReplacedby)[0]
 	}
 	return
 }
 
-func (n *NamingSystemPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if n.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *n.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *n.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *n.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if n.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *n.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if n.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *n.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if n.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *n.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if n.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *n.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if n.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *n.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if n.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *n.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *n.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *n.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if n.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *n.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedNamingSystemResourcesReferencingReplacedby() (namingSystems []NamingSystem, err error) {
+	if n.RevIncludedNamingSystemResourcesReferencingReplacedby == nil {
+		err = errors.New("RevIncluded namingSystems not requested")
+	} else {
+		namingSystems = *n.RevIncludedNamingSystemResourcesReferencingReplacedby
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *n.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if n.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *n.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (n *NamingSystemPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if n.IncludedReplacedbyResources != nil {
-		for _, r := range *n.IncludedReplacedbyResources {
+	if n.IncludedNamingSystemResourcesReferencedByReplacedby != nil {
+		for _, r := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (n *NamingSystemPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *n.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedNamingSystemResourcesReferencingReplacedby != nil {
+		for _, r := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (n *NamingSystemPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if n.IncludedNamingSystemResourcesReferencedByReplacedby != nil {
+		for _, r := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *n.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedNamingSystemResourcesReferencingReplacedby != nil {
+		for _, r := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -137,63 +137,468 @@ type NutritionOrderEnteralFormulaAdministrationComponent struct {
 }
 
 type NutritionOrderPlus struct {
-	NutritionOrder             `bson:",inline"`
-	NutritionOrderPlusIncludes `bson:",inline"`
+	NutritionOrder                     `bson:",inline"`
+	NutritionOrderPlusRelatedResources `bson:",inline"`
 }
 
-type NutritionOrderPlusIncludes struct {
-	IncludedProviderResources  *[]Practitioner `bson:"_includedProviderResources,omitempty"`
-	IncludedPatientResources   *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedEncounterResources *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type NutritionOrderPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByProvider           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByProvider,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (n *NutritionOrderPlusIncludes) GetIncludedProviderResource() (practitioner *Practitioner, err error) {
-	if n.IncludedProviderResources == nil {
+func (n *NutritionOrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByProvider() (practitioner *Practitioner, err error) {
+	if n.IncludedPractitionerResourcesReferencedByProvider == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*n.IncludedProviderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*n.IncludedProviderResources))
-	} else if len(*n.IncludedProviderResources) == 1 {
-		practitioner = &(*n.IncludedProviderResources)[0]
+	} else if len(*n.IncludedPractitionerResourcesReferencedByProvider) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*n.IncludedPractitionerResourcesReferencedByProvider))
+	} else if len(*n.IncludedPractitionerResourcesReferencedByProvider) == 1 {
+		practitioner = &(*n.IncludedPractitionerResourcesReferencedByProvider)[0]
 	}
 	return
 }
 
-func (n *NutritionOrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if n.IncludedPatientResources == nil {
+func (n *NutritionOrderPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if n.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*n.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*n.IncludedPatientResources))
-	} else if len(*n.IncludedPatientResources) == 1 {
-		patient = &(*n.IncludedPatientResources)[0]
+	} else if len(*n.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*n.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*n.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*n.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (n *NutritionOrderPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if n.IncludedEncounterResources == nil {
+func (n *NutritionOrderPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if n.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*n.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*n.IncludedEncounterResources))
-	} else if len(*n.IncludedEncounterResources) == 1 {
-		encounter = &(*n.IncludedEncounterResources)[0]
+	} else if len(*n.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*n.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*n.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*n.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (n *NutritionOrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if n.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *n.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *n.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *n.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if n.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *n.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if n.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *n.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if n.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *n.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if n.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *n.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if n.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *n.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if n.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *n.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if n.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *n.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *n.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *n.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if n.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *n.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *n.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if n.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *n.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if n.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *n.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if n.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *n.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if n.IncludedProviderResources != nil {
-		for _, r := range *n.IncludedProviderResources {
+	if n.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *n.IncludedPractitionerResourcesReferencedByProvider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if n.IncludedPatientResources != nil {
-		for _, r := range *n.IncludedPatientResources {
+	if n.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *n.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if n.IncludedEncounterResources != nil {
-		for _, r := range *n.IncludedEncounterResources {
+	if n.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *n.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *n.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (n *NutritionOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if n.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *n.IncludedPractitionerResourcesReferencedByProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *n.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *n.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *n.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/observation.go
+++ b/models/observation.go
@@ -138,259 +138,764 @@ type ObservationComponentComponent struct {
 }
 
 type ObservationPlus struct {
-	Observation             `bson:",inline"`
-	ObservationPlusIncludes `bson:",inline"`
+	Observation                     `bson:",inline"`
+	ObservationPlusRelatedResources `bson:",inline"`
 }
 
-type ObservationPlusIncludes struct {
-	IncludedSubjectGroupResources                       *[]Group                 `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources                      *[]Device                `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources                     *[]Patient               `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectLocationResources                    *[]Location              `bson:"_includedSubjectLocationResources,omitempty"`
-	IncludedPatientResources                            *[]Patient               `bson:"_includedPatientResources,omitempty"`
-	IncludedSpecimenResources                           *[]Specimen              `bson:"_includedSpecimenResources,omitempty"`
-	IncludedPerformerPractitionerResources              *[]Practitioner          `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerOrganizationResources              *[]Organization          `bson:"_includedPerformerOrganizationResources,omitempty"`
-	IncludedPerformerPatientResources                   *[]Patient               `bson:"_includedPerformerPatientResources,omitempty"`
-	IncludedPerformerRelatedPersonResources             *[]RelatedPerson         `bson:"_includedPerformerRelatedPersonResources,omitempty"`
-	IncludedEncounterResources                          *[]Encounter             `bson:"_includedEncounterResources,omitempty"`
-	IncludedRelatedtargetObservationResources           *[]Observation           `bson:"_includedRelatedtargetObservationResources,omitempty"`
-	IncludedRelatedtargetQuestionnaireResponseResources *[]QuestionnaireResponse `bson:"_includedRelatedtargetQuestionnaireResponseResources,omitempty"`
-	IncludedDeviceDeviceResources                       *[]Device                `bson:"_includedDeviceDeviceResources,omitempty"`
-	IncludedDeviceDeviceMetricResources                 *[]DeviceMetric          `bson:"_includedDeviceDeviceMetricResources,omitempty"`
+type ObservationPlusRelatedResources struct {
+	IncludedGroupResourcesReferencedBySubject                            *[]Group                      `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                           *[]Device                     `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                          *[]Patient                    `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedLocationResourcesReferencedBySubject                         *[]Location                   `bson:"_includedLocationResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                          *[]Patient                    `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedSpecimenResourcesReferencedBySpecimen                        *[]Specimen                   `bson:"_includedSpecimenResourcesReferencedBySpecimen,omitempty"`
+	IncludedPractitionerResourcesReferencedByPerformer                   *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedOrganizationResourcesReferencedByPerformer                   *[]Organization               `bson:"_includedOrganizationResourcesReferencedByPerformer,omitempty"`
+	IncludedPatientResourcesReferencedByPerformer                        *[]Patient                    `bson:"_includedPatientResourcesReferencedByPerformer,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByPerformer                  *[]RelatedPerson              `bson:"_includedRelatedPersonResourcesReferencedByPerformer,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter                      *[]Encounter                  `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedObservationResourcesReferencedByRelatedtarget                *[]Observation                `bson:"_includedObservationResourcesReferencedByRelatedtarget,omitempty"`
+	IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget      *[]QuestionnaireResponse      `bson:"_includedQuestionnaireResponseResourcesReferencedByRelatedtarget,omitempty"`
+	IncludedDeviceResourcesReferencedByDevice                            *[]Device                     `bson:"_includedDeviceResourcesReferencedByDevice,omitempty"`
+	IncludedDeviceMetricResourcesReferencedByDevice                      *[]DeviceMetric               `bson:"_includedDeviceMetricResourcesReferencedByDevice,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                      *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref            *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref            *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                              *[]List                       `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref           *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                           *[]Order                      `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedImmunizationResourcesReferencingReaction                  *[]Immunization               `bson:"_revIncludedImmunizationResourcesReferencingReaction,omitempty"`
+	RevIncludedObservationResourcesReferencingRelatedtarget              *[]Observation                `bson:"_revIncludedObservationResourcesReferencingRelatedtarget,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                          *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingResult                *[]DiagnosticReport           `bson:"_revIncludedDiagnosticReportResourcesReferencingResult,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                   *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                    *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                      *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated               *[]DetectedIssue              `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment              *[]OrderResponse              `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject          *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest                *[]ProcessResponse            `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger             *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingInvestigation       *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingInvestigation,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                     *[]MessageHeader              `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedImmunizationRecommendationResourcesReferencingInformation *[]ImmunizationRecommendation `bson:"_revIncludedImmunizationRecommendationResourcesReferencingInformation,omitempty"`
 }
 
-func (o *ObservationPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if o.IncludedSubjectGroupResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if o.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*o.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedSubjectGroupResources))
-	} else if len(*o.IncludedSubjectGroupResources) == 1 {
-		group = &(*o.IncludedSubjectGroupResources)[0]
+	} else if len(*o.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*o.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*o.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if o.IncludedSubjectDeviceResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if o.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*o.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedSubjectDeviceResources))
-	} else if len(*o.IncludedSubjectDeviceResources) == 1 {
-		device = &(*o.IncludedSubjectDeviceResources)[0]
+	} else if len(*o.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*o.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*o.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if o.IncludedSubjectPatientResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if o.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*o.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedSubjectPatientResources))
-	} else if len(*o.IncludedSubjectPatientResources) == 1 {
-		patient = &(*o.IncludedSubjectPatientResources)[0]
+	} else if len(*o.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*o.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*o.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedSubjectLocationResource() (location *Location, err error) {
-	if o.IncludedSubjectLocationResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedLocationResourceReferencedBySubject() (location *Location, err error) {
+	if o.IncludedLocationResourcesReferencedBySubject == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*o.IncludedSubjectLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*o.IncludedSubjectLocationResources))
-	} else if len(*o.IncludedSubjectLocationResources) == 1 {
-		location = &(*o.IncludedSubjectLocationResources)[0]
+	} else if len(*o.IncludedLocationResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*o.IncludedLocationResourcesReferencedBySubject))
+	} else if len(*o.IncludedLocationResourcesReferencedBySubject) == 1 {
+		location = &(*o.IncludedLocationResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if o.IncludedPatientResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if o.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*o.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResources))
-	} else if len(*o.IncludedPatientResources) == 1 {
-		patient = &(*o.IncludedPatientResources)[0]
+	} else if len(*o.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*o.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*o.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedSpecimenResource() (specimen *Specimen, err error) {
-	if o.IncludedSpecimenResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedSpecimenResourceReferencedBySpecimen() (specimen *Specimen, err error) {
+	if o.IncludedSpecimenResourcesReferencedBySpecimen == nil {
 		err = errors.New("Included specimen not requested")
-	} else if len(*o.IncludedSpecimenResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*o.IncludedSpecimenResources))
-	} else if len(*o.IncludedSpecimenResources) == 1 {
-		specimen = &(*o.IncludedSpecimenResources)[0]
+	} else if len(*o.IncludedSpecimenResourcesReferencedBySpecimen) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 specimen, but found %d", len(*o.IncludedSpecimenResourcesReferencedBySpecimen))
+	} else if len(*o.IncludedSpecimenResourcesReferencedBySpecimen) == 1 {
+		specimen = &(*o.IncludedSpecimenResourcesReferencedBySpecimen)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedPerformerPractitionerResources() (practitioners []Practitioner, err error) {
-	if o.IncludedPerformerPractitionerResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByPerformer() (practitioners []Practitioner, err error) {
+	if o.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *o.IncludedPerformerPractitionerResources
+		practitioners = *o.IncludedPractitionerResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedPerformerOrganizationResources() (organizations []Organization, err error) {
-	if o.IncludedPerformerOrganizationResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByPerformer() (organizations []Organization, err error) {
+	if o.IncludedOrganizationResourcesReferencedByPerformer == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *o.IncludedPerformerOrganizationResources
+		organizations = *o.IncludedOrganizationResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedPerformerPatientResources() (patients []Patient, err error) {
-	if o.IncludedPerformerPatientResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedPatientResourcesReferencedByPerformer() (patients []Patient, err error) {
+	if o.IncludedPatientResourcesReferencedByPerformer == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *o.IncludedPerformerPatientResources
+		patients = *o.IncludedPatientResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedPerformerRelatedPersonResources() (relatedPeople []RelatedPerson, err error) {
-	if o.IncludedPerformerRelatedPersonResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedRelatedPersonResourcesReferencedByPerformer() (relatedPeople []RelatedPerson, err error) {
+	if o.IncludedRelatedPersonResourcesReferencedByPerformer == nil {
 		err = errors.New("Included relatedPeople not requested")
 	} else {
-		relatedPeople = *o.IncludedPerformerRelatedPersonResources
+		relatedPeople = *o.IncludedRelatedPersonResourcesReferencedByPerformer
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if o.IncludedEncounterResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if o.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*o.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*o.IncludedEncounterResources))
-	} else if len(*o.IncludedEncounterResources) == 1 {
-		encounter = &(*o.IncludedEncounterResources)[0]
+	} else if len(*o.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*o.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*o.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*o.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedRelatedtargetObservationResource() (observation *Observation, err error) {
-	if o.IncludedRelatedtargetObservationResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedObservationResourceReferencedByRelatedtarget() (observation *Observation, err error) {
+	if o.IncludedObservationResourcesReferencedByRelatedtarget == nil {
 		err = errors.New("Included observations not requested")
-	} else if len(*o.IncludedRelatedtargetObservationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*o.IncludedRelatedtargetObservationResources))
-	} else if len(*o.IncludedRelatedtargetObservationResources) == 1 {
-		observation = &(*o.IncludedRelatedtargetObservationResources)[0]
+	} else if len(*o.IncludedObservationResourcesReferencedByRelatedtarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 observation, but found %d", len(*o.IncludedObservationResourcesReferencedByRelatedtarget))
+	} else if len(*o.IncludedObservationResourcesReferencedByRelatedtarget) == 1 {
+		observation = &(*o.IncludedObservationResourcesReferencedByRelatedtarget)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedRelatedtargetQuestionnaireResponseResource() (questionnaireResponse *QuestionnaireResponse, err error) {
-	if o.IncludedRelatedtargetQuestionnaireResponseResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedQuestionnaireResponseResourceReferencedByRelatedtarget() (questionnaireResponse *QuestionnaireResponse, err error) {
+	if o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget == nil {
 		err = errors.New("Included questionnaireresponses not requested")
-	} else if len(*o.IncludedRelatedtargetQuestionnaireResponseResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 questionnaireResponse, but found %d", len(*o.IncludedRelatedtargetQuestionnaireResponseResources))
-	} else if len(*o.IncludedRelatedtargetQuestionnaireResponseResources) == 1 {
-		questionnaireResponse = &(*o.IncludedRelatedtargetQuestionnaireResponseResources)[0]
+	} else if len(*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 questionnaireResponse, but found %d", len(*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget))
+	} else if len(*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget) == 1 {
+		questionnaireResponse = &(*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedDeviceDeviceResource() (device *Device, err error) {
-	if o.IncludedDeviceDeviceResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedDeviceResourceReferencedByDevice() (device *Device, err error) {
+	if o.IncludedDeviceResourcesReferencedByDevice == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*o.IncludedDeviceDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceDeviceResources))
-	} else if len(*o.IncludedDeviceDeviceResources) == 1 {
-		device = &(*o.IncludedDeviceDeviceResources)[0]
+	} else if len(*o.IncludedDeviceResourcesReferencedByDevice) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceResourcesReferencedByDevice))
+	} else if len(*o.IncludedDeviceResourcesReferencedByDevice) == 1 {
+		device = &(*o.IncludedDeviceResourcesReferencedByDevice)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedDeviceDeviceMetricResource() (deviceMetric *DeviceMetric, err error) {
-	if o.IncludedDeviceDeviceMetricResources == nil {
+func (o *ObservationPlusRelatedResources) GetIncludedDeviceMetricResourceReferencedByDevice() (deviceMetric *DeviceMetric, err error) {
+	if o.IncludedDeviceMetricResourcesReferencedByDevice == nil {
 		err = errors.New("Included devicemetrics not requested")
-	} else if len(*o.IncludedDeviceDeviceMetricResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 deviceMetric, but found %d", len(*o.IncludedDeviceDeviceMetricResources))
-	} else if len(*o.IncludedDeviceDeviceMetricResources) == 1 {
-		deviceMetric = &(*o.IncludedDeviceDeviceMetricResources)[0]
+	} else if len(*o.IncludedDeviceMetricResourcesReferencedByDevice) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 deviceMetric, but found %d", len(*o.IncludedDeviceMetricResourcesReferencedByDevice))
+	} else if len(*o.IncludedDeviceMetricResourcesReferencedByDevice) == 1 {
+		deviceMetric = &(*o.IncludedDeviceMetricResourcesReferencedByDevice)[0]
 	}
 	return
 }
 
-func (o *ObservationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *ObservationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingReaction() (immunizations []Immunization, err error) {
+	if o.RevIncludedImmunizationResourcesReferencingReaction == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *o.RevIncludedImmunizationResourcesReferencingReaction
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedObservationResourcesReferencingRelatedtarget() (observations []Observation, err error) {
+	if o.RevIncludedObservationResourcesReferencingRelatedtarget == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *o.RevIncludedObservationResourcesReferencingRelatedtarget
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingResult() (diagnosticReports []DiagnosticReport, err error) {
+	if o.RevIncludedDiagnosticReportResourcesReferencingResult == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *o.RevIncludedDiagnosticReportResourcesReferencingResult
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingInvestigation() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingInvestigation == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedImmunizationRecommendationResourcesReferencingInformation() (immunizationRecommendations []ImmunizationRecommendation, err error) {
+	if o.RevIncludedImmunizationRecommendationResourcesReferencingInformation == nil {
+		err = errors.New("RevIncluded immunizationRecommendations not requested")
+	} else {
+		immunizationRecommendations = *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation
+	}
+	return
+}
+
+func (o *ObservationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if o.IncludedSubjectGroupResources != nil {
-		for _, r := range *o.IncludedSubjectGroupResources {
+	if o.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectDeviceResources != nil {
-		for _, r := range *o.IncludedSubjectDeviceResources {
+	if o.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectPatientResources != nil {
-		for _, r := range *o.IncludedSubjectPatientResources {
+	if o.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectLocationResources != nil {
-		for _, r := range *o.IncludedSubjectLocationResources {
+	if o.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedLocationResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPatientResources != nil {
-		for _, r := range *o.IncludedPatientResources {
+	if o.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSpecimenResources != nil {
-		for _, r := range *o.IncludedSpecimenResources {
+	if o.IncludedSpecimenResourcesReferencedBySpecimen != nil {
+		for _, r := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *o.IncludedPerformerPractitionerResources {
+	if o.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPerformerOrganizationResources != nil {
-		for _, r := range *o.IncludedPerformerOrganizationResources {
+	if o.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPerformerPatientResources != nil {
-		for _, r := range *o.IncludedPerformerPatientResources {
+	if o.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPerformerRelatedPersonResources != nil {
-		for _, r := range *o.IncludedPerformerRelatedPersonResources {
+	if o.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedEncounterResources != nil {
-		for _, r := range *o.IncludedEncounterResources {
+	if o.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *o.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedRelatedtargetObservationResources != nil {
-		for _, r := range *o.IncludedRelatedtargetObservationResources {
+	if o.IncludedObservationResourcesReferencedByRelatedtarget != nil {
+		for _, r := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedRelatedtargetQuestionnaireResponseResources != nil {
-		for _, r := range *o.IncludedRelatedtargetQuestionnaireResponseResources {
+	if o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget != nil {
+		for _, r := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedDeviceDeviceResources != nil {
-		for _, r := range *o.IncludedDeviceDeviceResources {
+	if o.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByDevice {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedDeviceDeviceMetricResources != nil {
-		for _, r := range *o.IncludedDeviceDeviceMetricResources {
+	if o.IncludedDeviceMetricResourcesReferencedByDevice != nil {
+		for _, r := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *ObservationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationResourcesReferencingReaction != nil {
+		for _, r := range *o.RevIncludedImmunizationResourcesReferencingReaction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
+		for _, r := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDiagnosticReportResourcesReferencingResult != nil {
+		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
+		for _, r := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *ObservationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedLocationResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedLocationResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSpecimenResourcesReferencedBySpecimen != nil {
+		for _, r := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *o.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedObservationResourcesReferencedByRelatedtarget != nil {
+		for _, r := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget != nil {
+		for _, r := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceResourcesReferencedByDevice != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceMetricResourcesReferencedByDevice != nil {
+		for _, r := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationResourcesReferencingReaction != nil {
+		for _, r := range *o.RevIncludedImmunizationResourcesReferencingReaction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
+		for _, r := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDiagnosticReportResourcesReferencingResult != nil {
+		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
+		for _, r := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/operationdefinition.go
+++ b/models/operationdefinition.go
@@ -121,46 +121,406 @@ type OperationDefinitionParameterBindingComponent struct {
 }
 
 type OperationDefinitionPlus struct {
-	OperationDefinition             `bson:",inline"`
-	OperationDefinitionPlusIncludes `bson:",inline"`
+	OperationDefinition                     `bson:",inline"`
+	OperationDefinitionPlusRelatedResources `bson:",inline"`
 }
 
-type OperationDefinitionPlusIncludes struct {
-	IncludedProfileResources *[]StructureDefinition `bson:"_includedProfileResources,omitempty"`
-	IncludedBaseResources    *[]OperationDefinition `bson:"_includedBaseResources,omitempty"`
+type OperationDefinitionPlusRelatedResources struct {
+	IncludedStructureDefinitionResourcesReferencedByProfile     *[]StructureDefinition   `bson:"_includedStructureDefinitionResourcesReferencedByProfile,omitempty"`
+	IncludedOperationDefinitionResourcesReferencedByBase        *[]OperationDefinition   `bson:"_includedOperationDefinitionResourcesReferencedByBase,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedOperationDefinitionResourcesReferencingBase      *[]OperationDefinition   `bson:"_revIncludedOperationDefinitionResourcesReferencingBase,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (o *OperationDefinitionPlusIncludes) GetIncludedProfileResource() (structureDefinition *StructureDefinition, err error) {
-	if o.IncludedProfileResources == nil {
+func (o *OperationDefinitionPlusRelatedResources) GetIncludedStructureDefinitionResourceReferencedByProfile() (structureDefinition *StructureDefinition, err error) {
+	if o.IncludedStructureDefinitionResourcesReferencedByProfile == nil {
 		err = errors.New("Included structuredefinitions not requested")
-	} else if len(*o.IncludedProfileResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*o.IncludedProfileResources))
-	} else if len(*o.IncludedProfileResources) == 1 {
-		structureDefinition = &(*o.IncludedProfileResources)[0]
+	} else if len(*o.IncludedStructureDefinitionResourcesReferencedByProfile) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 structureDefinition, but found %d", len(*o.IncludedStructureDefinitionResourcesReferencedByProfile))
+	} else if len(*o.IncludedStructureDefinitionResourcesReferencedByProfile) == 1 {
+		structureDefinition = &(*o.IncludedStructureDefinitionResourcesReferencedByProfile)[0]
 	}
 	return
 }
 
-func (o *OperationDefinitionPlusIncludes) GetIncludedBaseResource() (operationDefinition *OperationDefinition, err error) {
-	if o.IncludedBaseResources == nil {
+func (o *OperationDefinitionPlusRelatedResources) GetIncludedOperationDefinitionResourceReferencedByBase() (operationDefinition *OperationDefinition, err error) {
+	if o.IncludedOperationDefinitionResourcesReferencedByBase == nil {
 		err = errors.New("Included operationdefinitions not requested")
-	} else if len(*o.IncludedBaseResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 operationDefinition, but found %d", len(*o.IncludedBaseResources))
-	} else if len(*o.IncludedBaseResources) == 1 {
-		operationDefinition = &(*o.IncludedBaseResources)[0]
+	} else if len(*o.IncludedOperationDefinitionResourcesReferencedByBase) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 operationDefinition, but found %d", len(*o.IncludedOperationDefinitionResourcesReferencedByBase))
+	} else if len(*o.IncludedOperationDefinitionResourcesReferencedByBase) == 1 {
+		operationDefinition = &(*o.IncludedOperationDefinitionResourcesReferencedByBase)[0]
 	}
 	return
 }
 
-func (o *OperationDefinitionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedOperationDefinitionResourcesReferencingBase() (operationDefinitions []OperationDefinition, err error) {
+	if o.RevIncludedOperationDefinitionResourcesReferencingBase == nil {
+		err = errors.New("RevIncluded operationDefinitions not requested")
+	} else {
+		operationDefinitions = *o.RevIncludedOperationDefinitionResourcesReferencingBase
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if o.IncludedProfileResources != nil {
-		for _, r := range *o.IncludedProfileResources {
+	if o.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
+		for _, r := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedBaseResources != nil {
-		for _, r := range *o.IncludedBaseResources {
+	if o.IncludedOperationDefinitionResourcesReferencedByBase != nil {
+		for _, r := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOperationDefinitionResourcesReferencingBase != nil {
+		for _, r := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OperationDefinitionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
+		for _, r := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedOperationDefinitionResourcesReferencedByBase != nil {
+		for _, r := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOperationDefinitionResourcesReferencingBase != nil {
+		for _, r := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/operationoutcome.go
+++ b/models/operationoutcome.go
@@ -88,14 +88,344 @@ type OperationOutcomeIssueComponent struct {
 }
 
 type OperationOutcomePlus struct {
-	OperationOutcome             `bson:",inline"`
-	OperationOutcomePlusIncludes `bson:",inline"`
+	OperationOutcome                     `bson:",inline"`
+	OperationOutcomePlusRelatedResources `bson:",inline"`
 }
 
-type OperationOutcomePlusIncludes struct {
+type OperationOutcomePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (o *OperationOutcomePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OperationOutcomePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/order.go
+++ b/models/order.go
@@ -93,182 +93,622 @@ type OrderWhenComponent struct {
 }
 
 type OrderPlus struct {
-	Order             `bson:",inline"`
-	OrderPlusIncludes `bson:",inline"`
+	Order                     `bson:",inline"`
+	OrderPlusRelatedResources `bson:",inline"`
 }
 
-type OrderPlusIncludes struct {
-	IncludedSubjectGroupResources       *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources      *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources     *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectSubstanceResources   *[]Substance    `bson:"_includedSubjectSubstanceResources,omitempty"`
-	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
-	IncludedSourceOrganizationResources *[]Organization `bson:"_includedSourceOrganizationResources,omitempty"`
-	IncludedTargetPractitionerResources *[]Practitioner `bson:"_includedTargetPractitionerResources,omitempty"`
-	IncludedTargetOrganizationResources *[]Organization `bson:"_includedTargetOrganizationResources,omitempty"`
-	IncludedTargetDeviceResources       *[]Device       `bson:"_includedTargetDeviceResources,omitempty"`
+type OrderPlusRelatedResources struct {
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedSubstanceResourcesReferencedBySubject               *[]Substance             `bson:"_includedSubstanceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedBySource             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySource,omitempty"`
+	IncludedOrganizationResourcesReferencedBySource             *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySource,omitempty"`
+	IncludedPractitionerResourcesReferencedByTarget             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByTarget,omitempty"`
+	IncludedOrganizationResourcesReferencedByTarget             *[]Organization          `bson:"_includedOrganizationResourcesReferencedByTarget,omitempty"`
+	IncludedDeviceResourcesReferencedByTarget                   *[]Device                `bson:"_includedDeviceResourcesReferencedByTarget,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingRequest         *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (o *OrderPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if o.IncludedSubjectGroupResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if o.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*o.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedSubjectGroupResources))
-	} else if len(*o.IncludedSubjectGroupResources) == 1 {
-		group = &(*o.IncludedSubjectGroupResources)[0]
+	} else if len(*o.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*o.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*o.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*o.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if o.IncludedSubjectDeviceResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if o.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*o.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedSubjectDeviceResources))
-	} else if len(*o.IncludedSubjectDeviceResources) == 1 {
-		device = &(*o.IncludedSubjectDeviceResources)[0]
+	} else if len(*o.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*o.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*o.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if o.IncludedSubjectPatientResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if o.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*o.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedSubjectPatientResources))
-	} else if len(*o.IncludedSubjectPatientResources) == 1 {
-		patient = &(*o.IncludedSubjectPatientResources)[0]
+	} else if len(*o.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*o.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*o.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedSubjectSubstanceResource() (substance *Substance, err error) {
-	if o.IncludedSubjectSubstanceResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedSubstanceResourceReferencedBySubject() (substance *Substance, err error) {
+	if o.IncludedSubstanceResourcesReferencedBySubject == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*o.IncludedSubjectSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*o.IncludedSubjectSubstanceResources))
-	} else if len(*o.IncludedSubjectSubstanceResources) == 1 {
-		substance = &(*o.IncludedSubjectSubstanceResources)[0]
+	} else if len(*o.IncludedSubstanceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*o.IncludedSubstanceResourcesReferencedBySubject))
+	} else if len(*o.IncludedSubstanceResourcesReferencedBySubject) == 1 {
+		substance = &(*o.IncludedSubstanceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if o.IncludedPatientResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if o.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*o.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResources))
-	} else if len(*o.IncludedPatientResources) == 1 {
-		patient = &(*o.IncludedPatientResources)[0]
+	} else if len(*o.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*o.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*o.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*o.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
-	if o.IncludedSourcePractitionerResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySource() (practitioner *Practitioner, err error) {
+	if o.IncludedPractitionerResourcesReferencedBySource == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*o.IncludedSourcePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedSourcePractitionerResources))
-	} else if len(*o.IncludedSourcePractitionerResources) == 1 {
-		practitioner = &(*o.IncludedSourcePractitionerResources)[0]
+	} else if len(*o.IncludedPractitionerResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedPractitionerResourcesReferencedBySource))
+	} else if len(*o.IncludedPractitionerResourcesReferencedBySource) == 1 {
+		practitioner = &(*o.IncludedPractitionerResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedSourceOrganizationResource() (organization *Organization, err error) {
-	if o.IncludedSourceOrganizationResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySource() (organization *Organization, err error) {
+	if o.IncludedOrganizationResourcesReferencedBySource == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*o.IncludedSourceOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedSourceOrganizationResources))
-	} else if len(*o.IncludedSourceOrganizationResources) == 1 {
-		organization = &(*o.IncludedSourceOrganizationResources)[0]
+	} else if len(*o.IncludedOrganizationResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedOrganizationResourcesReferencedBySource))
+	} else if len(*o.IncludedOrganizationResourcesReferencedBySource) == 1 {
+		organization = &(*o.IncludedOrganizationResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedTargetPractitionerResource() (practitioner *Practitioner, err error) {
-	if o.IncludedTargetPractitionerResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedPractitionerResourceReferencedByTarget() (practitioner *Practitioner, err error) {
+	if o.IncludedPractitionerResourcesReferencedByTarget == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*o.IncludedTargetPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedTargetPractitionerResources))
-	} else if len(*o.IncludedTargetPractitionerResources) == 1 {
-		practitioner = &(*o.IncludedTargetPractitionerResources)[0]
+	} else if len(*o.IncludedPractitionerResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedPractitionerResourcesReferencedByTarget))
+	} else if len(*o.IncludedPractitionerResourcesReferencedByTarget) == 1 {
+		practitioner = &(*o.IncludedPractitionerResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedTargetOrganizationResource() (organization *Organization, err error) {
-	if o.IncludedTargetOrganizationResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedOrganizationResourceReferencedByTarget() (organization *Organization, err error) {
+	if o.IncludedOrganizationResourcesReferencedByTarget == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*o.IncludedTargetOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedTargetOrganizationResources))
-	} else if len(*o.IncludedTargetOrganizationResources) == 1 {
-		organization = &(*o.IncludedTargetOrganizationResources)[0]
+	} else if len(*o.IncludedOrganizationResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedOrganizationResourcesReferencedByTarget))
+	} else if len(*o.IncludedOrganizationResourcesReferencedByTarget) == 1 {
+		organization = &(*o.IncludedOrganizationResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedTargetDeviceResource() (device *Device, err error) {
-	if o.IncludedTargetDeviceResources == nil {
+func (o *OrderPlusRelatedResources) GetIncludedDeviceResourceReferencedByTarget() (device *Device, err error) {
+	if o.IncludedDeviceResourcesReferencedByTarget == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*o.IncludedTargetDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedTargetDeviceResources))
-	} else if len(*o.IncludedTargetDeviceResources) == 1 {
-		device = &(*o.IncludedTargetDeviceResources)[0]
+	} else if len(*o.IncludedDeviceResourcesReferencedByTarget) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceResourcesReferencedByTarget))
+	} else if len(*o.IncludedDeviceResourcesReferencedByTarget) == 1 {
+		device = &(*o.IncludedDeviceResourcesReferencedByTarget)[0]
 	}
 	return
 }
 
-func (o *OrderPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *OrderPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if o.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *o.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingRequest() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *OrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if o.IncludedSubjectGroupResources != nil {
-		for _, r := range *o.IncludedSubjectGroupResources {
+	if o.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectDeviceResources != nil {
-		for _, r := range *o.IncludedSubjectDeviceResources {
+	if o.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectPatientResources != nil {
-		for _, r := range *o.IncludedSubjectPatientResources {
+	if o.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSubjectSubstanceResources != nil {
-		for _, r := range *o.IncludedSubjectSubstanceResources {
+	if o.IncludedSubstanceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedSubstanceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedPatientResources != nil {
-		for _, r := range *o.IncludedPatientResources {
+	if o.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSourcePractitionerResources != nil {
-		for _, r := range *o.IncludedSourcePractitionerResources {
+	if o.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedSourceOrganizationResources != nil {
-		for _, r := range *o.IncludedSourceOrganizationResources {
+	if o.IncludedOrganizationResourcesReferencedBySource != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedTargetPractitionerResources != nil {
-		for _, r := range *o.IncludedTargetPractitionerResources {
+	if o.IncludedPractitionerResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByTarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedTargetOrganizationResources != nil {
-		for _, r := range *o.IncludedTargetOrganizationResources {
+	if o.IncludedOrganizationResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByTarget {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedTargetDeviceResources != nil {
-		for _, r := range *o.IncludedTargetDeviceResources {
+	if o.IncludedDeviceResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedSubstanceResourcesReferencedBySubject != nil {
+		for _, r := range *o.IncludedSubstanceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedOrganizationResourcesReferencedBySource != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPractitionerResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedOrganizationResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceResourcesReferencedByTarget != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/orderresponse.go
+++ b/models/orderresponse.go
@@ -86,80 +86,430 @@ func (x *OrderResponse) checkResourceType() error {
 }
 
 type OrderResponsePlus struct {
-	OrderResponse             `bson:",inline"`
-	OrderResponsePlusIncludes `bson:",inline"`
+	OrderResponse                     `bson:",inline"`
+	OrderResponsePlusRelatedResources `bson:",inline"`
 }
 
-type OrderResponsePlusIncludes struct {
-	IncludedRequestResources         *[]Order        `bson:"_includedRequestResources,omitempty"`
-	IncludedWhoPractitionerResources *[]Practitioner `bson:"_includedWhoPractitionerResources,omitempty"`
-	IncludedWhoOrganizationResources *[]Organization `bson:"_includedWhoOrganizationResources,omitempty"`
-	IncludedWhoDeviceResources       *[]Device       `bson:"_includedWhoDeviceResources,omitempty"`
+type OrderResponsePlusRelatedResources struct {
+	IncludedOrderResourcesReferencedByRequest                   *[]Order                 `bson:"_includedOrderResourcesReferencedByRequest,omitempty"`
+	IncludedPractitionerResourcesReferencedByWho                *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByWho,omitempty"`
+	IncludedOrganizationResourcesReferencedByWho                *[]Organization          `bson:"_includedOrganizationResourcesReferencedByWho,omitempty"`
+	IncludedDeviceResourcesReferencedByWho                      *[]Device                `bson:"_includedDeviceResourcesReferencedByWho,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (o *OrderResponsePlusIncludes) GetIncludedRequestResource() (order *Order, err error) {
-	if o.IncludedRequestResources == nil {
+func (o *OrderResponsePlusRelatedResources) GetIncludedOrderResourceReferencedByRequest() (order *Order, err error) {
+	if o.IncludedOrderResourcesReferencedByRequest == nil {
 		err = errors.New("Included orders not requested")
-	} else if len(*o.IncludedRequestResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*o.IncludedRequestResources))
-	} else if len(*o.IncludedRequestResources) == 1 {
-		order = &(*o.IncludedRequestResources)[0]
+	} else if len(*o.IncludedOrderResourcesReferencedByRequest) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 order, but found %d", len(*o.IncludedOrderResourcesReferencedByRequest))
+	} else if len(*o.IncludedOrderResourcesReferencedByRequest) == 1 {
+		order = &(*o.IncludedOrderResourcesReferencedByRequest)[0]
 	}
 	return
 }
 
-func (o *OrderResponsePlusIncludes) GetIncludedWhoPractitionerResource() (practitioner *Practitioner, err error) {
-	if o.IncludedWhoPractitionerResources == nil {
+func (o *OrderResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedByWho() (practitioner *Practitioner, err error) {
+	if o.IncludedPractitionerResourcesReferencedByWho == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*o.IncludedWhoPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedWhoPractitionerResources))
-	} else if len(*o.IncludedWhoPractitionerResources) == 1 {
-		practitioner = &(*o.IncludedWhoPractitionerResources)[0]
+	} else if len(*o.IncludedPractitionerResourcesReferencedByWho) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*o.IncludedPractitionerResourcesReferencedByWho))
+	} else if len(*o.IncludedPractitionerResourcesReferencedByWho) == 1 {
+		practitioner = &(*o.IncludedPractitionerResourcesReferencedByWho)[0]
 	}
 	return
 }
 
-func (o *OrderResponsePlusIncludes) GetIncludedWhoOrganizationResource() (organization *Organization, err error) {
-	if o.IncludedWhoOrganizationResources == nil {
+func (o *OrderResponsePlusRelatedResources) GetIncludedOrganizationResourceReferencedByWho() (organization *Organization, err error) {
+	if o.IncludedOrganizationResourcesReferencedByWho == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*o.IncludedWhoOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedWhoOrganizationResources))
-	} else if len(*o.IncludedWhoOrganizationResources) == 1 {
-		organization = &(*o.IncludedWhoOrganizationResources)[0]
+	} else if len(*o.IncludedOrganizationResourcesReferencedByWho) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedOrganizationResourcesReferencedByWho))
+	} else if len(*o.IncludedOrganizationResourcesReferencedByWho) == 1 {
+		organization = &(*o.IncludedOrganizationResourcesReferencedByWho)[0]
 	}
 	return
 }
 
-func (o *OrderResponsePlusIncludes) GetIncludedWhoDeviceResource() (device *Device, err error) {
-	if o.IncludedWhoDeviceResources == nil {
+func (o *OrderResponsePlusRelatedResources) GetIncludedDeviceResourceReferencedByWho() (device *Device, err error) {
+	if o.IncludedDeviceResourcesReferencedByWho == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*o.IncludedWhoDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedWhoDeviceResources))
-	} else if len(*o.IncludedWhoDeviceResources) == 1 {
-		device = &(*o.IncludedWhoDeviceResources)[0]
+	} else if len(*o.IncludedDeviceResourcesReferencedByWho) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*o.IncludedDeviceResourcesReferencedByWho))
+	} else if len(*o.IncludedDeviceResourcesReferencedByWho) == 1 {
+		device = &(*o.IncludedDeviceResourcesReferencedByWho)[0]
 	}
 	return
 }
 
-func (o *OrderResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *OrderResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if o.IncludedRequestResources != nil {
-		for _, r := range *o.IncludedRequestResources {
+	if o.IncludedOrderResourcesReferencedByRequest != nil {
+		for _, r := range *o.IncludedOrderResourcesReferencedByRequest {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedWhoPractitionerResources != nil {
-		for _, r := range *o.IncludedWhoPractitionerResources {
+	if o.IncludedPractitionerResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByWho {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedWhoOrganizationResources != nil {
-		for _, r := range *o.IncludedWhoOrganizationResources {
+	if o.IncludedOrganizationResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByWho {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if o.IncludedWhoDeviceResources != nil {
-		for _, r := range *o.IncludedWhoDeviceResources {
+	if o.IncludedDeviceResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrderResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrderResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedOrderResourcesReferencedByRequest != nil {
+		for _, r := range *o.IncludedOrderResourcesReferencedByRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedPractitionerResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedPractitionerResourcesReferencedByWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedOrganizationResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.IncludedDeviceResourcesReferencedByWho != nil {
+		for _, r := range *o.IncludedDeviceResourcesReferencedByWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/organization.go
+++ b/models/organization.go
@@ -94,29 +94,1384 @@ type OrganizationContactComponent struct {
 }
 
 type OrganizationPlus struct {
-	Organization             `bson:",inline"`
-	OrganizationPlusIncludes `bson:",inline"`
+	Organization                     `bson:",inline"`
+	OrganizationPlusRelatedResources `bson:",inline"`
 }
 
-type OrganizationPlusIncludes struct {
-	IncludedPartofResources *[]Organization `bson:"_includedPartofResources,omitempty"`
+type OrganizationPlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByPartof                   *[]Organization           `bson:"_includedOrganizationResourcesReferencedByPartof,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingRequester           *[]ReferralRequest        `bson:"_revIncludedReferralRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingRecipient           *[]ReferralRequest        `bson:"_revIncludedReferralRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedAccountResourcesReferencingOwner                       *[]Account                `bson:"_revIncludedAccountResourcesReferencingOwner,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject                     *[]Account                `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingAgent                    *[]Provenance             `bson:"_revIncludedProvenanceResourcesReferencingAgent,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                   *[]Provenance             `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref         *[]DocumentManifest       `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingAuthor             *[]DocumentManifest       `bson:"_revIncludedDocumentManifestResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref         *[]DocumentManifest       `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRecipient          *[]DocumentManifest       `bson:"_revIncludedDocumentManifestResourcesReferencingRecipient,omitempty"`
+	RevIncludedCarePlanResourcesReferencingPerformer                  *[]CarePlan               `bson:"_revIncludedCarePlanResourcesReferencingPerformer,omitempty"`
+	RevIncludedCarePlanResourcesReferencingParticipant                *[]CarePlan               `bson:"_revIncludedCarePlanResourcesReferencingParticipant,omitempty"`
+	RevIncludedGoalResourcesReferencingSubject                        *[]Goal                   `bson:"_revIncludedGoalResourcesReferencingSubject,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingOrganization          *[]EpisodeOfCare          `bson:"_revIncludedEpisodeOfCareResourcesReferencingOrganization,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingTeammember            *[]EpisodeOfCare          `bson:"_revIncludedEpisodeOfCareResourcesReferencingTeammember,omitempty"`
+	RevIncludedMedicationResourcesReferencingManufacturer             *[]Medication             `bson:"_revIncludedMedicationResourcesReferencingManufacturer,omitempty"`
+	RevIncludedProcedureResourcesReferencingPerformer                 *[]Procedure              `bson:"_revIncludedProcedureResourcesReferencingPerformer,omitempty"`
+	RevIncludedListResourcesReferencingItem                           *[]List                   `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthenticator     *[]DocumentReference      `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthenticator,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingCustodian         *[]DocumentReference      `bson:"_revIncludedDocumentReferenceResourcesReferencingCustodian,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthor            *[]DocumentReference      `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref        *[]DocumentReference      `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSource                        *[]Order                  `bson:"_revIncludedOrderResourcesReferencingSource,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                        *[]Order                  `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedOrderResourcesReferencingTarget                        *[]Order                  `bson:"_revIncludedOrderResourcesReferencingTarget,omitempty"`
+	RevIncludedImmunizationResourcesReferencingManufacturer           *[]Immunization           `bson:"_revIncludedImmunizationResourcesReferencingManufacturer,omitempty"`
+	RevIncludedDeviceResourcesReferencingOrganization                 *[]Device                 `bson:"_revIncludedDeviceResourcesReferencingOrganization,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingPerformer          *[]ProcedureRequest       `bson:"_revIncludedProcedureRequestResourcesReferencingPerformer,omitempty"`
+	RevIncludedFlagResourcesReferencingSubject                        *[]Flag                   `bson:"_revIncludedFlagResourcesReferencingSubject,omitempty"`
+	RevIncludedFlagResourcesReferencingAuthor                         *[]Flag                   `bson:"_revIncludedFlagResourcesReferencingAuthor,omitempty"`
+	RevIncludedSupplyRequestResourcesReferencingSupplier              *[]SupplyRequest          `bson:"_revIncludedSupplyRequestResourcesReferencingSupplier,omitempty"`
+	RevIncludedSupplyRequestResourcesReferencingSource                *[]SupplyRequest          `bson:"_revIncludedSupplyRequestResourcesReferencingSource,omitempty"`
+	RevIncludedPractitionerResourcesReferencingOrganization           *[]Practitioner           `bson:"_revIncludedPractitionerResourcesReferencingOrganization,omitempty"`
+	RevIncludedObservationResourcesReferencingPerformer               *[]Observation            `bson:"_revIncludedObservationResourcesReferencingPerformer,omitempty"`
+	RevIncludedPersonResourcesReferencingOrganization                 *[]Person                 `bson:"_revIncludedPersonResourcesReferencingOrganization,omitempty"`
+	RevIncludedContractResourcesReferencingActor                      *[]Contract               `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedContractResourcesReferencingSigner                     *[]Contract               `bson:"_revIncludedContractResourcesReferencingSigner,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSender         *[]CommunicationRequest   `bson:"_revIncludedCommunicationRequestResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRecipient      *[]CommunicationRequest   `bson:"_revIncludedCommunicationRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                       *[]Basic                  `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedOrganizationResourcesReferencingPartof                 *[]Organization           `bson:"_revIncludedOrganizationResourcesReferencingPartof,omitempty"`
+	RevIncludedProcessRequestResourcesReferencingOrganization         *[]ProcessRequest         `bson:"_revIncludedProcessRequestResourcesReferencingOrganization,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingPerformer          *[]DiagnosticReport       `bson:"_revIncludedDiagnosticReportResourcesReferencingPerformer,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingAuthor       *[]ImagingObjectSelection `bson:"_revIncludedImagingObjectSelectionResourcesReferencingAuthor,omitempty"`
+	RevIncludedHealthcareServiceResourcesReferencingOrganization      *[]HealthcareService      `bson:"_revIncludedHealthcareServiceResourcesReferencingOrganization,omitempty"`
+	RevIncludedAuditEventResourcesReferencingParticipant              *[]AuditEvent             `bson:"_revIncludedAuditEventResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                *[]AuditEvent             `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSender                *[]Communication          `bson:"_revIncludedCommunicationResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient             *[]Communication          `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                 *[]Composition            `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingAttester                *[]Composition            `bson:"_revIncludedCompositionResourcesReferencingAttester,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                   *[]Composition            `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated            *[]DetectedIssue          `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedPatientResourcesReferencingCareprovider                *[]Patient                `bson:"_revIncludedPatientResourcesReferencingCareprovider,omitempty"`
+	RevIncludedPatientResourcesReferencingOrganization                *[]Patient                `bson:"_revIncludedPatientResourcesReferencingOrganization,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment           *[]OrderResponse          `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingWho                   *[]OrderResponse          `bson:"_revIncludedOrderResponseResourcesReferencingWho,omitempty"`
+	RevIncludedCoverageResourcesReferencingIssuer                     *[]Coverage               `bson:"_revIncludedCoverageResourcesReferencingIssuer,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject       *[]QuestionnaireResponse  `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest             *[]ProcessResponse        `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingOrganization        *[]ProcessResponse        `bson:"_revIncludedProcessResponseResourcesReferencingOrganization,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequestorganization *[]ProcessResponse        `bson:"_revIncludedProcessResponseResourcesReferencingRequestorganization,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger          *[]ClinicalImpression     `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                  *[]MessageHeader          `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingReceiver              *[]MessageHeader          `bson:"_revIncludedMessageHeaderResourcesReferencingReceiver,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingResponsible           *[]MessageHeader          `bson:"_revIncludedMessageHeaderResourcesReferencingResponsible,omitempty"`
+	RevIncludedLocationResourcesReferencingOrganization               *[]Location               `bson:"_revIncludedLocationResourcesReferencingOrganization,omitempty"`
 }
 
-func (o *OrganizationPlusIncludes) GetIncludedPartofResource() (organization *Organization, err error) {
-	if o.IncludedPartofResources == nil {
+func (o *OrganizationPlusRelatedResources) GetIncludedOrganizationResourceReferencedByPartof() (organization *Organization, err error) {
+	if o.IncludedOrganizationResourcesReferencedByPartof == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*o.IncludedPartofResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedPartofResources))
-	} else if len(*o.IncludedPartofResources) == 1 {
-		organization = &(*o.IncludedPartofResources)[0]
+	} else if len(*o.IncludedOrganizationResourcesReferencedByPartof) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*o.IncludedOrganizationResourcesReferencedByPartof))
+	} else if len(*o.IncludedOrganizationResourcesReferencedByPartof) == 1 {
+		organization = &(*o.IncludedOrganizationResourcesReferencedByPartof)[0]
 	}
 	return
 }
 
-func (o *OrganizationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (o *OrganizationPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingRequester() (referralRequests []ReferralRequest, err error) {
+	if o.RevIncludedReferralRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *o.RevIncludedReferralRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingRecipient() (referralRequests []ReferralRequest, err error) {
+	if o.RevIncludedReferralRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *o.RevIncludedReferralRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedAccountResourcesReferencingOwner() (accounts []Account, err error) {
+	if o.RevIncludedAccountResourcesReferencingOwner == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *o.RevIncludedAccountResourcesReferencingOwner
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if o.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *o.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingAgent() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingAgent == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingAgent
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if o.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *o.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingAuthor() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingAuthor
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRecipient() (documentManifests []DocumentManifest, err error) {
+	if o.RevIncludedDocumentManifestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *o.RevIncludedDocumentManifestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingPerformer() (carePlans []CarePlan, err error) {
+	if o.RevIncludedCarePlanResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *o.RevIncludedCarePlanResourcesReferencingPerformer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingParticipant() (carePlans []CarePlan, err error) {
+	if o.RevIncludedCarePlanResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *o.RevIncludedCarePlanResourcesReferencingParticipant
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedGoalResourcesReferencingSubject() (goals []Goal, err error) {
+	if o.RevIncludedGoalResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded goals not requested")
+	} else {
+		goals = *o.RevIncludedGoalResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingOrganization() (episodeOfCares []EpisodeOfCare, err error) {
+	if o.RevIncludedEpisodeOfCareResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingTeammember() (episodeOfCares []EpisodeOfCare, err error) {
+	if o.RevIncludedEpisodeOfCareResourcesReferencingTeammember == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedMedicationResourcesReferencingManufacturer() (medications []Medication, err error) {
+	if o.RevIncludedMedicationResourcesReferencingManufacturer == nil {
+		err = errors.New("RevIncluded medications not requested")
+	} else {
+		medications = *o.RevIncludedMedicationResourcesReferencingManufacturer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingPerformer() (procedures []Procedure, err error) {
+	if o.RevIncludedProcedureResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *o.RevIncludedProcedureResourcesReferencingPerformer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if o.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *o.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthenticator() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingCustodian() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingCustodian == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingCustodian
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthor() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingAuthor
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingSource() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingSource
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingTarget() (orders []Order, err error) {
+	if o.RevIncludedOrderResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *o.RevIncludedOrderResourcesReferencingTarget
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingManufacturer() (immunizations []Immunization, err error) {
+	if o.RevIncludedImmunizationResourcesReferencingManufacturer == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *o.RevIncludedImmunizationResourcesReferencingManufacturer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDeviceResourcesReferencingOrganization() (devices []Device, err error) {
+	if o.RevIncludedDeviceResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded devices not requested")
+	} else {
+		devices = *o.RevIncludedDeviceResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingPerformer() (procedureRequests []ProcedureRequest, err error) {
+	if o.RevIncludedProcedureRequestResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *o.RevIncludedProcedureRequestResourcesReferencingPerformer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedFlagResourcesReferencingSubject() (flags []Flag, err error) {
+	if o.RevIncludedFlagResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *o.RevIncludedFlagResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedFlagResourcesReferencingAuthor() (flags []Flag, err error) {
+	if o.RevIncludedFlagResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *o.RevIncludedFlagResourcesReferencingAuthor
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedSupplyRequestResourcesReferencingSupplier() (supplyRequests []SupplyRequest, err error) {
+	if o.RevIncludedSupplyRequestResourcesReferencingSupplier == nil {
+		err = errors.New("RevIncluded supplyRequests not requested")
+	} else {
+		supplyRequests = *o.RevIncludedSupplyRequestResourcesReferencingSupplier
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedSupplyRequestResourcesReferencingSource() (supplyRequests []SupplyRequest, err error) {
+	if o.RevIncludedSupplyRequestResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded supplyRequests not requested")
+	} else {
+		supplyRequests = *o.RevIncludedSupplyRequestResourcesReferencingSource
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedPractitionerResourcesReferencingOrganization() (practitioners []Practitioner, err error) {
+	if o.RevIncludedPractitionerResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded practitioners not requested")
+	} else {
+		practitioners = *o.RevIncludedPractitionerResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedObservationResourcesReferencingPerformer() (observations []Observation, err error) {
+	if o.RevIncludedObservationResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *o.RevIncludedObservationResourcesReferencingPerformer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedPersonResourcesReferencingOrganization() (people []Person, err error) {
+	if o.RevIncludedPersonResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *o.RevIncludedPersonResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if o.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *o.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedContractResourcesReferencingSigner() (contracts []Contract, err error) {
+	if o.RevIncludedContractResourcesReferencingSigner == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *o.RevIncludedContractResourcesReferencingSigner
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSender() (communicationRequests []CommunicationRequest, err error) {
+	if o.RevIncludedCommunicationRequestResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *o.RevIncludedCommunicationRequestResourcesReferencingSender
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRecipient() (communicationRequests []CommunicationRequest, err error) {
+	if o.RevIncludedCommunicationRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *o.RevIncludedCommunicationRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if o.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *o.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrganizationResourcesReferencingPartof() (organizations []Organization, err error) {
+	if o.RevIncludedOrganizationResourcesReferencingPartof == nil {
+		err = errors.New("RevIncluded organizations not requested")
+	} else {
+		organizations = *o.RevIncludedOrganizationResourcesReferencingPartof
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcessRequestResourcesReferencingOrganization() (processRequests []ProcessRequest, err error) {
+	if o.RevIncludedProcessRequestResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded processRequests not requested")
+	} else {
+		processRequests = *o.RevIncludedProcessRequestResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingPerformer() (diagnosticReports []DiagnosticReport, err error) {
+	if o.RevIncludedDiagnosticReportResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *o.RevIncludedDiagnosticReportResourcesReferencingPerformer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingAuthor() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedHealthcareServiceResourcesReferencingOrganization() (healthcareServices []HealthcareService, err error) {
+	if o.RevIncludedHealthcareServiceResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded healthcareServices not requested")
+	} else {
+		healthcareServices = *o.RevIncludedHealthcareServiceResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingParticipant() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingParticipant
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if o.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *o.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSender() (communications []Communication, err error) {
+	if o.RevIncludedCommunicationResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *o.RevIncludedCommunicationResourcesReferencingSender
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if o.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *o.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAttester() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingAttester == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingAttester
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if o.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *o.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *o.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedPatientResourcesReferencingCareprovider() (patients []Patient, err error) {
+	if o.RevIncludedPatientResourcesReferencingCareprovider == nil {
+		err = errors.New("RevIncluded patients not requested")
+	} else {
+		patients = *o.RevIncludedPatientResourcesReferencingCareprovider
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedPatientResourcesReferencingOrganization() (patients []Patient, err error) {
+	if o.RevIncludedPatientResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded patients not requested")
+	} else {
+		patients = *o.RevIncludedPatientResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingWho() (orderResponses []OrderResponse, err error) {
+	if o.RevIncludedOrderResponseResourcesReferencingWho == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *o.RevIncludedOrderResponseResourcesReferencingWho
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedCoverageResourcesReferencingIssuer() (coverages []Coverage, err error) {
+	if o.RevIncludedCoverageResourcesReferencingIssuer == nil {
+		err = errors.New("RevIncluded coverages not requested")
+	} else {
+		coverages = *o.RevIncludedCoverageResourcesReferencingIssuer
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingOrganization() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequestorganization() (processResponses []ProcessResponse, err error) {
+	if o.RevIncludedProcessResponseResourcesReferencingRequestorganization == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *o.RevIncludedProcessResponseResourcesReferencingRequestorganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *o.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingReceiver() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingReceiver == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingReceiver
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingResponsible() (messageHeaders []MessageHeader, err error) {
+	if o.RevIncludedMessageHeaderResourcesReferencingResponsible == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *o.RevIncludedMessageHeaderResourcesReferencingResponsible
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedLocationResourcesReferencingOrganization() (locations []Location, err error) {
+	if o.RevIncludedLocationResourcesReferencingOrganization == nil {
+		err = errors.New("RevIncluded locations not requested")
+	} else {
+		locations = *o.RevIncludedLocationResourcesReferencingOrganization
+	}
+	return
+}
+
+func (o *OrganizationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if o.IncludedPartofResources != nil {
-		for _, r := range *o.IncludedPartofResources {
+	if o.IncludedOrganizationResourcesReferencedByPartof != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrganizationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAccountResourcesReferencingOwner != nil {
+		for _, r := range *o.RevIncludedAccountResourcesReferencingOwner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedEpisodeOfCareResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
+		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMedicationResourcesReferencingManufacturer != nil {
+		for _, r := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingCustodian != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingSource != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationResourcesReferencingManufacturer != nil {
+		for _, r := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDeviceResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedDeviceResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedSupplyRequestResourcesReferencingSupplier != nil {
+		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPractitionerResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPersonResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPersonResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *o.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *o.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrganizationResourcesReferencingPartof != nil {
+		for _, r := range *o.RevIncludedOrganizationResourcesReferencingPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessRequestResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedHealthcareServiceResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *o.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPatientResourcesReferencingCareprovider != nil {
+		for _, r := range *o.RevIncludedPatientResourcesReferencingCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPatientResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPatientResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCoverageResourcesReferencingIssuer != nil {
+		for _, r := range *o.RevIncludedCoverageResourcesReferencingIssuer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequestorganization != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedLocationResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedLocationResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (o *OrganizationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if o.IncludedOrganizationResourcesReferencedByPartof != nil {
+		for _, r := range *o.IncludedOrganizationResourcesReferencedByPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAccountResourcesReferencingOwner != nil {
+		for _, r := range *o.RevIncludedAccountResourcesReferencingOwner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedEpisodeOfCareResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
+		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMedicationResourcesReferencingManufacturer != nil {
+		for _, r := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *o.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingCustodian != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingSource != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *o.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImmunizationResourcesReferencingManufacturer != nil {
+		for _, r := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDeviceResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedDeviceResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedSupplyRequestResourcesReferencingSupplier != nil {
+		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPractitionerResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPersonResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPersonResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *o.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *o.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrganizationResourcesReferencingPartof != nil {
+		for _, r := range *o.RevIncludedOrganizationResourcesReferencingPartof {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessRequestResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
+		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedHealthcareServiceResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *o.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPatientResourcesReferencingCareprovider != nil {
+		for _, r := range *o.RevIncludedPatientResourcesReferencingCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedPatientResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedPatientResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedCoverageResourcesReferencingIssuer != nil {
+		for _, r := range *o.RevIncludedCoverageResourcesReferencingIssuer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedProcessResponseResourcesReferencingRequestorganization != nil {
+		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
+		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if o.RevIncludedLocationResourcesReferencingOrganization != nil {
+		for _, r := range *o.RevIncludedLocationResourcesReferencingOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/patient.go
+++ b/models/patient.go
@@ -124,76 +124,2766 @@ type PatientLinkComponent struct {
 }
 
 type PatientPlus struct {
-	Patient             `bson:",inline"`
-	PatientPlusIncludes `bson:",inline"`
+	Patient                     `bson:",inline"`
+	PatientPlusRelatedResources `bson:",inline"`
 }
 
-type PatientPlusIncludes struct {
-	IncludedLinkResources                     *[]Patient      `bson:"_includedLinkResources,omitempty"`
-	IncludedCareproviderPractitionerResources *[]Practitioner `bson:"_includedCareproviderPractitionerResources,omitempty"`
-	IncludedCareproviderOrganizationResources *[]Organization `bson:"_includedCareproviderOrganizationResources,omitempty"`
-	IncludedOrganizationResources             *[]Organization `bson:"_includedOrganizationResources,omitempty"`
+type PatientPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByLink                            *[]Patient                    `bson:"_includedPatientResourcesReferencedByLink,omitempty"`
+	IncludedPractitionerResourcesReferencedByCareprovider               *[]Practitioner               `bson:"_includedPractitionerResourcesReferencedByCareprovider,omitempty"`
+	IncludedOrganizationResourcesReferencedByCareprovider               *[]Organization               `bson:"_includedOrganizationResourcesReferencedByCareprovider,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization               *[]Organization               `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor                     *[]Appointment                `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResourcesReferencingPatient                   *[]Appointment                `bson:"_revIncludedAppointmentResourcesReferencingPatient,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingRequester             *[]ReferralRequest            `bson:"_revIncludedReferralRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingPatient               *[]ReferralRequest            `bson:"_revIncludedReferralRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject                       *[]Account                    `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedAccountResourcesReferencingPatient                       *[]Account                    `bson:"_revIncludedAccountResourcesReferencingPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingAgent                      *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingAgent,omitempty"`
+	RevIncludedProvenanceResourcesReferencingPatient                    *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingPatient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                     *[]Provenance                 `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref           *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingSubject              *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingAuthor               *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref           *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingPatient              *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingPatient,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRecipient            *[]DocumentManifest           `bson:"_revIncludedDocumentManifestResourcesReferencingRecipient,omitempty"`
+	RevIncludedSpecimenResourcesReferencingSubject                      *[]Specimen                   `bson:"_revIncludedSpecimenResourcesReferencingSubject,omitempty"`
+	RevIncludedSpecimenResourcesReferencingPatient                      *[]Specimen                   `bson:"_revIncludedSpecimenResourcesReferencingPatient,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingRecorder           *[]AllergyIntolerance         `bson:"_revIncludedAllergyIntoleranceResourcesReferencingRecorder,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingReporter           *[]AllergyIntolerance         `bson:"_revIncludedAllergyIntoleranceResourcesReferencingReporter,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingPatient            *[]AllergyIntolerance         `bson:"_revIncludedAllergyIntoleranceResourcesReferencingPatient,omitempty"`
+	RevIncludedCarePlanResourcesReferencingPerformer                    *[]CarePlan                   `bson:"_revIncludedCarePlanResourcesReferencingPerformer,omitempty"`
+	RevIncludedCarePlanResourcesReferencingSubject                      *[]CarePlan                   `bson:"_revIncludedCarePlanResourcesReferencingSubject,omitempty"`
+	RevIncludedCarePlanResourcesReferencingParticipant                  *[]CarePlan                   `bson:"_revIncludedCarePlanResourcesReferencingParticipant,omitempty"`
+	RevIncludedCarePlanResourcesReferencingPatient                      *[]CarePlan                   `bson:"_revIncludedCarePlanResourcesReferencingPatient,omitempty"`
+	RevIncludedGoalResourcesReferencingPatient                          *[]Goal                       `bson:"_revIncludedGoalResourcesReferencingPatient,omitempty"`
+	RevIncludedGoalResourcesReferencingSubject                          *[]Goal                       `bson:"_revIncludedGoalResourcesReferencingSubject,omitempty"`
+	RevIncludedEnrollmentRequestResourcesReferencingSubject             *[]EnrollmentRequest          `bson:"_revIncludedEnrollmentRequestResourcesReferencingSubject,omitempty"`
+	RevIncludedEnrollmentRequestResourcesReferencingPatient             *[]EnrollmentRequest          `bson:"_revIncludedEnrollmentRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingPatient                 *[]EpisodeOfCare              `bson:"_revIncludedEpisodeOfCareResourcesReferencingPatient,omitempty"`
+	RevIncludedProcedureResourcesReferencingPerformer                   *[]Procedure                  `bson:"_revIncludedProcedureResourcesReferencingPerformer,omitempty"`
+	RevIncludedProcedureResourcesReferencingSubject                     *[]Procedure                  `bson:"_revIncludedProcedureResourcesReferencingSubject,omitempty"`
+	RevIncludedProcedureResourcesReferencingPatient                     *[]Procedure                  `bson:"_revIncludedProcedureResourcesReferencingPatient,omitempty"`
+	RevIncludedListResourcesReferencingItem                             *[]List                       `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingSubject                          *[]List                       `bson:"_revIncludedListResourcesReferencingSubject,omitempty"`
+	RevIncludedListResourcesReferencingPatient                          *[]List                       `bson:"_revIncludedListResourcesReferencingPatient,omitempty"`
+	RevIncludedListResourcesReferencingSource                           *[]List                       `bson:"_revIncludedListResourcesReferencingSource,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingSubject             *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingPatient             *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingPatient,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthor              *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref          *[]DocumentReference          `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSubject                         *[]Order                      `bson:"_revIncludedOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResourcesReferencingPatient                         *[]Order                      `bson:"_revIncludedOrderResourcesReferencingPatient,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                          *[]Order                      `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedImmunizationResourcesReferencingPatient                  *[]Immunization               `bson:"_revIncludedImmunizationResourcesReferencingPatient,omitempty"`
+	RevIncludedDeviceResourcesReferencingPatient                        *[]Device                     `bson:"_revIncludedDeviceResourcesReferencingPatient,omitempty"`
+	RevIncludedVisionPrescriptionResourcesReferencingPatient            *[]VisionPrescription         `bson:"_revIncludedVisionPrescriptionResourcesReferencingPatient,omitempty"`
+	RevIncludedMediaResourcesReferencingSubject                         *[]Media                      `bson:"_revIncludedMediaResourcesReferencingSubject,omitempty"`
+	RevIncludedMediaResourcesReferencingPatient                         *[]Media                      `bson:"_revIncludedMediaResourcesReferencingPatient,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingPerformer            *[]ProcedureRequest           `bson:"_revIncludedProcedureRequestResourcesReferencingPerformer,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingSubject              *[]ProcedureRequest           `bson:"_revIncludedProcedureRequestResourcesReferencingSubject,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingPatient              *[]ProcedureRequest           `bson:"_revIncludedProcedureRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingOrderer              *[]ProcedureRequest           `bson:"_revIncludedProcedureRequestResourcesReferencingOrderer,omitempty"`
+	RevIncludedDeviceUseRequestResourcesReferencingSubject              *[]DeviceUseRequest           `bson:"_revIncludedDeviceUseRequestResourcesReferencingSubject,omitempty"`
+	RevIncludedDeviceUseRequestResourcesReferencingPatient              *[]DeviceUseRequest           `bson:"_revIncludedDeviceUseRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedFlagResourcesReferencingSubject                          *[]Flag                       `bson:"_revIncludedFlagResourcesReferencingSubject,omitempty"`
+	RevIncludedFlagResourcesReferencingPatient                          *[]Flag                       `bson:"_revIncludedFlagResourcesReferencingPatient,omitempty"`
+	RevIncludedFlagResourcesReferencingAuthor                           *[]Flag                       `bson:"_revIncludedFlagResourcesReferencingAuthor,omitempty"`
+	RevIncludedRelatedPersonResourcesReferencingPatient                 *[]RelatedPerson              `bson:"_revIncludedRelatedPersonResourcesReferencingPatient,omitempty"`
+	RevIncludedSupplyRequestResourcesReferencingPatient                 *[]SupplyRequest              `bson:"_revIncludedSupplyRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedSupplyRequestResourcesReferencingSource                  *[]SupplyRequest              `bson:"_revIncludedSupplyRequestResourcesReferencingSource,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor             *[]AppointmentResponse        `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingPatient           *[]AppointmentResponse        `bson:"_revIncludedAppointmentResponseResourcesReferencingPatient,omitempty"`
+	RevIncludedObservationResourcesReferencingSubject                   *[]Observation                `bson:"_revIncludedObservationResourcesReferencingSubject,omitempty"`
+	RevIncludedObservationResourcesReferencingPatient                   *[]Observation                `bson:"_revIncludedObservationResourcesReferencingPatient,omitempty"`
+	RevIncludedObservationResourcesReferencingPerformer                 *[]Observation                `bson:"_revIncludedObservationResourcesReferencingPerformer,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingPractitioner *[]MedicationAdministration   `bson:"_revIncludedMedicationAdministrationResourcesReferencingPractitioner,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingPatient      *[]MedicationAdministration   `bson:"_revIncludedMedicationAdministrationResourcesReferencingPatient,omitempty"`
+	RevIncludedMedicationStatementResourcesReferencingPatient           *[]MedicationStatement        `bson:"_revIncludedMedicationStatementResourcesReferencingPatient,omitempty"`
+	RevIncludedMedicationStatementResourcesReferencingSource            *[]MedicationStatement        `bson:"_revIncludedMedicationStatementResourcesReferencingSource,omitempty"`
+	RevIncludedPersonResourcesReferencingLink                           *[]Person                     `bson:"_revIncludedPersonResourcesReferencingLink,omitempty"`
+	RevIncludedPersonResourcesReferencingPatient                        *[]Person                     `bson:"_revIncludedPersonResourcesReferencingPatient,omitempty"`
+	RevIncludedContractResourcesReferencingActor                        *[]Contract                   `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedContractResourcesReferencingSubject                      *[]Contract                   `bson:"_revIncludedContractResourcesReferencingSubject,omitempty"`
+	RevIncludedContractResourcesReferencingPatient                      *[]Contract                   `bson:"_revIncludedContractResourcesReferencingPatient,omitempty"`
+	RevIncludedContractResourcesReferencingSigner                       *[]Contract                   `bson:"_revIncludedContractResourcesReferencingSigner,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRequester        *[]CommunicationRequest       `bson:"_revIncludedCommunicationRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSubject          *[]CommunicationRequest       `bson:"_revIncludedCommunicationRequestResourcesReferencingSubject,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSender           *[]CommunicationRequest       `bson:"_revIncludedCommunicationRequestResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingPatient          *[]CommunicationRequest       `bson:"_revIncludedCommunicationRequestResourcesReferencingPatient,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRecipient        *[]CommunicationRequest       `bson:"_revIncludedCommunicationRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingSubject                *[]RiskAssessment             `bson:"_revIncludedRiskAssessmentResourcesReferencingSubject,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingPatient                *[]RiskAssessment             `bson:"_revIncludedRiskAssessmentResourcesReferencingPatient,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                         *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedBasicResourcesReferencingPatient                         *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingPatient,omitempty"`
+	RevIncludedBasicResourcesReferencingAuthor                          *[]Basic                      `bson:"_revIncludedBasicResourcesReferencingAuthor,omitempty"`
+	RevIncludedGroupResourcesReferencingMember                          *[]Group                      `bson:"_revIncludedGroupResourcesReferencingMember,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingReceiver           *[]MedicationDispense         `bson:"_revIncludedMedicationDispenseResourcesReferencingReceiver,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingPatient            *[]MedicationDispense         `bson:"_revIncludedMedicationDispenseResourcesReferencingPatient,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingSubject              *[]DiagnosticReport           `bson:"_revIncludedDiagnosticReportResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingPatient              *[]DiagnosticReport           `bson:"_revIncludedDiagnosticReportResourcesReferencingPatient,omitempty"`
+	RevIncludedImagingStudyResourcesReferencingPatient                  *[]ImagingStudy               `bson:"_revIncludedImagingStudyResourcesReferencingPatient,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingAuthor         *[]ImagingObjectSelection     `bson:"_revIncludedImagingObjectSelectionResourcesReferencingAuthor,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingPatient        *[]ImagingObjectSelection     `bson:"_revIncludedImagingObjectSelectionResourcesReferencingPatient,omitempty"`
+	RevIncludedFamilyMemberHistoryResourcesReferencingPatient           *[]FamilyMemberHistory        `bson:"_revIncludedFamilyMemberHistoryResourcesReferencingPatient,omitempty"`
+	RevIncludedNutritionOrderResourcesReferencingPatient                *[]NutritionOrder             `bson:"_revIncludedNutritionOrderResourcesReferencingPatient,omitempty"`
+	RevIncludedEncounterResourcesReferencingPatient                     *[]Encounter                  `bson:"_revIncludedEncounterResourcesReferencingPatient,omitempty"`
+	RevIncludedAuditEventResourcesReferencingParticipant                *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                  *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedAuditEventResourcesReferencingPatientPath1               *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingPatientPath1,omitempty"`
+	RevIncludedAuditEventResourcesReferencingPatientPath2               *[]AuditEvent                 `bson:"_revIncludedAuditEventResourcesReferencingPatientPath2,omitempty"`
+	RevIncludedMedicationOrderResourcesReferencingPatient               *[]MedicationOrder            `bson:"_revIncludedMedicationOrderResourcesReferencingPatient,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSender                  *[]Communication              `bson:"_revIncludedCommunicationResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSubject                 *[]Communication              `bson:"_revIncludedCommunicationResourcesReferencingSubject,omitempty"`
+	RevIncludedCommunicationResourcesReferencingPatient                 *[]Communication              `bson:"_revIncludedCommunicationResourcesReferencingPatient,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient               *[]Communication              `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedConditionResourcesReferencingAsserter                    *[]Condition                  `bson:"_revIncludedConditionResourcesReferencingAsserter,omitempty"`
+	RevIncludedConditionResourcesReferencingPatient                     *[]Condition                  `bson:"_revIncludedConditionResourcesReferencingPatient,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                   *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingAuthor                    *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingAuthor,omitempty"`
+	RevIncludedCompositionResourcesReferencingAttester                  *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingAttester,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                     *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedCompositionResourcesReferencingPatient                   *[]Composition                `bson:"_revIncludedCompositionResourcesReferencingPatient,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingPatient                 *[]DetectedIssue              `bson:"_revIncludedDetectedIssueResourcesReferencingPatient,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated              *[]DetectedIssue              `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSubject               *[]DiagnosticOrder            `bson:"_revIncludedDiagnosticOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingPatient               *[]DiagnosticOrder            `bson:"_revIncludedDiagnosticOrderResourcesReferencingPatient,omitempty"`
+	RevIncludedPatientResourcesReferencingLink                          *[]Patient                    `bson:"_revIncludedPatientResourcesReferencingLink,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment             *[]OrderResponse              `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject         *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingAuthor          *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingAuthor,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingPatient         *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingPatient,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSource          *[]QuestionnaireResponse      `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSource,omitempty"`
+	RevIncludedDeviceUseStatementResourcesReferencingSubject            *[]DeviceUseStatement         `bson:"_revIncludedDeviceUseStatementResourcesReferencingSubject,omitempty"`
+	RevIncludedDeviceUseStatementResourcesReferencingPatient            *[]DeviceUseStatement         `bson:"_revIncludedDeviceUseStatementResourcesReferencingPatient,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest               *[]ProcessResponse            `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                        *[]Schedule                   `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedSupplyDeliveryResourcesReferencingPatient                *[]SupplyDelivery             `bson:"_revIncludedSupplyDeliveryResourcesReferencingPatient,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger            *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPatient            *[]ClinicalImpression         `bson:"_revIncludedClinicalImpressionResourcesReferencingPatient,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                    *[]MessageHeader              `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedClaimResourcesReferencingPatient                         *[]Claim                      `bson:"_revIncludedClaimResourcesReferencingPatient,omitempty"`
+	RevIncludedImmunizationRecommendationResourcesReferencingPatient    *[]ImmunizationRecommendation `bson:"_revIncludedImmunizationRecommendationResourcesReferencingPatient,omitempty"`
+	RevIncludedBodySiteResourcesReferencingPatient                      *[]BodySite                   `bson:"_revIncludedBodySiteResourcesReferencingPatient,omitempty"`
 }
 
-func (p *PatientPlusIncludes) GetIncludedLinkResource() (patient *Patient, err error) {
-	if p.IncludedLinkResources == nil {
+func (p *PatientPlusRelatedResources) GetIncludedPatientResourceReferencedByLink() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByLink == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedLinkResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedLinkResources))
-	} else if len(*p.IncludedLinkResources) == 1 {
-		patient = &(*p.IncludedLinkResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByLink) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByLink))
+	} else if len(*p.IncludedPatientResourcesReferencedByLink) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByLink)[0]
 	}
 	return
 }
 
-func (p *PatientPlusIncludes) GetIncludedCareproviderPractitionerResources() (practitioners []Practitioner, err error) {
-	if p.IncludedCareproviderPractitionerResources == nil {
+func (p *PatientPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByCareprovider() (practitioners []Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByCareprovider == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *p.IncludedCareproviderPractitionerResources
+		practitioners = *p.IncludedPractitionerResourcesReferencedByCareprovider
 	}
 	return
 }
 
-func (p *PatientPlusIncludes) GetIncludedCareproviderOrganizationResources() (organizations []Organization, err error) {
-	if p.IncludedCareproviderOrganizationResources == nil {
+func (p *PatientPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByCareprovider() (organizations []Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByCareprovider == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *p.IncludedCareproviderOrganizationResources
+		organizations = *p.IncludedOrganizationResourcesReferencedByCareprovider
 	}
 	return
 }
 
-func (p *PatientPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedOrganizationResources == nil {
+func (p *PatientPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
-	} else if len(*p.IncludedOrganizationResources) == 1 {
-		organization = &(*p.IncludedOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (p *PatientPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *PatientPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if p.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *p.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingPatient() (appointments []Appointment, err error) {
+	if p.RevIncludedAppointmentResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *p.RevIncludedAppointmentResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingRequester() (referralRequests []ReferralRequest, err error) {
+	if p.RevIncludedReferralRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *p.RevIncludedReferralRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingPatient() (referralRequests []ReferralRequest, err error) {
+	if p.RevIncludedReferralRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *p.RevIncludedReferralRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if p.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *p.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAccountResourcesReferencingPatient() (accounts []Account, err error) {
+	if p.RevIncludedAccountResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *p.RevIncludedAccountResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingAgent() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingAgent == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingAgent
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingPatient() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingSubject() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingAuthor() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingPatient() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRecipient() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingSubject() (specimen []Specimen, err error) {
+	if p.RevIncludedSpecimenResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *p.RevIncludedSpecimenResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingPatient() (specimen []Specimen, err error) {
+	if p.RevIncludedSpecimenResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *p.RevIncludedSpecimenResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingRecorder() (allergyIntolerances []AllergyIntolerance, err error) {
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingReporter() (allergyIntolerances []AllergyIntolerance, err error) {
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingPatient() (allergyIntolerances []AllergyIntolerance, err error) {
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingPerformer() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingSubject() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingParticipant() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingParticipant
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingPatient() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedGoalResourcesReferencingPatient() (goals []Goal, err error) {
+	if p.RevIncludedGoalResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded goals not requested")
+	} else {
+		goals = *p.RevIncludedGoalResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedGoalResourcesReferencingSubject() (goals []Goal, err error) {
+	if p.RevIncludedGoalResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded goals not requested")
+	} else {
+		goals = *p.RevIncludedGoalResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedEnrollmentRequestResourcesReferencingSubject() (enrollmentRequests []EnrollmentRequest, err error) {
+	if p.RevIncludedEnrollmentRequestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded enrollmentRequests not requested")
+	} else {
+		enrollmentRequests = *p.RevIncludedEnrollmentRequestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedEnrollmentRequestResourcesReferencingPatient() (enrollmentRequests []EnrollmentRequest, err error) {
+	if p.RevIncludedEnrollmentRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded enrollmentRequests not requested")
+	} else {
+		enrollmentRequests = *p.RevIncludedEnrollmentRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingPatient() (episodeOfCares []EpisodeOfCare, err error) {
+	if p.RevIncludedEpisodeOfCareResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *p.RevIncludedEpisodeOfCareResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingPerformer() (procedures []Procedure, err error) {
+	if p.RevIncludedProcedureResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *p.RevIncludedProcedureResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingSubject() (procedures []Procedure, err error) {
+	if p.RevIncludedProcedureResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *p.RevIncludedProcedureResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingPatient() (procedures []Procedure, err error) {
+	if p.RevIncludedProcedureResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *p.RevIncludedProcedureResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedListResourcesReferencingSubject() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedListResourcesReferencingPatient() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedListResourcesReferencingSource() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingSubject() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingPatient() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthor() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedOrderResourcesReferencingSubject() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedOrderResourcesReferencingPatient() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingPatient() (immunizations []Immunization, err error) {
+	if p.RevIncludedImmunizationResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *p.RevIncludedImmunizationResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDeviceResourcesReferencingPatient() (devices []Device, err error) {
+	if p.RevIncludedDeviceResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded devices not requested")
+	} else {
+		devices = *p.RevIncludedDeviceResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedVisionPrescriptionResourcesReferencingPatient() (visionPrescriptions []VisionPrescription, err error) {
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded visionPrescriptions not requested")
+	} else {
+		visionPrescriptions = *p.RevIncludedVisionPrescriptionResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMediaResourcesReferencingSubject() (media []Media, err error) {
+	if p.RevIncludedMediaResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *p.RevIncludedMediaResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMediaResourcesReferencingPatient() (media []Media, err error) {
+	if p.RevIncludedMediaResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *p.RevIncludedMediaResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingPerformer() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingSubject() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingPatient() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingOrderer() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingOrderer
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDeviceUseRequestResourcesReferencingSubject() (deviceUseRequests []DeviceUseRequest, err error) {
+	if p.RevIncludedDeviceUseRequestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded deviceUseRequests not requested")
+	} else {
+		deviceUseRequests = *p.RevIncludedDeviceUseRequestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDeviceUseRequestResourcesReferencingPatient() (deviceUseRequests []DeviceUseRequest, err error) {
+	if p.RevIncludedDeviceUseRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded deviceUseRequests not requested")
+	} else {
+		deviceUseRequests = *p.RevIncludedDeviceUseRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedFlagResourcesReferencingSubject() (flags []Flag, err error) {
+	if p.RevIncludedFlagResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *p.RevIncludedFlagResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedFlagResourcesReferencingPatient() (flags []Flag, err error) {
+	if p.RevIncludedFlagResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *p.RevIncludedFlagResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedFlagResourcesReferencingAuthor() (flags []Flag, err error) {
+	if p.RevIncludedFlagResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *p.RevIncludedFlagResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedRelatedPersonResourcesReferencingPatient() (relatedPeople []RelatedPerson, err error) {
+	if p.RevIncludedRelatedPersonResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded relatedPeople not requested")
+	} else {
+		relatedPeople = *p.RevIncludedRelatedPersonResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedSupplyRequestResourcesReferencingPatient() (supplyRequests []SupplyRequest, err error) {
+	if p.RevIncludedSupplyRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded supplyRequests not requested")
+	} else {
+		supplyRequests = *p.RevIncludedSupplyRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedSupplyRequestResourcesReferencingSource() (supplyRequests []SupplyRequest, err error) {
+	if p.RevIncludedSupplyRequestResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded supplyRequests not requested")
+	} else {
+		supplyRequests = *p.RevIncludedSupplyRequestResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *p.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingPatient() (appointmentResponses []AppointmentResponse, err error) {
+	if p.RevIncludedAppointmentResponseResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *p.RevIncludedAppointmentResponseResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedObservationResourcesReferencingSubject() (observations []Observation, err error) {
+	if p.RevIncludedObservationResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *p.RevIncludedObservationResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedObservationResourcesReferencingPatient() (observations []Observation, err error) {
+	if p.RevIncludedObservationResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *p.RevIncludedObservationResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedObservationResourcesReferencingPerformer() (observations []Observation, err error) {
+	if p.RevIncludedObservationResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *p.RevIncludedObservationResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingPractitioner() (medicationAdministrations []MedicationAdministration, err error) {
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingPatient() (medicationAdministrations []MedicationAdministration, err error) {
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *p.RevIncludedMedicationAdministrationResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationStatementResourcesReferencingPatient() (medicationStatements []MedicationStatement, err error) {
+	if p.RevIncludedMedicationStatementResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded medicationStatements not requested")
+	} else {
+		medicationStatements = *p.RevIncludedMedicationStatementResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationStatementResourcesReferencingSource() (medicationStatements []MedicationStatement, err error) {
+	if p.RevIncludedMedicationStatementResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded medicationStatements not requested")
+	} else {
+		medicationStatements = *p.RevIncludedMedicationStatementResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedPersonResourcesReferencingLink() (people []Person, err error) {
+	if p.RevIncludedPersonResourcesReferencingLink == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *p.RevIncludedPersonResourcesReferencingLink
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedPersonResourcesReferencingPatient() (people []Person, err error) {
+	if p.RevIncludedPersonResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *p.RevIncludedPersonResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedContractResourcesReferencingSubject() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedContractResourcesReferencingPatient() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedContractResourcesReferencingSigner() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingSigner == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingSigner
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRequester() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSubject() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSender() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingSender
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingPatient() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRecipient() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingSubject() (riskAssessments []RiskAssessment, err error) {
+	if p.RevIncludedRiskAssessmentResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *p.RevIncludedRiskAssessmentResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingPatient() (riskAssessments []RiskAssessment, err error) {
+	if p.RevIncludedRiskAssessmentResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *p.RevIncludedRiskAssessmentResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedBasicResourcesReferencingPatient() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedBasicResourcesReferencingAuthor() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedGroupResourcesReferencingMember() (groups []Group, err error) {
+	if p.RevIncludedGroupResourcesReferencingMember == nil {
+		err = errors.New("RevIncluded groups not requested")
+	} else {
+		groups = *p.RevIncludedGroupResourcesReferencingMember
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingReceiver() (medicationDispenses []MedicationDispense, err error) {
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *p.RevIncludedMedicationDispenseResourcesReferencingReceiver
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingPatient() (medicationDispenses []MedicationDispense, err error) {
+	if p.RevIncludedMedicationDispenseResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *p.RevIncludedMedicationDispenseResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingSubject() (diagnosticReports []DiagnosticReport, err error) {
+	if p.RevIncludedDiagnosticReportResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *p.RevIncludedDiagnosticReportResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingPatient() (diagnosticReports []DiagnosticReport, err error) {
+	if p.RevIncludedDiagnosticReportResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *p.RevIncludedDiagnosticReportResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedImagingStudyResourcesReferencingPatient() (imagingStudies []ImagingStudy, err error) {
+	if p.RevIncludedImagingStudyResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded imagingStudies not requested")
+	} else {
+		imagingStudies = *p.RevIncludedImagingStudyResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingAuthor() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingPatient() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedFamilyMemberHistoryResourcesReferencingPatient() (familyMemberHistories []FamilyMemberHistory, err error) {
+	if p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded familyMemberHistories not requested")
+	} else {
+		familyMemberHistories = *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedNutritionOrderResourcesReferencingPatient() (nutritionOrders []NutritionOrder, err error) {
+	if p.RevIncludedNutritionOrderResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded nutritionOrders not requested")
+	} else {
+		nutritionOrders = *p.RevIncludedNutritionOrderResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingPatient() (encounters []Encounter, err error) {
+	if p.RevIncludedEncounterResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *p.RevIncludedEncounterResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingParticipant() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingParticipant
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingPatientPath1() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath1 == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingPatientPath1
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingPatientPath2() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath2 == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingPatientPath2
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMedicationOrderResourcesReferencingPatient() (medicationOrders []MedicationOrder, err error) {
+	if p.RevIncludedMedicationOrderResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded medicationOrders not requested")
+	} else {
+		medicationOrders = *p.RevIncludedMedicationOrderResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSender() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingSender
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSubject() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingPatient() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedConditionResourcesReferencingAsserter() (conditions []Condition, err error) {
+	if p.RevIncludedConditionResourcesReferencingAsserter == nil {
+		err = errors.New("RevIncluded conditions not requested")
+	} else {
+		conditions = *p.RevIncludedConditionResourcesReferencingAsserter
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedConditionResourcesReferencingPatient() (conditions []Condition, err error) {
+	if p.RevIncludedConditionResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded conditions not requested")
+	} else {
+		conditions = *p.RevIncludedConditionResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAuthor() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAttester() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingAttester == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingAttester
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingPatient() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingPatient() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSubject() (diagnosticOrders []DiagnosticOrder, err error) {
+	if p.RevIncludedDiagnosticOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *p.RevIncludedDiagnosticOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingPatient() (diagnosticOrders []DiagnosticOrder, err error) {
+	if p.RevIncludedDiagnosticOrderResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *p.RevIncludedDiagnosticOrderResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedPatientResourcesReferencingLink() (patients []Patient, err error) {
+	if p.RevIncludedPatientResourcesReferencingLink == nil {
+		err = errors.New("RevIncluded patients not requested")
+	} else {
+		patients = *p.RevIncludedPatientResourcesReferencingLink
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingAuthor() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingPatient() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSource() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDeviceUseStatementResourcesReferencingSubject() (deviceUseStatements []DeviceUseStatement, err error) {
+	if p.RevIncludedDeviceUseStatementResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded deviceUseStatements not requested")
+	} else {
+		deviceUseStatements = *p.RevIncludedDeviceUseStatementResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedDeviceUseStatementResourcesReferencingPatient() (deviceUseStatements []DeviceUseStatement, err error) {
+	if p.RevIncludedDeviceUseStatementResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded deviceUseStatements not requested")
+	} else {
+		deviceUseStatements = *p.RevIncludedDeviceUseStatementResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if p.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *p.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedSupplyDeliveryResourcesReferencingPatient() (supplyDeliveries []SupplyDelivery, err error) {
+	if p.RevIncludedSupplyDeliveryResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded supplyDeliveries not requested")
+	} else {
+		supplyDeliveries = *p.RevIncludedSupplyDeliveryResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPatient() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedClaimResourcesReferencingPatient() (claims []Claim, err error) {
+	if p.RevIncludedClaimResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded claims not requested")
+	} else {
+		claims = *p.RevIncludedClaimResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedImmunizationRecommendationResourcesReferencingPatient() (immunizationRecommendations []ImmunizationRecommendation, err error) {
+	if p.RevIncludedImmunizationRecommendationResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded immunizationRecommendations not requested")
+	} else {
+		immunizationRecommendations = *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedBodySiteResourcesReferencingPatient() (bodySites []BodySite, err error) {
+	if p.RevIncludedBodySiteResourcesReferencingPatient == nil {
+		err = errors.New("RevIncluded bodySites not requested")
+	} else {
+		bodySites = *p.RevIncludedBodySiteResourcesReferencingPatient
+	}
+	return
+}
+
+func (p *PatientPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedLinkResources != nil {
-		for _, r := range *p.IncludedLinkResources {
+	if p.IncludedPatientResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedCareproviderPractitionerResources != nil {
-		for _, r := range *p.IncludedCareproviderPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByCareprovider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedCareproviderOrganizationResources != nil {
-		for _, r := range *p.IncludedCareproviderOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByCareprovider != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrganizationResources != nil {
-		for _, r := range *p.IncludedOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PatientPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGoalResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedGoalResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEnrollmentRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEnrollmentRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRelatedPersonResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingStudyResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedNutritionOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath1 != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath2 != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPatientResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPatientResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseStatementResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseStatementResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClaimResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedClaimResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationRecommendationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBodySiteResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedBodySiteResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PatientPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPatientResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPractitionerResourcesReferencedByCareprovider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByCareprovider != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGoalResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedGoalResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGoalResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedGoalResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEnrollmentRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEnrollmentRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRelatedPersonResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingStudyResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedNutritionOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath1 != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingPatientPath2 != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPatientResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPatientResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseStatementResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDeviceUseStatementResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClaimResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedClaimResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationRecommendationResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBodySiteResourcesReferencingPatient != nil {
+		for _, r := range *p.RevIncludedBodySiteResourcesReferencingPatient {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/paymentnotice.go
+++ b/models/paymentnotice.go
@@ -89,14 +89,344 @@ func (x *PaymentNotice) checkResourceType() error {
 }
 
 type PaymentNoticePlus struct {
-	PaymentNotice             `bson:",inline"`
-	PaymentNoticePlusIncludes `bson:",inline"`
+	PaymentNotice                     `bson:",inline"`
+	PaymentNoticePlusRelatedResources `bson:",inline"`
 }
 
-type PaymentNoticePlusIncludes struct {
+type PaymentNoticePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *PaymentNoticePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PaymentNoticePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/paymentreconciliation.go
+++ b/models/paymentreconciliation.go
@@ -109,14 +109,344 @@ type PaymentReconciliationNotesComponent struct {
 }
 
 type PaymentReconciliationPlus struct {
-	PaymentReconciliation             `bson:",inline"`
-	PaymentReconciliationPlusIncludes `bson:",inline"`
+	PaymentReconciliation                     `bson:",inline"`
+	PaymentReconciliationPlusRelatedResources `bson:",inline"`
 }
 
-type PaymentReconciliationPlusIncludes struct {
+type PaymentReconciliationPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *PaymentReconciliationPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PaymentReconciliationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/person.go
+++ b/models/person.go
@@ -94,148 +94,538 @@ type PersonLinkComponent struct {
 }
 
 type PersonPlus struct {
-	Person             `bson:",inline"`
-	PersonPlusIncludes `bson:",inline"`
+	Person                     `bson:",inline"`
+	PersonPlusRelatedResources `bson:",inline"`
 }
 
-type PersonPlusIncludes struct {
-	IncludedPractitionerResources      *[]Practitioner  `bson:"_includedPractitionerResources,omitempty"`
-	IncludedLinkPractitionerResources  *[]Practitioner  `bson:"_includedLinkPractitionerResources,omitempty"`
-	IncludedLinkPatientResources       *[]Patient       `bson:"_includedLinkPatientResources,omitempty"`
-	IncludedLinkPersonResources        *[]Person        `bson:"_includedLinkPersonResources,omitempty"`
-	IncludedLinkRelatedPersonResources *[]RelatedPerson `bson:"_includedLinkRelatedPersonResources,omitempty"`
-	IncludedRelatedpersonResources     *[]RelatedPerson `bson:"_includedRelatedpersonResources,omitempty"`
-	IncludedPatientResources           *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedOrganizationResources      *[]Organization  `bson:"_includedOrganizationResources,omitempty"`
+type PersonPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByPractitioner       *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPractitioner,omitempty"`
+	IncludedPractitionerResourcesReferencedByLink               *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByLink,omitempty"`
+	IncludedPatientResourcesReferencedByLink                    *[]Patient               `bson:"_includedPatientResourcesReferencedByLink,omitempty"`
+	IncludedPersonResourcesReferencedByLink                     *[]Person                `bson:"_includedPersonResourcesReferencedByLink,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByLink              *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByLink,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByRelatedperson     *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByRelatedperson,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization       *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedPersonResourcesReferencingLink                   *[]Person                `bson:"_revIncludedPersonResourcesReferencingLink,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *PersonPlusIncludes) GetIncludedPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedPractitionerResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPractitioner() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByPractitioner == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResources))
-	} else if len(*p.IncludedPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPractitioner) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByPractitioner))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPractitioner) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByPractitioner)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedLinkPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedLinkPractitionerResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedPractitionerResourceReferencedByLink() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByLink == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedLinkPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedLinkPractitionerResources))
-	} else if len(*p.IncludedLinkPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedLinkPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByLink) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByLink))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByLink) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByLink)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedLinkPatientResource() (patient *Patient, err error) {
-	if p.IncludedLinkPatientResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedPatientResourceReferencedByLink() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByLink == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedLinkPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedLinkPatientResources))
-	} else if len(*p.IncludedLinkPatientResources) == 1 {
-		patient = &(*p.IncludedLinkPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByLink) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByLink))
+	} else if len(*p.IncludedPatientResourcesReferencedByLink) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByLink)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedLinkPersonResource() (person *Person, err error) {
-	if p.IncludedLinkPersonResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedPersonResourceReferencedByLink() (person *Person, err error) {
+	if p.IncludedPersonResourcesReferencedByLink == nil {
 		err = errors.New("Included people not requested")
-	} else if len(*p.IncludedLinkPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 person, but found %d", len(*p.IncludedLinkPersonResources))
-	} else if len(*p.IncludedLinkPersonResources) == 1 {
-		person = &(*p.IncludedLinkPersonResources)[0]
+	} else if len(*p.IncludedPersonResourcesReferencedByLink) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 person, but found %d", len(*p.IncludedPersonResourcesReferencedByLink))
+	} else if len(*p.IncludedPersonResourcesReferencedByLink) == 1 {
+		person = &(*p.IncludedPersonResourcesReferencedByLink)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedLinkRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedLinkRelatedPersonResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByLink() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByLink == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedLinkRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedLinkRelatedPersonResources))
-	} else if len(*p.IncludedLinkRelatedPersonResources) == 1 {
-		relatedPerson = &(*p.IncludedLinkRelatedPersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByLink) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByLink))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByLink) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByLink)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedRelatedpersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedRelatedpersonResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByRelatedperson() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByRelatedperson == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedRelatedpersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedpersonResources))
-	} else if len(*p.IncludedRelatedpersonResources) == 1 {
-		relatedPerson = &(*p.IncludedRelatedpersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByRelatedperson) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByRelatedperson))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByRelatedperson) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByRelatedperson)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if p.IncludedPatientResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
-	} else if len(*p.IncludedPatientResources) == 1 {
-		patient = &(*p.IncludedPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedOrganizationResources == nil {
+func (p *PersonPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
-	} else if len(*p.IncludedOrganizationResources) == 1 {
-		organization = &(*p.IncludedOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (p *PersonPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *PersonPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedPersonResourcesReferencingLink() (people []Person, err error) {
+	if p.RevIncludedPersonResourcesReferencingLink == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *p.RevIncludedPersonResourcesReferencingLink
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *PersonPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedPractitionerResources != nil {
-		for _, r := range *p.IncludedPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLinkPractitionerResources != nil {
-		for _, r := range *p.IncludedLinkPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByLink {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLinkPatientResources != nil {
-		for _, r := range *p.IncludedLinkPatientResources {
+	if p.IncludedPatientResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLinkPersonResources != nil {
-		for _, r := range *p.IncludedLinkPersonResources {
+	if p.IncludedPersonResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPersonResourcesReferencedByLink {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLinkRelatedPersonResources != nil {
-		for _, r := range *p.IncludedLinkRelatedPersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByLink {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedRelatedpersonResources != nil {
-		for _, r := range *p.IncludedRelatedpersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByRelatedperson != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPatientResources != nil {
-		for _, r := range *p.IncludedPatientResources {
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrganizationResources != nil {
-		for _, r := range *p.IncludedOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PersonPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PersonPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResourcesReferencedByPractitioner != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPractitionerResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPersonResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedPersonResourcesReferencedByLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByLink != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByRelatedperson != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/practitioner.go
+++ b/models/practitioner.go
@@ -106,44 +106,2024 @@ type PractitionerQualificationComponent struct {
 }
 
 type PractitionerPlus struct {
-	Practitioner             `bson:",inline"`
-	PractitionerPlusIncludes `bson:",inline"`
+	Practitioner                     `bson:",inline"`
+	PractitionerPlusRelatedResources `bson:",inline"`
 }
 
-type PractitionerPlusIncludes struct {
-	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
-	IncludedLocationResources     *[]Location     `bson:"_includedLocationResources,omitempty"`
+type PractitionerPlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByOrganization               *[]Organization             `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	IncludedLocationResourcesReferencedByLocation                       *[]Location                 `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor                     *[]Appointment              `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResourcesReferencingPractitioner              *[]Appointment              `bson:"_revIncludedAppointmentResourcesReferencingPractitioner,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingRequester             *[]ReferralRequest          `bson:"_revIncludedReferralRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedReferralRequestResourcesReferencingRecipient             *[]ReferralRequest          `bson:"_revIncludedReferralRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedAccountResourcesReferencingSubject                       *[]Account                  `bson:"_revIncludedAccountResourcesReferencingSubject,omitempty"`
+	RevIncludedProvenanceResourcesReferencingAgent                      *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingAgent,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                     *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingSubject              *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingAuthor               *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRecipient            *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRecipient,omitempty"`
+	RevIncludedSpecimenResourcesReferencingCollector                    *[]Specimen                 `bson:"_revIncludedSpecimenResourcesReferencingCollector,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingRecorder           *[]AllergyIntolerance       `bson:"_revIncludedAllergyIntoleranceResourcesReferencingRecorder,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingReporter           *[]AllergyIntolerance       `bson:"_revIncludedAllergyIntoleranceResourcesReferencingReporter,omitempty"`
+	RevIncludedCarePlanResourcesReferencingPerformer                    *[]CarePlan                 `bson:"_revIncludedCarePlanResourcesReferencingPerformer,omitempty"`
+	RevIncludedCarePlanResourcesReferencingParticipant                  *[]CarePlan                 `bson:"_revIncludedCarePlanResourcesReferencingParticipant,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingTeammember              *[]EpisodeOfCare            `bson:"_revIncludedEpisodeOfCareResourcesReferencingTeammember,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingCaremanager             *[]EpisodeOfCare            `bson:"_revIncludedEpisodeOfCareResourcesReferencingCaremanager,omitempty"`
+	RevIncludedProcedureResourcesReferencingPerformer                   *[]Procedure                `bson:"_revIncludedProcedureResourcesReferencingPerformer,omitempty"`
+	RevIncludedListResourcesReferencingItem                             *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedListResourcesReferencingSource                           *[]List                     `bson:"_revIncludedListResourcesReferencingSource,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingSubject             *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingSubject,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthenticator       *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthenticator,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthor              *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref          *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSource                          *[]Order                    `bson:"_revIncludedOrderResourcesReferencingSource,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                          *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedOrderResourcesReferencingTarget                          *[]Order                    `bson:"_revIncludedOrderResourcesReferencingTarget,omitempty"`
+	RevIncludedImmunizationResourcesReferencingRequester                *[]Immunization             `bson:"_revIncludedImmunizationResourcesReferencingRequester,omitempty"`
+	RevIncludedImmunizationResourcesReferencingPerformer                *[]Immunization             `bson:"_revIncludedImmunizationResourcesReferencingPerformer,omitempty"`
+	RevIncludedVisionPrescriptionResourcesReferencingPrescriber         *[]VisionPrescription       `bson:"_revIncludedVisionPrescriptionResourcesReferencingPrescriber,omitempty"`
+	RevIncludedMediaResourcesReferencingSubject                         *[]Media                    `bson:"_revIncludedMediaResourcesReferencingSubject,omitempty"`
+	RevIncludedMediaResourcesReferencingOperator                        *[]Media                    `bson:"_revIncludedMediaResourcesReferencingOperator,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingPerformer            *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingPerformer,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingOrderer              *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingOrderer,omitempty"`
+	RevIncludedFlagResourcesReferencingSubject                          *[]Flag                     `bson:"_revIncludedFlagResourcesReferencingSubject,omitempty"`
+	RevIncludedFlagResourcesReferencingAuthor                           *[]Flag                     `bson:"_revIncludedFlagResourcesReferencingAuthor,omitempty"`
+	RevIncludedSupplyRequestResourcesReferencingSource                  *[]SupplyRequest            `bson:"_revIncludedSupplyRequestResourcesReferencingSource,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor             *[]AppointmentResponse      `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingPractitioner      *[]AppointmentResponse      `bson:"_revIncludedAppointmentResponseResourcesReferencingPractitioner,omitempty"`
+	RevIncludedObservationResourcesReferencingPerformer                 *[]Observation              `bson:"_revIncludedObservationResourcesReferencingPerformer,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingPractitioner *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingPractitioner,omitempty"`
+	RevIncludedMedicationStatementResourcesReferencingSource            *[]MedicationStatement      `bson:"_revIncludedMedicationStatementResourcesReferencingSource,omitempty"`
+	RevIncludedPersonResourcesReferencingPractitioner                   *[]Person                   `bson:"_revIncludedPersonResourcesReferencingPractitioner,omitempty"`
+	RevIncludedPersonResourcesReferencingLink                           *[]Person                   `bson:"_revIncludedPersonResourcesReferencingLink,omitempty"`
+	RevIncludedContractResourcesReferencingActor                        *[]Contract                 `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedContractResourcesReferencingSigner                       *[]Contract                 `bson:"_revIncludedContractResourcesReferencingSigner,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRequester        *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSender           *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRecipient        *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedRiskAssessmentResourcesReferencingPerformer              *[]RiskAssessment           `bson:"_revIncludedRiskAssessmentResourcesReferencingPerformer,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                         *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedBasicResourcesReferencingAuthor                          *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingAuthor,omitempty"`
+	RevIncludedGroupResourcesReferencingMember                          *[]Group                    `bson:"_revIncludedGroupResourcesReferencingMember,omitempty"`
+	RevIncludedProcessRequestResourcesReferencingProvider               *[]ProcessRequest           `bson:"_revIncludedProcessRequestResourcesReferencingProvider,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingReceiver           *[]MedicationDispense       `bson:"_revIncludedMedicationDispenseResourcesReferencingReceiver,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingResponsibleparty   *[]MedicationDispense       `bson:"_revIncludedMedicationDispenseResourcesReferencingResponsibleparty,omitempty"`
+	RevIncludedMedicationDispenseResourcesReferencingDispenser          *[]MedicationDispense       `bson:"_revIncludedMedicationDispenseResourcesReferencingDispenser,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingPerformer            *[]DiagnosticReport         `bson:"_revIncludedDiagnosticReportResourcesReferencingPerformer,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingAuthor         *[]ImagingObjectSelection   `bson:"_revIncludedImagingObjectSelectionResourcesReferencingAuthor,omitempty"`
+	RevIncludedNutritionOrderResourcesReferencingProvider               *[]NutritionOrder           `bson:"_revIncludedNutritionOrderResourcesReferencingProvider,omitempty"`
+	RevIncludedEncounterResourcesReferencingPractitioner                *[]Encounter                `bson:"_revIncludedEncounterResourcesReferencingPractitioner,omitempty"`
+	RevIncludedEncounterResourcesReferencingParticipant                 *[]Encounter                `bson:"_revIncludedEncounterResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingParticipant                *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                  *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedMedicationOrderResourcesReferencingPrescriber            *[]MedicationOrder          `bson:"_revIncludedMedicationOrderResourcesReferencingPrescriber,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSender                  *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient               *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedConditionResourcesReferencingAsserter                    *[]Condition                `bson:"_revIncludedConditionResourcesReferencingAsserter,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                   *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingAuthor                    *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingAuthor,omitempty"`
+	RevIncludedCompositionResourcesReferencingAttester                  *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingAttester,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                     *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingAuthor                  *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingAuthor,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated              *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingActorPath1            *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingActorPath1,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingActorPath2            *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingActorPath2,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingOrderer               *[]DiagnosticOrder          `bson:"_revIncludedDiagnosticOrderResourcesReferencingOrderer,omitempty"`
+	RevIncludedPatientResourcesReferencingCareprovider                  *[]Patient                  `bson:"_revIncludedPatientResourcesReferencingCareprovider,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment             *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingWho                     *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingWho,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject         *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingAuthor          *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingAuthor,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSource          *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSource,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest               *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequestprovider       *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequestprovider,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                        *[]Schedule                 `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedSupplyDeliveryResourcesReferencingReceiver               *[]SupplyDelivery           `bson:"_revIncludedSupplyDeliveryResourcesReferencingReceiver,omitempty"`
+	RevIncludedSupplyDeliveryResourcesReferencingSupplier               *[]SupplyDelivery           `bson:"_revIncludedSupplyDeliveryResourcesReferencingSupplier,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAssessor           *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingAssessor,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger            *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                    *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingReceiver                *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingReceiver,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingAuthor                  *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingAuthor,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingResponsible             *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingResponsible,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingEnterer                 *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingEnterer,omitempty"`
+	RevIncludedClaimResourcesReferencingProvider                        *[]Claim                    `bson:"_revIncludedClaimResourcesReferencingProvider,omitempty"`
 }
 
-func (p *PractitionerPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedOrganizationResources == nil {
+func (p *PractitionerPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
-	} else if len(*p.IncludedOrganizationResources) == 1 {
-		organization = &(*p.IncludedOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (p *PractitionerPlusIncludes) GetIncludedLocationResources() (locations []Location, err error) {
-	if p.IncludedLocationResources == nil {
+func (p *PractitionerPlusRelatedResources) GetIncludedLocationResourcesReferencedByLocation() (locations []Location, err error) {
+	if p.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
 	} else {
-		locations = *p.IncludedLocationResources
+		locations = *p.IncludedLocationResourcesReferencedByLocation
 	}
 	return
 }
 
-func (p *PractitionerPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if p.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *p.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingPractitioner() (appointments []Appointment, err error) {
+	if p.RevIncludedAppointmentResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *p.RevIncludedAppointmentResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingRequester() (referralRequests []ReferralRequest, err error) {
+	if p.RevIncludedReferralRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *p.RevIncludedReferralRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedReferralRequestResourcesReferencingRecipient() (referralRequests []ReferralRequest, err error) {
+	if p.RevIncludedReferralRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded referralRequests not requested")
+	} else {
+		referralRequests = *p.RevIncludedReferralRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAccountResourcesReferencingSubject() (accounts []Account, err error) {
+	if p.RevIncludedAccountResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded accounts not requested")
+	} else {
+		accounts = *p.RevIncludedAccountResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingAgent() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingAgent == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingAgent
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingSubject() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingAuthor() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRecipient() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingCollector() (specimen []Specimen, err error) {
+	if p.RevIncludedSpecimenResourcesReferencingCollector == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *p.RevIncludedSpecimenResourcesReferencingCollector
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingRecorder() (allergyIntolerances []AllergyIntolerance, err error) {
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingReporter() (allergyIntolerances []AllergyIntolerance, err error) {
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingPerformer() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingParticipant() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingParticipant
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingTeammember() (episodeOfCares []EpisodeOfCare, err error) {
+	if p.RevIncludedEpisodeOfCareResourcesReferencingTeammember == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingCaremanager() (episodeOfCares []EpisodeOfCare, err error) {
+	if p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingPerformer() (procedures []Procedure, err error) {
+	if p.RevIncludedProcedureResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *p.RevIncludedProcedureResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedListResourcesReferencingSource() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingSubject() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthenticator() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthor() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedOrderResourcesReferencingSource() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedOrderResourcesReferencingTarget() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingRequester() (immunizations []Immunization, err error) {
+	if p.RevIncludedImmunizationResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *p.RevIncludedImmunizationResourcesReferencingRequester
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedImmunizationResourcesReferencingPerformer() (immunizations []Immunization, err error) {
+	if p.RevIncludedImmunizationResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded immunizations not requested")
+	} else {
+		immunizations = *p.RevIncludedImmunizationResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedVisionPrescriptionResourcesReferencingPrescriber() (visionPrescriptions []VisionPrescription, err error) {
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber == nil {
+		err = errors.New("RevIncluded visionPrescriptions not requested")
+	} else {
+		visionPrescriptions = *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMediaResourcesReferencingSubject() (media []Media, err error) {
+	if p.RevIncludedMediaResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *p.RevIncludedMediaResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMediaResourcesReferencingOperator() (media []Media, err error) {
+	if p.RevIncludedMediaResourcesReferencingOperator == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *p.RevIncludedMediaResourcesReferencingOperator
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingPerformer() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingOrderer() (procedureRequests []ProcedureRequest, err error) {
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *p.RevIncludedProcedureRequestResourcesReferencingOrderer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedFlagResourcesReferencingSubject() (flags []Flag, err error) {
+	if p.RevIncludedFlagResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *p.RevIncludedFlagResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedFlagResourcesReferencingAuthor() (flags []Flag, err error) {
+	if p.RevIncludedFlagResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded flags not requested")
+	} else {
+		flags = *p.RevIncludedFlagResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedSupplyRequestResourcesReferencingSource() (supplyRequests []SupplyRequest, err error) {
+	if p.RevIncludedSupplyRequestResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded supplyRequests not requested")
+	} else {
+		supplyRequests = *p.RevIncludedSupplyRequestResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *p.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingPractitioner() (appointmentResponses []AppointmentResponse, err error) {
+	if p.RevIncludedAppointmentResponseResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedObservationResourcesReferencingPerformer() (observations []Observation, err error) {
+	if p.RevIncludedObservationResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *p.RevIncludedObservationResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingPractitioner() (medicationAdministrations []MedicationAdministration, err error) {
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationStatementResourcesReferencingSource() (medicationStatements []MedicationStatement, err error) {
+	if p.RevIncludedMedicationStatementResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded medicationStatements not requested")
+	} else {
+		medicationStatements = *p.RevIncludedMedicationStatementResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedPersonResourcesReferencingPractitioner() (people []Person, err error) {
+	if p.RevIncludedPersonResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *p.RevIncludedPersonResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedPersonResourcesReferencingLink() (people []Person, err error) {
+	if p.RevIncludedPersonResourcesReferencingLink == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *p.RevIncludedPersonResourcesReferencingLink
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedContractResourcesReferencingSigner() (contracts []Contract, err error) {
+	if p.RevIncludedContractResourcesReferencingSigner == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *p.RevIncludedContractResourcesReferencingSigner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRequester() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSender() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingSender
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRecipient() (communicationRequests []CommunicationRequest, err error) {
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *p.RevIncludedCommunicationRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedRiskAssessmentResourcesReferencingPerformer() (riskAssessments []RiskAssessment, err error) {
+	if p.RevIncludedRiskAssessmentResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded riskAssessments not requested")
+	} else {
+		riskAssessments = *p.RevIncludedRiskAssessmentResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedBasicResourcesReferencingAuthor() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedGroupResourcesReferencingMember() (groups []Group, err error) {
+	if p.RevIncludedGroupResourcesReferencingMember == nil {
+		err = errors.New("RevIncluded groups not requested")
+	} else {
+		groups = *p.RevIncludedGroupResourcesReferencingMember
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcessRequestResourcesReferencingProvider() (processRequests []ProcessRequest, err error) {
+	if p.RevIncludedProcessRequestResourcesReferencingProvider == nil {
+		err = errors.New("RevIncluded processRequests not requested")
+	} else {
+		processRequests = *p.RevIncludedProcessRequestResourcesReferencingProvider
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingReceiver() (medicationDispenses []MedicationDispense, err error) {
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *p.RevIncludedMedicationDispenseResourcesReferencingReceiver
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingResponsibleparty() (medicationDispenses []MedicationDispense, err error) {
+	if p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationDispenseResourcesReferencingDispenser() (medicationDispenses []MedicationDispense, err error) {
+	if p.RevIncludedMedicationDispenseResourcesReferencingDispenser == nil {
+		err = errors.New("RevIncluded medicationDispenses not requested")
+	} else {
+		medicationDispenses = *p.RevIncludedMedicationDispenseResourcesReferencingDispenser
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingPerformer() (diagnosticReports []DiagnosticReport, err error) {
+	if p.RevIncludedDiagnosticReportResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *p.RevIncludedDiagnosticReportResourcesReferencingPerformer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingAuthor() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedNutritionOrderResourcesReferencingProvider() (nutritionOrders []NutritionOrder, err error) {
+	if p.RevIncludedNutritionOrderResourcesReferencingProvider == nil {
+		err = errors.New("RevIncluded nutritionOrders not requested")
+	} else {
+		nutritionOrders = *p.RevIncludedNutritionOrderResourcesReferencingProvider
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingPractitioner() (encounters []Encounter, err error) {
+	if p.RevIncludedEncounterResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *p.RevIncludedEncounterResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingParticipant() (encounters []Encounter, err error) {
+	if p.RevIncludedEncounterResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *p.RevIncludedEncounterResourcesReferencingParticipant
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingParticipant() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingParticipant
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMedicationOrderResourcesReferencingPrescriber() (medicationOrders []MedicationOrder, err error) {
+	if p.RevIncludedMedicationOrderResourcesReferencingPrescriber == nil {
+		err = errors.New("RevIncluded medicationOrders not requested")
+	} else {
+		medicationOrders = *p.RevIncludedMedicationOrderResourcesReferencingPrescriber
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSender() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingSender
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if p.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *p.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedConditionResourcesReferencingAsserter() (conditions []Condition, err error) {
+	if p.RevIncludedConditionResourcesReferencingAsserter == nil {
+		err = errors.New("RevIncluded conditions not requested")
+	} else {
+		conditions = *p.RevIncludedConditionResourcesReferencingAsserter
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAuthor() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAttester() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingAttester == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingAttester
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingAuthor() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingActorPath1() (diagnosticOrders []DiagnosticOrder, err error) {
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingActorPath2() (diagnosticOrders []DiagnosticOrder, err error) {
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingOrderer() (diagnosticOrders []DiagnosticOrder, err error) {
+	if p.RevIncludedDiagnosticOrderResourcesReferencingOrderer == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedPatientResourcesReferencingCareprovider() (patients []Patient, err error) {
+	if p.RevIncludedPatientResourcesReferencingCareprovider == nil {
+		err = errors.New("RevIncluded patients not requested")
+	} else {
+		patients = *p.RevIncludedPatientResourcesReferencingCareprovider
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingWho() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingWho == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingWho
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingAuthor() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSource() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSource
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequestprovider() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequestprovider == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequestprovider
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if p.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *p.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedSupplyDeliveryResourcesReferencingReceiver() (supplyDeliveries []SupplyDelivery, err error) {
+	if p.RevIncludedSupplyDeliveryResourcesReferencingReceiver == nil {
+		err = errors.New("RevIncluded supplyDeliveries not requested")
+	} else {
+		supplyDeliveries = *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedSupplyDeliveryResourcesReferencingSupplier() (supplyDeliveries []SupplyDelivery, err error) {
+	if p.RevIncludedSupplyDeliveryResourcesReferencingSupplier == nil {
+		err = errors.New("RevIncluded supplyDeliveries not requested")
+	} else {
+		supplyDeliveries = *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAssessor() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingAssessor == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingAssessor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingReceiver() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingReceiver == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingReceiver
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingAuthor() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingAuthor
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingResponsible() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingResponsible == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingResponsible
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingEnterer() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingEnterer == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingEnterer
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedClaimResourcesReferencingProvider() (claims []Claim, err error) {
+	if p.RevIncludedClaimResourcesReferencingProvider == nil {
+		err = errors.New("RevIncluded claims not requested")
+	} else {
+		claims = *p.RevIncludedClaimResourcesReferencingProvider
+	}
+	return
+}
+
+func (p *PractitionerPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedOrganizationResources != nil {
-		for _, r := range *p.IncludedOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLocationResources != nil {
-		for _, r := range *p.IncludedLocationResources {
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PractitionerPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingCollector != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingCollector {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber != nil {
+		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingOperator != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingOperator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessRequestResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingDispenser != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedNutritionOrderResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationOrderResourcesReferencingPrescriber != nil {
+		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPatientResourcesReferencingCareprovider != nil {
+		for _, r := range *p.RevIncludedPatientResourcesReferencingCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequestprovider != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingSupplier != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAssessor != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingEnterer != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClaimResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedClaimResourcesReferencingProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *PractitionerPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAccountResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSpecimenResourcesReferencingCollector != nil {
+		for _, r := range *p.RevIncludedSpecimenResourcesReferencingCollector {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager != nil {
+		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImmunizationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber != nil {
+		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMediaResourcesReferencingOperator != nil {
+		for _, r := range *p.RevIncludedMediaResourcesReferencingOperator {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAppointmentResponseResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessRequestResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationDispenseResourcesReferencingDispenser != nil {
+		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedNutritionOrderResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingPractitioner != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMedicationOrderResourcesReferencingPrescriber != nil {
+		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
+		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticOrderResourcesReferencingOrderer != nil {
+		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedPatientResourcesReferencingCareprovider != nil {
+		for _, r := range *p.RevIncludedPatientResourcesReferencingCareprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingWho != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingWho {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequestprovider != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedSupplyDeliveryResourcesReferencingSupplier != nil {
+		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAssessor != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingAuthor != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingEnterer != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClaimResourcesReferencingProvider != nil {
+		for _, r := range *p.RevIncludedClaimResourcesReferencingProvider {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -112,165 +112,600 @@ type ProcedureFocalDeviceComponent struct {
 }
 
 type ProcedurePlus struct {
-	Procedure             `bson:",inline"`
-	ProcedurePlusIncludes `bson:",inline"`
+	Procedure                     `bson:",inline"`
+	ProcedurePlusRelatedResources `bson:",inline"`
 }
 
-type ProcedurePlusIncludes struct {
-	IncludedPerformerPractitionerResources  *[]Practitioner  `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerOrganizationResources  *[]Organization  `bson:"_includedPerformerOrganizationResources,omitempty"`
-	IncludedPerformerPatientResources       *[]Patient       `bson:"_includedPerformerPatientResources,omitempty"`
-	IncludedPerformerRelatedPersonResources *[]RelatedPerson `bson:"_includedPerformerRelatedPersonResources,omitempty"`
-	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedLocationResources               *[]Location      `bson:"_includedLocationResources,omitempty"`
-	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+type ProcedurePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByPerformer          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedOrganizationResourcesReferencedByPerformer          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByPerformer,omitempty"`
+	IncludedPatientResourcesReferencedByPerformer               *[]Patient               `bson:"_includedPatientResourcesReferencedByPerformer,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByPerformer         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByPerformer,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedLocationResourcesReferencedByLocation               *[]Location              `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedEncounterResourcesReferencingProcedure           *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingProcedure,omitempty"`
+	RevIncludedEncounterResourcesReferencingIndication          *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingIndication,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedPerformerPractitionerResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedPractitionerResourceReferencedByPerformer() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedPerformerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPerformerPractitionerResources))
-	} else if len(*p.IncludedPerformerPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedPerformerPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByPerformer))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPerformer) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedPerformerOrganizationResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedOrganizationResourceReferencedByPerformer() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByPerformer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedPerformerOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedPerformerOrganizationResources))
-	} else if len(*p.IncludedPerformerOrganizationResources) == 1 {
-		organization = &(*p.IncludedPerformerOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByPerformer))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByPerformer) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedPerformerPatientResource() (patient *Patient, err error) {
-	if p.IncludedPerformerPatientResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedPatientResourceReferencedByPerformer() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPerformer == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedPerformerPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPerformerPatientResources))
-	} else if len(*p.IncludedPerformerPatientResources) == 1 {
-		patient = &(*p.IncludedPerformerPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByPerformer))
+	} else if len(*p.IncludedPatientResourcesReferencedByPerformer) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedPerformerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedPerformerRelatedPersonResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByPerformer() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedPerformerRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedPerformerRelatedPersonResources))
-	} else if len(*p.IncludedPerformerRelatedPersonResources) == 1 {
-		relatedPerson = &(*p.IncludedPerformerRelatedPersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByPerformer))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByPerformer) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if p.IncludedSubjectGroupResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if p.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*p.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedSubjectGroupResources))
-	} else if len(*p.IncludedSubjectGroupResources) == 1 {
-		group = &(*p.IncludedSubjectGroupResources)[0]
+	} else if len(*p.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*p.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*p.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if p.IncludedSubjectPatientResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedSubjectPatientResources))
-	} else if len(*p.IncludedSubjectPatientResources) == 1 {
-		patient = &(*p.IncludedSubjectPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*p.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if p.IncludedPatientResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
-	} else if len(*p.IncludedPatientResources) == 1 {
-		patient = &(*p.IncludedPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if p.IncludedLocationResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if p.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*p.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResources))
-	} else if len(*p.IncludedLocationResources) == 1 {
-		location = &(*p.IncludedLocationResources)[0]
+	} else if len(*p.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*p.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*p.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if p.IncludedEncounterResources == nil {
+func (p *ProcedurePlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if p.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*p.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResources))
-	} else if len(*p.IncludedEncounterResources) == 1 {
-		encounter = &(*p.IncludedEncounterResources)[0]
+	} else if len(*p.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*p.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*p.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (p *ProcedurePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *ProcedurePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedEncounterResourcesReferencingProcedure() (encounters []Encounter, err error) {
+	if p.RevIncludedEncounterResourcesReferencingProcedure == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *p.RevIncludedEncounterResourcesReferencingProcedure
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedEncounterResourcesReferencingIndication() (encounters []Encounter, err error) {
+	if p.RevIncludedEncounterResourcesReferencingIndication == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *p.RevIncludedEncounterResourcesReferencingIndication
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *ProcedurePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *p.IncludedPerformerPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerOrganizationResources != nil {
-		for _, r := range *p.IncludedPerformerOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerPatientResources != nil {
-		for _, r := range *p.IncludedPerformerPatientResources {
+	if p.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerRelatedPersonResources != nil {
-		for _, r := range *p.IncludedPerformerRelatedPersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedSubjectGroupResources != nil {
-		for _, r := range *p.IncludedSubjectGroupResources {
+	if p.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedSubjectPatientResources != nil {
-		for _, r := range *p.IncludedSubjectPatientResources {
+	if p.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPatientResources != nil {
-		for _, r := range *p.IncludedPatientResources {
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLocationResources != nil {
-		for _, r := range *p.IncludedLocationResources {
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedEncounterResources != nil {
-		for _, r := range *p.IncludedEncounterResources {
+	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcedurePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingProcedure != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingProcedure {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingIndication != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcedurePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingProcedure != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingProcedure {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedEncounterResourcesReferencingIndication != nil {
+		for _, r := range *p.RevIncludedEncounterResourcesReferencingIndication {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/procedurerequest.go
+++ b/models/procedurerequest.go
@@ -97,216 +97,686 @@ func (x *ProcedureRequest) checkResourceType() error {
 }
 
 type ProcedureRequestPlus struct {
-	ProcedureRequest             `bson:",inline"`
-	ProcedureRequestPlusIncludes `bson:",inline"`
+	ProcedureRequest                     `bson:",inline"`
+	ProcedureRequestPlusRelatedResources `bson:",inline"`
 }
 
-type ProcedureRequestPlusIncludes struct {
-	IncludedPerformerPractitionerResources  *[]Practitioner  `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerOrganizationResources  *[]Organization  `bson:"_includedPerformerOrganizationResources,omitempty"`
-	IncludedPerformerPatientResources       *[]Patient       `bson:"_includedPerformerPatientResources,omitempty"`
-	IncludedPerformerRelatedPersonResources *[]RelatedPerson `bson:"_includedPerformerRelatedPersonResources,omitempty"`
-	IncludedSubjectGroupResources           *[]Group         `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectPatientResources         *[]Patient       `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedPatientResources                *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedOrdererPractitionerResources    *[]Practitioner  `bson:"_includedOrdererPractitionerResources,omitempty"`
-	IncludedOrdererDeviceResources          *[]Device        `bson:"_includedOrdererDeviceResources,omitempty"`
-	IncludedOrdererPatientResources         *[]Patient       `bson:"_includedOrdererPatientResources,omitempty"`
-	IncludedOrdererRelatedPersonResources   *[]RelatedPerson `bson:"_includedOrdererRelatedPersonResources,omitempty"`
-	IncludedEncounterResources              *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
+type ProcedureRequestPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByPerformer          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedOrganizationResourcesReferencedByPerformer          *[]Organization          `bson:"_includedOrganizationResourcesReferencedByPerformer,omitempty"`
+	IncludedPatientResourcesReferencedByPerformer               *[]Patient               `bson:"_includedPatientResourcesReferencedByPerformer,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByPerformer         *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByPerformer,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByOrderer            *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByOrderer,omitempty"`
+	IncludedDeviceResourcesReferencedByOrderer                  *[]Device                `bson:"_includedDeviceResourcesReferencedByOrderer,omitempty"`
+	IncludedPatientResourcesReferencedByOrderer                 *[]Patient               `bson:"_includedPatientResourcesReferencedByOrderer,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByOrderer           *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByOrderer,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingRequest      *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingRequest,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedPerformerPractitionerResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPerformer() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedPerformerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPerformerPractitionerResources))
-	} else if len(*p.IncludedPerformerPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedPerformerPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByPerformer))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByPerformer) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedPerformerOrganizationResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedOrganizationResourceReferencedByPerformer() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByPerformer == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedPerformerOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedPerformerOrganizationResources))
-	} else if len(*p.IncludedPerformerOrganizationResources) == 1 {
-		organization = &(*p.IncludedPerformerOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByPerformer))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByPerformer) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerPatientResource() (patient *Patient, err error) {
-	if p.IncludedPerformerPatientResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPerformer() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPerformer == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedPerformerPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPerformerPatientResources))
-	} else if len(*p.IncludedPerformerPatientResources) == 1 {
-		patient = &(*p.IncludedPerformerPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByPerformer))
+	} else if len(*p.IncludedPatientResourcesReferencedByPerformer) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedPerformerRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedPerformerRelatedPersonResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByPerformer() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedPerformerRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedPerformerRelatedPersonResources))
-	} else if len(*p.IncludedPerformerRelatedPersonResources) == 1 {
-		relatedPerson = &(*p.IncludedPerformerRelatedPersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByPerformer))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByPerformer) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if p.IncludedSubjectGroupResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if p.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*p.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedSubjectGroupResources))
-	} else if len(*p.IncludedSubjectGroupResources) == 1 {
-		group = &(*p.IncludedSubjectGroupResources)[0]
+	} else if len(*p.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*p.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*p.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*p.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if p.IncludedSubjectPatientResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedSubjectPatientResources))
-	} else if len(*p.IncludedSubjectPatientResources) == 1 {
-		patient = &(*p.IncludedSubjectPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*p.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if p.IncludedPatientResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResources))
-	} else if len(*p.IncludedPatientResources) == 1 {
-		patient = &(*p.IncludedPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*p.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedOrdererPractitionerResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedByOrderer() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByOrderer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedOrdererPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedOrdererPractitionerResources))
-	} else if len(*p.IncludedOrdererPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedOrdererPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByOrderer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByOrderer))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByOrderer) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByOrderer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererDeviceResource() (device *Device, err error) {
-	if p.IncludedOrdererDeviceResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedDeviceResourceReferencedByOrderer() (device *Device, err error) {
+	if p.IncludedDeviceResourcesReferencedByOrderer == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*p.IncludedOrdererDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedOrdererDeviceResources))
-	} else if len(*p.IncludedOrdererDeviceResources) == 1 {
-		device = &(*p.IncludedOrdererDeviceResources)[0]
+	} else if len(*p.IncludedDeviceResourcesReferencedByOrderer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedDeviceResourcesReferencedByOrderer))
+	} else if len(*p.IncludedDeviceResourcesReferencedByOrderer) == 1 {
+		device = &(*p.IncludedDeviceResourcesReferencedByOrderer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererPatientResource() (patient *Patient, err error) {
-	if p.IncludedOrdererPatientResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByOrderer() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByOrderer == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedOrdererPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedOrdererPatientResources))
-	} else if len(*p.IncludedOrdererPatientResources) == 1 {
-		patient = &(*p.IncludedOrdererPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByOrderer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByOrderer))
+	} else if len(*p.IncludedPatientResourcesReferencedByOrderer) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByOrderer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedOrdererRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedOrdererRelatedPersonResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByOrderer() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByOrderer == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedOrdererRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedOrdererRelatedPersonResources))
-	} else if len(*p.IncludedOrdererRelatedPersonResources) == 1 {
-		relatedPerson = &(*p.IncludedOrdererRelatedPersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByOrderer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByOrderer))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByOrderer) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByOrderer)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if p.IncludedEncounterResources == nil {
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if p.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*p.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResources))
-	} else if len(*p.IncludedEncounterResources) == 1 {
-		encounter = &(*p.IncludedEncounterResources)[0]
+	} else if len(*p.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*p.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*p.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*p.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (p *ProcedureRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingRequest() (diagnosticReports []DiagnosticReport, err error) {
+	if p.RevIncludedDiagnosticReportResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *p.RevIncludedDiagnosticReportResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *p.IncludedPerformerPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerOrganizationResources != nil {
-		for _, r := range *p.IncludedPerformerOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerPatientResources != nil {
-		for _, r := range *p.IncludedPerformerPatientResources {
+	if p.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPerformerRelatedPersonResources != nil {
-		for _, r := range *p.IncludedPerformerRelatedPersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedSubjectGroupResources != nil {
-		for _, r := range *p.IncludedSubjectGroupResources {
+	if p.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedSubjectPatientResources != nil {
-		for _, r := range *p.IncludedSubjectPatientResources {
+	if p.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPatientResources != nil {
-		for _, r := range *p.IncludedPatientResources {
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrdererPractitionerResources != nil {
-		for _, r := range *p.IncludedOrdererPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByOrderer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrdererDeviceResources != nil {
-		for _, r := range *p.IncludedOrdererDeviceResources {
+	if p.IncludedDeviceResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedDeviceResourcesReferencedByOrderer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrdererPatientResources != nil {
-		for _, r := range *p.IncludedOrdererPatientResources {
+	if p.IncludedPatientResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByOrderer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrdererRelatedPersonResources != nil {
-		for _, r := range *p.IncludedOrdererRelatedPersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedEncounterResources != nil {
-		for _, r := range *p.IncludedEncounterResources {
+	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcedureRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPractitionerResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedDeviceResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedDeviceResourcesReferencedByOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByOrderer != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/processrequest.go
+++ b/models/processrequest.go
@@ -99,46 +99,426 @@ type ProcessRequestItemsComponent struct {
 }
 
 type ProcessRequestPlus struct {
-	ProcessRequest             `bson:",inline"`
-	ProcessRequestPlusIncludes `bson:",inline"`
+	ProcessRequest                     `bson:",inline"`
+	ProcessRequestPlusRelatedResources `bson:",inline"`
 }
 
-type ProcessRequestPlusIncludes struct {
-	IncludedProviderResources     *[]Practitioner `bson:"_includedProviderResources,omitempty"`
-	IncludedOrganizationResources *[]Organization `bson:"_includedOrganizationResources,omitempty"`
+type ProcessRequestPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByProvider           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByProvider,omitempty"`
+	IncludedOrganizationResourcesReferencedByOrganization       *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *ProcessRequestPlusIncludes) GetIncludedProviderResource() (practitioner *Practitioner, err error) {
-	if p.IncludedProviderResources == nil {
+func (p *ProcessRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedByProvider() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByProvider == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedProviderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedProviderResources))
-	} else if len(*p.IncludedProviderResources) == 1 {
-		practitioner = &(*p.IncludedProviderResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByProvider) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByProvider))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByProvider) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByProvider)[0]
 	}
 	return
 }
 
-func (p *ProcessRequestPlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedOrganizationResources == nil {
+func (p *ProcessRequestPlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
-	} else if len(*p.IncludedOrganizationResources) == 1 {
-		organization = &(*p.IncludedOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (p *ProcessRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *p.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedProviderResources != nil {
-		for _, r := range *p.IncludedProviderResources {
+	if p.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByProvider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedOrganizationResources != nil {
-		for _, r := range *p.IncludedOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcessRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResourcesReferencedByProvider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByProvider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -97,63 +97,408 @@ type ProcessResponseNotesComponent struct {
 }
 
 type ProcessResponsePlus struct {
-	ProcessResponse             `bson:",inline"`
-	ProcessResponsePlusIncludes `bson:",inline"`
+	ProcessResponse                     `bson:",inline"`
+	ProcessResponsePlusRelatedResources `bson:",inline"`
 }
 
-type ProcessResponsePlusIncludes struct {
-	IncludedOrganizationResources        *[]Organization `bson:"_includedOrganizationResources,omitempty"`
-	IncludedRequestproviderResources     *[]Practitioner `bson:"_includedRequestproviderResources,omitempty"`
-	IncludedRequestorganizationResources *[]Organization `bson:"_includedRequestorganizationResources,omitempty"`
+type ProcessResponsePlusRelatedResources struct {
+	IncludedOrganizationResourcesReferencedByOrganization        *[]Organization          `bson:"_includedOrganizationResourcesReferencedByOrganization,omitempty"`
+	IncludedPractitionerResourcesReferencedByRequestprovider     *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRequestprovider,omitempty"`
+	IncludedOrganizationResourcesReferencedByRequestorganization *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRequestorganization,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget              *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                      *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref   *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                   *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                  *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference           *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject            *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated       *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment      *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject  *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest        *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData             *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *ProcessResponsePlusIncludes) GetIncludedOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedOrganizationResources == nil {
+func (p *ProcessResponsePlusRelatedResources) GetIncludedOrganizationResourceReferencedByOrganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByOrganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResources))
-	} else if len(*p.IncludedOrganizationResources) == 1 {
-		organization = &(*p.IncludedOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByOrganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByOrganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByOrganization)[0]
 	}
 	return
 }
 
-func (p *ProcessResponsePlusIncludes) GetIncludedRequestproviderResource() (practitioner *Practitioner, err error) {
-	if p.IncludedRequestproviderResources == nil {
+func (p *ProcessResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedByRequestprovider() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByRequestprovider == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedRequestproviderResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedRequestproviderResources))
-	} else if len(*p.IncludedRequestproviderResources) == 1 {
-		practitioner = &(*p.IncludedRequestproviderResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByRequestprovider) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByRequestprovider))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByRequestprovider) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByRequestprovider)[0]
 	}
 	return
 }
 
-func (p *ProcessResponsePlusIncludes) GetIncludedRequestorganizationResource() (organization *Organization, err error) {
-	if p.IncludedRequestorganizationResources == nil {
+func (p *ProcessResponsePlusRelatedResources) GetIncludedOrganizationResourceReferencedByRequestorganization() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByRequestorganization == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedRequestorganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedRequestorganizationResources))
-	} else if len(*p.IncludedRequestorganizationResources) == 1 {
-		organization = &(*p.IncludedRequestorganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByRequestorganization) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByRequestorganization))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByRequestorganization) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByRequestorganization)[0]
 	}
 	return
 }
 
-func (p *ProcessResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedOrganizationResources != nil {
-		for _, r := range *p.IncludedOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedRequestproviderResources != nil {
-		for _, r := range *p.IncludedRequestproviderResources {
+	if p.IncludedPractitionerResourcesReferencedByRequestprovider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedRequestorganizationResources != nil {
-		for _, r := range *p.IncludedRequestorganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByRequestorganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProcessResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPractitionerResourcesReferencedByRequestprovider != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByRequestorganization != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -109,129 +109,494 @@ type ProvenanceEntityComponent struct {
 }
 
 type ProvenancePlus struct {
-	Provenance             `bson:",inline"`
-	ProvenancePlusIncludes `bson:",inline"`
+	Provenance                     `bson:",inline"`
+	ProvenancePlusRelatedResources `bson:",inline"`
 }
 
-type ProvenancePlusIncludes struct {
-	IncludedAgentPractitionerResources  *[]Practitioner  `bson:"_includedAgentPractitionerResources,omitempty"`
-	IncludedAgentOrganizationResources  *[]Organization  `bson:"_includedAgentOrganizationResources,omitempty"`
-	IncludedAgentDeviceResources        *[]Device        `bson:"_includedAgentDeviceResources,omitempty"`
-	IncludedAgentPatientResources       *[]Patient       `bson:"_includedAgentPatientResources,omitempty"`
-	IncludedAgentRelatedPersonResources *[]RelatedPerson `bson:"_includedAgentRelatedPersonResources,omitempty"`
-	IncludedPatientResources            *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedLocationResources           *[]Location      `bson:"_includedLocationResources,omitempty"`
+type ProvenancePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByAgent              *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAgent,omitempty"`
+	IncludedOrganizationResourcesReferencedByAgent              *[]Organization          `bson:"_includedOrganizationResourcesReferencedByAgent,omitempty"`
+	IncludedDeviceResourcesReferencedByAgent                    *[]Device                `bson:"_includedDeviceResourcesReferencedByAgent,omitempty"`
+	IncludedPatientResourcesReferencedByAgent                   *[]Patient               `bson:"_includedPatientResourcesReferencedByAgent,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAgent             *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAgent,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedLocationResourcesReferencedByLocation               *[]Location              `bson:"_includedLocationResourcesReferencedByLocation,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedAgentPractitionerResource() (practitioner *Practitioner, err error) {
-	if p.IncludedAgentPractitionerResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedPractitionerResourceReferencedByAgent() (practitioner *Practitioner, err error) {
+	if p.IncludedPractitionerResourcesReferencedByAgent == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*p.IncludedAgentPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedAgentPractitionerResources))
-	} else if len(*p.IncludedAgentPractitionerResources) == 1 {
-		practitioner = &(*p.IncludedAgentPractitionerResources)[0]
+	} else if len(*p.IncludedPractitionerResourcesReferencedByAgent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*p.IncludedPractitionerResourcesReferencedByAgent))
+	} else if len(*p.IncludedPractitionerResourcesReferencedByAgent) == 1 {
+		practitioner = &(*p.IncludedPractitionerResourcesReferencedByAgent)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedAgentOrganizationResource() (organization *Organization, err error) {
-	if p.IncludedAgentOrganizationResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedOrganizationResourceReferencedByAgent() (organization *Organization, err error) {
+	if p.IncludedOrganizationResourcesReferencedByAgent == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*p.IncludedAgentOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedAgentOrganizationResources))
-	} else if len(*p.IncludedAgentOrganizationResources) == 1 {
-		organization = &(*p.IncludedAgentOrganizationResources)[0]
+	} else if len(*p.IncludedOrganizationResourcesReferencedByAgent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*p.IncludedOrganizationResourcesReferencedByAgent))
+	} else if len(*p.IncludedOrganizationResourcesReferencedByAgent) == 1 {
+		organization = &(*p.IncludedOrganizationResourcesReferencedByAgent)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedAgentDeviceResource() (device *Device, err error) {
-	if p.IncludedAgentDeviceResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedDeviceResourceReferencedByAgent() (device *Device, err error) {
+	if p.IncludedDeviceResourcesReferencedByAgent == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*p.IncludedAgentDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedAgentDeviceResources))
-	} else if len(*p.IncludedAgentDeviceResources) == 1 {
-		device = &(*p.IncludedAgentDeviceResources)[0]
+	} else if len(*p.IncludedDeviceResourcesReferencedByAgent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*p.IncludedDeviceResourcesReferencedByAgent))
+	} else if len(*p.IncludedDeviceResourcesReferencedByAgent) == 1 {
+		device = &(*p.IncludedDeviceResourcesReferencedByAgent)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedAgentPatientResource() (patient *Patient, err error) {
-	if p.IncludedAgentPatientResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedPatientResourceReferencedByAgent() (patient *Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByAgent == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*p.IncludedAgentPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedAgentPatientResources))
-	} else if len(*p.IncludedAgentPatientResources) == 1 {
-		patient = &(*p.IncludedAgentPatientResources)[0]
+	} else if len(*p.IncludedPatientResourcesReferencedByAgent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*p.IncludedPatientResourcesReferencedByAgent))
+	} else if len(*p.IncludedPatientResourcesReferencedByAgent) == 1 {
+		patient = &(*p.IncludedPatientResourcesReferencedByAgent)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedAgentRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if p.IncludedAgentRelatedPersonResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByAgent() (relatedPerson *RelatedPerson, err error) {
+	if p.IncludedRelatedPersonResourcesReferencedByAgent == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*p.IncludedAgentRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedAgentRelatedPersonResources))
-	} else if len(*p.IncludedAgentRelatedPersonResources) == 1 {
-		relatedPerson = &(*p.IncludedAgentRelatedPersonResources)[0]
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByAgent) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*p.IncludedRelatedPersonResourcesReferencedByAgent))
+	} else if len(*p.IncludedRelatedPersonResourcesReferencedByAgent) == 1 {
+		relatedPerson = &(*p.IncludedRelatedPersonResourcesReferencedByAgent)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedPatientResources() (patients []Patient, err error) {
-	if p.IncludedPatientResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedPatientResourcesReferencedByPatient() (patients []Patient, err error) {
+	if p.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
 	} else {
-		patients = *p.IncludedPatientResources
+		patients = *p.IncludedPatientResourcesReferencedByPatient
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedLocationResource() (location *Location, err error) {
-	if p.IncludedLocationResources == nil {
+func (p *ProvenancePlusRelatedResources) GetIncludedLocationResourceReferencedByLocation() (location *Location, err error) {
+	if p.IncludedLocationResourcesReferencedByLocation == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*p.IncludedLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResources))
-	} else if len(*p.IncludedLocationResources) == 1 {
-		location = &(*p.IncludedLocationResources)[0]
+	} else if len(*p.IncludedLocationResourcesReferencedByLocation) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*p.IncludedLocationResourcesReferencedByLocation))
+	} else if len(*p.IncludedLocationResourcesReferencedByLocation) == 1 {
+		location = &(*p.IncludedLocationResourcesReferencedByLocation)[0]
 	}
 	return
 }
 
-func (p *ProvenancePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (p *ProvenancePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if p.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *p.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *p.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if p.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *p.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if p.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *p.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if p.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *p.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if p.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *p.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if p.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *p.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *p.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *p.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if p.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *p.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *p.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if p.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *p.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (p *ProvenancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if p.IncludedAgentPractitionerResources != nil {
-		for _, r := range *p.IncludedAgentPractitionerResources {
+	if p.IncludedPractitionerResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByAgent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedAgentOrganizationResources != nil {
-		for _, r := range *p.IncludedAgentOrganizationResources {
+	if p.IncludedOrganizationResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByAgent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedAgentDeviceResources != nil {
-		for _, r := range *p.IncludedAgentDeviceResources {
+	if p.IncludedDeviceResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedDeviceResourcesReferencedByAgent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedAgentPatientResources != nil {
-		for _, r := range *p.IncludedAgentPatientResources {
+	if p.IncludedPatientResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByAgent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedAgentRelatedPersonResources != nil {
-		for _, r := range *p.IncludedAgentRelatedPersonResources {
+	if p.IncludedRelatedPersonResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedPatientResources != nil {
-		for _, r := range *p.IncludedPatientResources {
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if p.IncludedLocationResources != nil {
-		for _, r := range *p.IncludedLocationResources {
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProvenancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (p *ProvenancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if p.IncludedPractitionerResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedPractitionerResourcesReferencedByAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedOrganizationResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedOrganizationResourcesReferencedByAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedDeviceResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedDeviceResourcesReferencedByAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedRelatedPersonResourcesReferencedByAgent != nil {
+		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.IncludedLocationResourcesReferencedByLocation != nil {
+		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *p.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/questionnaire.go
+++ b/models/questionnaire.go
@@ -110,14 +110,364 @@ type QuestionnaireQuestionComponent struct {
 }
 
 type QuestionnairePlus struct {
-	Questionnaire             `bson:",inline"`
-	QuestionnairePlusIncludes `bson:",inline"`
+	Questionnaire                     `bson:",inline"`
+	QuestionnairePlusRelatedResources `bson:",inline"`
 }
 
-type QuestionnairePlusIncludes struct {
+type QuestionnairePlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget                   *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref         *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref         *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                           *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref        *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                        *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                       *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                 *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                   *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated            *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment           *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingQuestionnaire,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject       *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest             *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger          *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                  *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (q *QuestionnairePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if q.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *q.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *q.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *q.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if q.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *q.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if q.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *q.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if q.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *q.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if q.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *q.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if q.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *q.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if q.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *q.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *q.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *q.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if q.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *q.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *q.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if q.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *q.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (q *QuestionnairePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (q *QuestionnairePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *q.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (q *QuestionnairePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *q.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -120,182 +120,602 @@ type QuestionnaireResponseQuestionAnswerComponent struct {
 }
 
 type QuestionnaireResponsePlus struct {
-	QuestionnaireResponse             `bson:",inline"`
-	QuestionnaireResponsePlusIncludes `bson:",inline"`
+	QuestionnaireResponse                     `bson:",inline"`
+	QuestionnaireResponsePlusRelatedResources `bson:",inline"`
 }
 
-type QuestionnaireResponsePlusIncludes struct {
-	IncludedQuestionnaireResources       *[]Questionnaire `bson:"_includedQuestionnaireResources,omitempty"`
-	IncludedAuthorPractitionerResources  *[]Practitioner  `bson:"_includedAuthorPractitionerResources,omitempty"`
-	IncludedAuthorDeviceResources        *[]Device        `bson:"_includedAuthorDeviceResources,omitempty"`
-	IncludedAuthorPatientResources       *[]Patient       `bson:"_includedAuthorPatientResources,omitempty"`
-	IncludedAuthorRelatedPersonResources *[]RelatedPerson `bson:"_includedAuthorRelatedPersonResources,omitempty"`
-	IncludedPatientResources             *[]Patient       `bson:"_includedPatientResources,omitempty"`
-	IncludedEncounterResources           *[]Encounter     `bson:"_includedEncounterResources,omitempty"`
-	IncludedSourcePractitionerResources  *[]Practitioner  `bson:"_includedSourcePractitionerResources,omitempty"`
-	IncludedSourcePatientResources       *[]Patient       `bson:"_includedSourcePatientResources,omitempty"`
-	IncludedSourceRelatedPersonResources *[]RelatedPerson `bson:"_includedSourceRelatedPersonResources,omitempty"`
+type QuestionnaireResponsePlusRelatedResources struct {
+	IncludedQuestionnaireResourcesReferencedByQuestionnaire        *[]Questionnaire         `bson:"_includedQuestionnaireResourcesReferencedByQuestionnaire,omitempty"`
+	IncludedPractitionerResourcesReferencedByAuthor                *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByAuthor,omitempty"`
+	IncludedDeviceResourcesReferencedByAuthor                      *[]Device                `bson:"_includedDeviceResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByAuthor                     *[]Patient               `bson:"_includedPatientResourcesReferencedByAuthor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByAuthor               *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByAuthor,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                    *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter                *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	IncludedPractitionerResourcesReferencedBySource                *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySource,omitempty"`
+	IncludedPatientResourcesReferencedBySource                     *[]Patient               `bson:"_includedPatientResourcesReferencedBySource,omitempty"`
+	IncludedRelatedPersonResourcesReferencedBySource               *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedBySource,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref      *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                        *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref     *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                     *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedObservationResourcesReferencingRelatedtarget        *[]Observation           `bson:"_revIncludedObservationResourcesReferencingRelatedtarget,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                    *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference             *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated         *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment        *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject    *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest          *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingInvestigation *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingInvestigation,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData               *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedQuestionnaireResource() (questionnaire *Questionnaire, err error) {
-	if q.IncludedQuestionnaireResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedQuestionnaireResourceReferencedByQuestionnaire() (questionnaire *Questionnaire, err error) {
+	if q.IncludedQuestionnaireResourcesReferencedByQuestionnaire == nil {
 		err = errors.New("Included questionnaires not requested")
-	} else if len(*q.IncludedQuestionnaireResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 questionnaire, but found %d", len(*q.IncludedQuestionnaireResources))
-	} else if len(*q.IncludedQuestionnaireResources) == 1 {
-		questionnaire = &(*q.IncludedQuestionnaireResources)[0]
+	} else if len(*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 questionnaire, but found %d", len(*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire))
+	} else if len(*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire) == 1 {
+		questionnaire = &(*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorPractitionerResource() (practitioner *Practitioner, err error) {
-	if q.IncludedAuthorPractitionerResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedByAuthor() (practitioner *Practitioner, err error) {
+	if q.IncludedPractitionerResourcesReferencedByAuthor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*q.IncludedAuthorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedAuthorPractitionerResources))
-	} else if len(*q.IncludedAuthorPractitionerResources) == 1 {
-		practitioner = &(*q.IncludedAuthorPractitionerResources)[0]
+	} else if len(*q.IncludedPractitionerResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedPractitionerResourcesReferencedByAuthor))
+	} else if len(*q.IncludedPractitionerResourcesReferencedByAuthor) == 1 {
+		practitioner = &(*q.IncludedPractitionerResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorDeviceResource() (device *Device, err error) {
-	if q.IncludedAuthorDeviceResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedDeviceResourceReferencedByAuthor() (device *Device, err error) {
+	if q.IncludedDeviceResourcesReferencedByAuthor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*q.IncludedAuthorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*q.IncludedAuthorDeviceResources))
-	} else if len(*q.IncludedAuthorDeviceResources) == 1 {
-		device = &(*q.IncludedAuthorDeviceResources)[0]
+	} else if len(*q.IncludedDeviceResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*q.IncludedDeviceResourcesReferencedByAuthor))
+	} else if len(*q.IncludedDeviceResourcesReferencedByAuthor) == 1 {
+		device = &(*q.IncludedDeviceResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorPatientResource() (patient *Patient, err error) {
-	if q.IncludedAuthorPatientResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedPatientResourceReferencedByAuthor() (patient *Patient, err error) {
+	if q.IncludedPatientResourcesReferencedByAuthor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*q.IncludedAuthorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedAuthorPatientResources))
-	} else if len(*q.IncludedAuthorPatientResources) == 1 {
-		patient = &(*q.IncludedAuthorPatientResources)[0]
+	} else if len(*q.IncludedPatientResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedPatientResourcesReferencedByAuthor))
+	} else if len(*q.IncludedPatientResourcesReferencedByAuthor) == 1 {
+		patient = &(*q.IncludedPatientResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedAuthorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if q.IncludedAuthorRelatedPersonResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByAuthor() (relatedPerson *RelatedPerson, err error) {
+	if q.IncludedRelatedPersonResourcesReferencedByAuthor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*q.IncludedAuthorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedAuthorRelatedPersonResources))
-	} else if len(*q.IncludedAuthorRelatedPersonResources) == 1 {
-		relatedPerson = &(*q.IncludedAuthorRelatedPersonResources)[0]
+	} else if len(*q.IncludedRelatedPersonResourcesReferencedByAuthor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedRelatedPersonResourcesReferencedByAuthor))
+	} else if len(*q.IncludedRelatedPersonResourcesReferencedByAuthor) == 1 {
+		relatedPerson = &(*q.IncludedRelatedPersonResourcesReferencedByAuthor)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if q.IncludedPatientResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if q.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*q.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedPatientResources))
-	} else if len(*q.IncludedPatientResources) == 1 {
-		patient = &(*q.IncludedPatientResources)[0]
+	} else if len(*q.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*q.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*q.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if q.IncludedEncounterResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if q.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*q.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*q.IncludedEncounterResources))
-	} else if len(*q.IncludedEncounterResources) == 1 {
-		encounter = &(*q.IncludedEncounterResources)[0]
+	} else if len(*q.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*q.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*q.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*q.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
-	if q.IncludedSourcePractitionerResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedPractitionerResourceReferencedBySource() (practitioner *Practitioner, err error) {
+	if q.IncludedPractitionerResourcesReferencedBySource == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*q.IncludedSourcePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedSourcePractitionerResources))
-	} else if len(*q.IncludedSourcePractitionerResources) == 1 {
-		practitioner = &(*q.IncludedSourcePractitionerResources)[0]
+	} else if len(*q.IncludedPractitionerResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*q.IncludedPractitionerResourcesReferencedBySource))
+	} else if len(*q.IncludedPractitionerResourcesReferencedBySource) == 1 {
+		practitioner = &(*q.IncludedPractitionerResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
-	if q.IncludedSourcePatientResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedPatientResourceReferencedBySource() (patient *Patient, err error) {
+	if q.IncludedPatientResourcesReferencedBySource == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*q.IncludedSourcePatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedSourcePatientResources))
-	} else if len(*q.IncludedSourcePatientResources) == 1 {
-		patient = &(*q.IncludedSourcePatientResources)[0]
+	} else if len(*q.IncludedPatientResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*q.IncludedPatientResourcesReferencedBySource))
+	} else if len(*q.IncludedPatientResourcesReferencedBySource) == 1 {
+		patient = &(*q.IncludedPatientResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedSourceRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if q.IncludedSourceRelatedPersonResources == nil {
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedBySource() (relatedPerson *RelatedPerson, err error) {
+	if q.IncludedRelatedPersonResourcesReferencedBySource == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*q.IncludedSourceRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedSourceRelatedPersonResources))
-	} else if len(*q.IncludedSourceRelatedPersonResources) == 1 {
-		relatedPerson = &(*q.IncludedSourceRelatedPersonResources)[0]
+	} else if len(*q.IncludedRelatedPersonResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*q.IncludedRelatedPersonResourcesReferencedBySource))
+	} else if len(*q.IncludedRelatedPersonResourcesReferencedBySource) == 1 {
+		relatedPerson = &(*q.IncludedRelatedPersonResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (q *QuestionnaireResponsePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if q.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *q.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *q.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *q.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if q.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *q.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if q.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *q.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedObservationResourcesReferencingRelatedtarget() (observations []Observation, err error) {
+	if q.RevIncludedObservationResourcesReferencingRelatedtarget == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *q.RevIncludedObservationResourcesReferencingRelatedtarget
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if q.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *q.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if q.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *q.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if q.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *q.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if q.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *q.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *q.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *q.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if q.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *q.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *q.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingInvestigation() (clinicalImpressions []ClinicalImpression, err error) {
+	if q.RevIncludedClinicalImpressionResourcesReferencingInvestigation == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if q.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *q.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if q.IncludedQuestionnaireResources != nil {
-		for _, r := range *q.IncludedQuestionnaireResources {
+	if q.IncludedQuestionnaireResourcesReferencedByQuestionnaire != nil {
+		for _, r := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedAuthorPractitionerResources != nil {
-		for _, r := range *q.IncludedAuthorPractitionerResources {
+	if q.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedPractitionerResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedAuthorDeviceResources != nil {
-		for _, r := range *q.IncludedAuthorDeviceResources {
+	if q.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedDeviceResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedAuthorPatientResources != nil {
-		for _, r := range *q.IncludedAuthorPatientResources {
+	if q.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedAuthorRelatedPersonResources != nil {
-		for _, r := range *q.IncludedAuthorRelatedPersonResources {
+	if q.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedPatientResources != nil {
-		for _, r := range *q.IncludedPatientResources {
+	if q.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedEncounterResources != nil {
-		for _, r := range *q.IncludedEncounterResources {
+	if q.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *q.IncludedEncounterResourcesReferencedByEncounter {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedSourcePractitionerResources != nil {
-		for _, r := range *q.IncludedSourcePractitionerResources {
+	if q.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedPractitionerResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedSourcePatientResources != nil {
-		for _, r := range *q.IncludedSourcePatientResources {
+	if q.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if q.IncludedSourceRelatedPersonResources != nil {
-		for _, r := range *q.IncludedSourceRelatedPersonResources {
+	if q.IncludedRelatedPersonResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedRelatedPersonResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *q.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
+		for _, r := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if q.IncludedQuestionnaireResourcesReferencedByQuestionnaire != nil {
+		for _, r := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPractitionerResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedPractitionerResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedDeviceResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedDeviceResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPatientResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
+		for _, r := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *q.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedPractitionerResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedPatientResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.IncludedRelatedPersonResourcesReferencedBySource != nil {
+		for _, r := range *q.IncludedRelatedPersonResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *q.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
+		for _, r := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
+		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/referralrequest.go
+++ b/models/referralrequest.go
@@ -95,110 +95,590 @@ func (x *ReferralRequest) checkResourceType() error {
 }
 
 type ReferralRequestPlus struct {
-	ReferralRequest             `bson:",inline"`
-	ReferralRequestPlusIncludes `bson:",inline"`
+	ReferralRequest                     `bson:",inline"`
+	ReferralRequestPlusRelatedResources `bson:",inline"`
 }
 
-type ReferralRequestPlusIncludes struct {
-	IncludedRequesterPractitionerResources *[]Practitioner `bson:"_includedRequesterPractitionerResources,omitempty"`
-	IncludedRequesterOrganizationResources *[]Organization `bson:"_includedRequesterOrganizationResources,omitempty"`
-	IncludedRequesterPatientResources      *[]Patient      `bson:"_includedRequesterPatientResources,omitempty"`
-	IncludedPatientResources               *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedRecipientPractitionerResources *[]Practitioner `bson:"_includedRecipientPractitionerResources,omitempty"`
-	IncludedRecipientOrganizationResources *[]Organization `bson:"_includedRecipientOrganizationResources,omitempty"`
+type ReferralRequestPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByRequester           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRequester,omitempty"`
+	IncludedOrganizationResourcesReferencedByRequester           *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRequester,omitempty"`
+	IncludedPatientResourcesReferencedByRequester                *[]Patient               `bson:"_includedPatientResourcesReferencedByRequester,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                  *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByRecipient           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByRecipient,omitempty"`
+	IncludedOrganizationResourcesReferencedByRecipient           *[]Organization          `bson:"_includedOrganizationResourcesReferencedByRecipient,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget              *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref    *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference     *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral *[]EpisodeOfCare         `bson:"_revIncludedEpisodeOfCareResourcesReferencingIncomingreferral,omitempty"`
+	RevIncludedListResourcesReferencingItem                      *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref   *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                   *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                  *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingRequest       *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingRequest,omitempty"`
+	RevIncludedEncounterResourcesReferencingIncomingreferral     *[]Encounter             `bson:"_revIncludedEncounterResourcesReferencingIncomingreferral,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference           *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject            *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry              *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated       *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment      *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject  *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest        *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction      *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan        *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData             *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedRequesterPractitionerResource() (practitioner *Practitioner, err error) {
-	if r.IncludedRequesterPractitionerResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedByRequester() (practitioner *Practitioner, err error) {
+	if r.IncludedPractitionerResourcesReferencedByRequester == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*r.IncludedRequesterPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedRequesterPractitionerResources))
-	} else if len(*r.IncludedRequesterPractitionerResources) == 1 {
-		practitioner = &(*r.IncludedRequesterPractitionerResources)[0]
+	} else if len(*r.IncludedPractitionerResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedPractitionerResourcesReferencedByRequester))
+	} else if len(*r.IncludedPractitionerResourcesReferencedByRequester) == 1 {
+		practitioner = &(*r.IncludedPractitionerResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedRequesterOrganizationResource() (organization *Organization, err error) {
-	if r.IncludedRequesterOrganizationResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedOrganizationResourceReferencedByRequester() (organization *Organization, err error) {
+	if r.IncludedOrganizationResourcesReferencedByRequester == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*r.IncludedRequesterOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*r.IncludedRequesterOrganizationResources))
-	} else if len(*r.IncludedRequesterOrganizationResources) == 1 {
-		organization = &(*r.IncludedRequesterOrganizationResources)[0]
+	} else if len(*r.IncludedOrganizationResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*r.IncludedOrganizationResourcesReferencedByRequester))
+	} else if len(*r.IncludedOrganizationResourcesReferencedByRequester) == 1 {
+		organization = &(*r.IncludedOrganizationResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedRequesterPatientResource() (patient *Patient, err error) {
-	if r.IncludedRequesterPatientResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByRequester() (patient *Patient, err error) {
+	if r.IncludedPatientResourcesReferencedByRequester == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*r.IncludedRequesterPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedRequesterPatientResources))
-	} else if len(*r.IncludedRequesterPatientResources) == 1 {
-		patient = &(*r.IncludedRequesterPatientResources)[0]
+	} else if len(*r.IncludedPatientResourcesReferencedByRequester) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResourcesReferencedByRequester))
+	} else if len(*r.IncludedPatientResourcesReferencedByRequester) == 1 {
+		patient = &(*r.IncludedPatientResourcesReferencedByRequester)[0]
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if r.IncludedPatientResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if r.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*r.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResources))
-	} else if len(*r.IncludedPatientResources) == 1 {
-		patient = &(*r.IncludedPatientResources)[0]
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*r.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedRecipientPractitionerResources() (practitioners []Practitioner, err error) {
-	if r.IncludedRecipientPractitionerResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByRecipient() (practitioners []Practitioner, err error) {
+	if r.IncludedPractitionerResourcesReferencedByRecipient == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *r.IncludedRecipientPractitionerResources
+		practitioners = *r.IncludedPractitionerResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedRecipientOrganizationResources() (organizations []Organization, err error) {
-	if r.IncludedRecipientOrganizationResources == nil {
+func (r *ReferralRequestPlusRelatedResources) GetIncludedOrganizationResourcesReferencedByRecipient() (organizations []Organization, err error) {
+	if r.IncludedOrganizationResourcesReferencedByRecipient == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *r.IncludedRecipientOrganizationResources
+		organizations = *r.IncludedOrganizationResourcesReferencedByRecipient
 	}
 	return
 }
 
-func (r *ReferralRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if r.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *r.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if r.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *r.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedEpisodeOfCareResourcesReferencingIncomingreferral() (episodeOfCares []EpisodeOfCare, err error) {
+	if r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral == nil {
+		err = errors.New("RevIncluded episodeOfCares not requested")
+	} else {
+		episodeOfCares = *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if r.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *r.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if r.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *r.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if r.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *r.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingRequest() (diagnosticReports []DiagnosticReport, err error) {
+	if r.RevIncludedDiagnosticReportResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *r.RevIncludedDiagnosticReportResourcesReferencingRequest
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingIncomingreferral() (encounters []Encounter, err error) {
+	if r.RevIncludedEncounterResourcesReferencingIncomingreferral == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *r.RevIncludedEncounterResourcesReferencingIncomingreferral
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if r.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *r.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *r.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *r.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if r.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *r.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *r.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if r.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *r.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if r.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *r.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if r.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *r.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if r.IncludedRequesterPractitionerResources != nil {
-		for _, r := range *r.IncludedRequesterPractitionerResources {
+	if r.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedRequesterOrganizationResources != nil {
-		for _, r := range *r.IncludedRequesterOrganizationResources {
+	if r.IncludedOrganizationResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedOrganizationResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedRequesterPatientResources != nil {
-		for _, r := range *r.IncludedRequesterPatientResources {
+	if r.IncludedPatientResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByRequester {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedPatientResources != nil {
-		for _, r := range *r.IncludedPatientResources {
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedRecipientPractitionerResources != nil {
-		for _, r := range *r.IncludedRecipientPractitionerResources {
+	if r.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByRecipient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedRecipientOrganizationResources != nil {
-		for _, r := range *r.IncludedRecipientOrganizationResources {
+	if r.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *r.IncludedOrganizationResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral != nil {
+		for _, r := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEncounterResourcesReferencingIncomingreferral != nil {
+		for _, r := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *ReferralRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.IncludedPractitionerResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedOrganizationResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedOrganizationResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResourcesReferencedByRequester != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPractitionerResourcesReferencedByRecipient != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedOrganizationResourcesReferencedByRecipient != nil {
+		for _, r := range *r.IncludedOrganizationResourcesReferencedByRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral != nil {
+		for _, r := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEncounterResourcesReferencingIncomingreferral != nil {
+		for _, r := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/relatedperson.go
+++ b/models/relatedperson.go
@@ -89,29 +89,1004 @@ func (x *RelatedPerson) checkResourceType() error {
 }
 
 type RelatedPersonPlus struct {
-	RelatedPerson             `bson:",inline"`
-	RelatedPersonPlusIncludes `bson:",inline"`
+	RelatedPerson                     `bson:",inline"`
+	RelatedPersonPlusRelatedResources `bson:",inline"`
 }
 
-type RelatedPersonPlusIncludes struct {
-	IncludedPatientResources *[]Patient `bson:"_includedPatientResources,omitempty"`
+type RelatedPersonPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                         *[]Patient                  `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	RevIncludedAppointmentResourcesReferencingActor                     *[]Appointment              `bson:"_revIncludedAppointmentResourcesReferencingActor,omitempty"`
+	RevIncludedProvenanceResourcesReferencingAgent                      *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingAgent,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget                     *[]Provenance               `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingAuthor               *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref           *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRecipient            *[]DocumentManifest         `bson:"_revIncludedDocumentManifestResourcesReferencingRecipient,omitempty"`
+	RevIncludedAllergyIntoleranceResourcesReferencingReporter           *[]AllergyIntolerance       `bson:"_revIncludedAllergyIntoleranceResourcesReferencingReporter,omitempty"`
+	RevIncludedCarePlanResourcesReferencingPerformer                    *[]CarePlan                 `bson:"_revIncludedCarePlanResourcesReferencingPerformer,omitempty"`
+	RevIncludedCarePlanResourcesReferencingParticipant                  *[]CarePlan                 `bson:"_revIncludedCarePlanResourcesReferencingParticipant,omitempty"`
+	RevIncludedProcedureResourcesReferencingPerformer                   *[]Procedure                `bson:"_revIncludedProcedureResourcesReferencingPerformer,omitempty"`
+	RevIncludedListResourcesReferencingItem                             *[]List                     `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingAuthor              *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingAuthor,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref          *[]DocumentReference        `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                          *[]Order                    `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingPerformer            *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingPerformer,omitempty"`
+	RevIncludedProcedureRequestResourcesReferencingOrderer              *[]ProcedureRequest         `bson:"_revIncludedProcedureRequestResourcesReferencingOrderer,omitempty"`
+	RevIncludedAppointmentResponseResourcesReferencingActor             *[]AppointmentResponse      `bson:"_revIncludedAppointmentResponseResourcesReferencingActor,omitempty"`
+	RevIncludedObservationResourcesReferencingPerformer                 *[]Observation              `bson:"_revIncludedObservationResourcesReferencingPerformer,omitempty"`
+	RevIncludedMedicationAdministrationResourcesReferencingPractitioner *[]MedicationAdministration `bson:"_revIncludedMedicationAdministrationResourcesReferencingPractitioner,omitempty"`
+	RevIncludedMedicationStatementResourcesReferencingSource            *[]MedicationStatement      `bson:"_revIncludedMedicationStatementResourcesReferencingSource,omitempty"`
+	RevIncludedPersonResourcesReferencingLink                           *[]Person                   `bson:"_revIncludedPersonResourcesReferencingLink,omitempty"`
+	RevIncludedPersonResourcesReferencingRelatedperson                  *[]Person                   `bson:"_revIncludedPersonResourcesReferencingRelatedperson,omitempty"`
+	RevIncludedContractResourcesReferencingActor                        *[]Contract                 `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedContractResourcesReferencingSigner                       *[]Contract                 `bson:"_revIncludedContractResourcesReferencingSigner,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRequester        *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingRequester,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingSender           *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationRequestResourcesReferencingRecipient        *[]CommunicationRequest     `bson:"_revIncludedCommunicationRequestResourcesReferencingRecipient,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                         *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedBasicResourcesReferencingAuthor                          *[]Basic                    `bson:"_revIncludedBasicResourcesReferencingAuthor,omitempty"`
+	RevIncludedImagingObjectSelectionResourcesReferencingAuthor         *[]ImagingObjectSelection   `bson:"_revIncludedImagingObjectSelectionResourcesReferencingAuthor,omitempty"`
+	RevIncludedEncounterResourcesReferencingParticipant                 *[]Encounter                `bson:"_revIncludedEncounterResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingParticipant                *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingParticipant,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference                  *[]AuditEvent               `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCommunicationResourcesReferencingSender                  *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingSender,omitempty"`
+	RevIncludedCommunicationResourcesReferencingRecipient               *[]Communication            `bson:"_revIncludedCommunicationResourcesReferencingRecipient,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject                   *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingAuthor                    *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingAuthor,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry                     *[]Composition              `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated              *[]DetectedIssue            `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment             *[]OrderResponse            `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject         *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingAuthor          *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingAuthor,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSource          *[]QuestionnaireResponse    `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSource,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest               *[]ProcessResponse          `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedScheduleResourcesReferencingActor                        *[]Schedule                 `bson:"_revIncludedScheduleResourcesReferencingActor,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger            *[]ClinicalImpression       `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData                    *[]MessageHeader            `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (r *RelatedPersonPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if r.IncludedPatientResources == nil {
+func (r *RelatedPersonPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if r.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*r.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResources))
-	} else if len(*r.IncludedPatientResources) == 1 {
-		patient = &(*r.IncludedPatientResources)[0]
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*r.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (r *RelatedPersonPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedAppointmentResourcesReferencingActor() (appointments []Appointment, err error) {
+	if r.RevIncludedAppointmentResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointments not requested")
+	} else {
+		appointments = *r.RevIncludedAppointmentResourcesReferencingActor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingAgent() (provenances []Provenance, err error) {
+	if r.RevIncludedProvenanceResourcesReferencingAgent == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *r.RevIncludedProvenanceResourcesReferencingAgent
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if r.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *r.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingAuthor() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRecipient() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedAllergyIntoleranceResourcesReferencingReporter() (allergyIntolerances []AllergyIntolerance, err error) {
+	if r.RevIncludedAllergyIntoleranceResourcesReferencingReporter == nil {
+		err = errors.New("RevIncluded allergyIntolerances not requested")
+	} else {
+		allergyIntolerances = *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingPerformer() (carePlans []CarePlan, err error) {
+	if r.RevIncludedCarePlanResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *r.RevIncludedCarePlanResourcesReferencingPerformer
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingParticipant() (carePlans []CarePlan, err error) {
+	if r.RevIncludedCarePlanResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *r.RevIncludedCarePlanResourcesReferencingParticipant
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProcedureResourcesReferencingPerformer() (procedures []Procedure, err error) {
+	if r.RevIncludedProcedureResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedures not requested")
+	} else {
+		procedures = *r.RevIncludedProcedureResourcesReferencingPerformer
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if r.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *r.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingAuthor() (documentReferences []DocumentReference, err error) {
+	if r.RevIncludedDocumentReferenceResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *r.RevIncludedDocumentReferenceResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if r.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *r.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingPerformer() (procedureRequests []ProcedureRequest, err error) {
+	if r.RevIncludedProcedureRequestResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *r.RevIncludedProcedureRequestResourcesReferencingPerformer
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProcedureRequestResourcesReferencingOrderer() (procedureRequests []ProcedureRequest, err error) {
+	if r.RevIncludedProcedureRequestResourcesReferencingOrderer == nil {
+		err = errors.New("RevIncluded procedureRequests not requested")
+	} else {
+		procedureRequests = *r.RevIncludedProcedureRequestResourcesReferencingOrderer
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedAppointmentResponseResourcesReferencingActor() (appointmentResponses []AppointmentResponse, err error) {
+	if r.RevIncludedAppointmentResponseResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded appointmentResponses not requested")
+	} else {
+		appointmentResponses = *r.RevIncludedAppointmentResponseResourcesReferencingActor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedObservationResourcesReferencingPerformer() (observations []Observation, err error) {
+	if r.RevIncludedObservationResourcesReferencingPerformer == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *r.RevIncludedObservationResourcesReferencingPerformer
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedMedicationAdministrationResourcesReferencingPractitioner() (medicationAdministrations []MedicationAdministration, err error) {
+	if r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner == nil {
+		err = errors.New("RevIncluded medicationAdministrations not requested")
+	} else {
+		medicationAdministrations = *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedMedicationStatementResourcesReferencingSource() (medicationStatements []MedicationStatement, err error) {
+	if r.RevIncludedMedicationStatementResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded medicationStatements not requested")
+	} else {
+		medicationStatements = *r.RevIncludedMedicationStatementResourcesReferencingSource
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedPersonResourcesReferencingLink() (people []Person, err error) {
+	if r.RevIncludedPersonResourcesReferencingLink == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *r.RevIncludedPersonResourcesReferencingLink
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedPersonResourcesReferencingRelatedperson() (people []Person, err error) {
+	if r.RevIncludedPersonResourcesReferencingRelatedperson == nil {
+		err = errors.New("RevIncluded people not requested")
+	} else {
+		people = *r.RevIncludedPersonResourcesReferencingRelatedperson
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if r.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *r.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedContractResourcesReferencingSigner() (contracts []Contract, err error) {
+	if r.RevIncludedContractResourcesReferencingSigner == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *r.RevIncludedContractResourcesReferencingSigner
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRequester() (communicationRequests []CommunicationRequest, err error) {
+	if r.RevIncludedCommunicationRequestResourcesReferencingRequester == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *r.RevIncludedCommunicationRequestResourcesReferencingRequester
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingSender() (communicationRequests []CommunicationRequest, err error) {
+	if r.RevIncludedCommunicationRequestResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *r.RevIncludedCommunicationRequestResourcesReferencingSender
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCommunicationRequestResourcesReferencingRecipient() (communicationRequests []CommunicationRequest, err error) {
+	if r.RevIncludedCommunicationRequestResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communicationRequests not requested")
+	} else {
+		communicationRequests = *r.RevIncludedCommunicationRequestResourcesReferencingRecipient
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if r.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *r.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedBasicResourcesReferencingAuthor() (basics []Basic, err error) {
+	if r.RevIncludedBasicResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *r.RevIncludedBasicResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedImagingObjectSelectionResourcesReferencingAuthor() (imagingObjectSelections []ImagingObjectSelection, err error) {
+	if r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded imagingObjectSelections not requested")
+	} else {
+		imagingObjectSelections = *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedEncounterResourcesReferencingParticipant() (encounters []Encounter, err error) {
+	if r.RevIncludedEncounterResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded encounters not requested")
+	} else {
+		encounters = *r.RevIncludedEncounterResourcesReferencingParticipant
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingParticipant() (auditEvents []AuditEvent, err error) {
+	if r.RevIncludedAuditEventResourcesReferencingParticipant == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *r.RevIncludedAuditEventResourcesReferencingParticipant
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if r.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *r.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingSender() (communications []Communication, err error) {
+	if r.RevIncludedCommunicationResourcesReferencingSender == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *r.RevIncludedCommunicationResourcesReferencingSender
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCommunicationResourcesReferencingRecipient() (communications []Communication, err error) {
+	if r.RevIncludedCommunicationResourcesReferencingRecipient == nil {
+		err = errors.New("RevIncluded communications not requested")
+	} else {
+		communications = *r.RevIncludedCommunicationResourcesReferencingRecipient
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingAuthor() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *r.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *r.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingAuthor() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSource() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *r.RevIncludedQuestionnaireResponseResourcesReferencingSource
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if r.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *r.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedScheduleResourcesReferencingActor() (schedules []Schedule, err error) {
+	if r.RevIncludedScheduleResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded schedules not requested")
+	} else {
+		schedules = *r.RevIncludedScheduleResourcesReferencingActor
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *r.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if r.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *r.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if r.IncludedPatientResources != nil {
-		for _, r := range *r.IncludedPatientResources {
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *r.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedPersonResourcesReferencingRelatedperson != nil {
+		for _, r := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *r.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEncounterResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedEncounterResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *r.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *RelatedPersonPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAppointmentResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedAppointmentResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingAgent != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingAgent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
+		for _, r := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCarePlanResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedProcedureResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
+		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedObservationResourcesReferencingPerformer != nil {
+		for _, r := range *r.RevIncludedObservationResourcesReferencingPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
+		for _, r := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMedicationStatementResourcesReferencingSource != nil {
+		for _, r := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedPersonResourcesReferencingLink != nil {
+		for _, r := range *r.RevIncludedPersonResourcesReferencingLink {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedPersonResourcesReferencingRelatedperson != nil {
+		for _, r := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedContractResourcesReferencingSigner != nil {
+		for _, r := range *r.RevIncludedContractResourcesReferencingSigner {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedEncounterResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedEncounterResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingParticipant != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationResourcesReferencingSender != nil {
+		for _, r := range *r.RevIncludedCommunicationResourcesReferencingSender {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCommunicationResourcesReferencingRecipient != nil {
+		for _, r := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedScheduleResourcesReferencingActor != nil {
+		for _, r := range *r.RevIncludedScheduleResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -100,131 +100,496 @@ type RiskAssessmentPredictionComponent struct {
 }
 
 type RiskAssessmentPlus struct {
-	RiskAssessment             `bson:",inline"`
-	RiskAssessmentPlusIncludes `bson:",inline"`
+	RiskAssessment                     `bson:",inline"`
+	RiskAssessmentPlusRelatedResources `bson:",inline"`
 }
 
-type RiskAssessmentPlusIncludes struct {
-	IncludedConditionResources             *[]Condition    `bson:"_includedConditionResources,omitempty"`
-	IncludedPerformerPractitionerResources *[]Practitioner `bson:"_includedPerformerPractitionerResources,omitempty"`
-	IncludedPerformerDeviceResources       *[]Device       `bson:"_includedPerformerDeviceResources,omitempty"`
-	IncludedSubjectGroupResources          *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectPatientResources        *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedPatientResources               *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedEncounterResources             *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type RiskAssessmentPlusRelatedResources struct {
+	IncludedConditionResourcesReferencedByCondition             *[]Condition             `bson:"_includedConditionResourcesReferencedByCondition,omitempty"`
+	IncludedPractitionerResourcesReferencedByPerformer          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPerformer,omitempty"`
+	IncludedDeviceResourcesReferencedByPerformer                *[]Device                `bson:"_includedDeviceResourcesReferencedByPerformer,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedConditionResource() (condition *Condition, err error) {
-	if r.IncludedConditionResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedConditionResourceReferencedByCondition() (condition *Condition, err error) {
+	if r.IncludedConditionResourcesReferencedByCondition == nil {
 		err = errors.New("Included conditions not requested")
-	} else if len(*r.IncludedConditionResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 condition, but found %d", len(*r.IncludedConditionResources))
-	} else if len(*r.IncludedConditionResources) == 1 {
-		condition = &(*r.IncludedConditionResources)[0]
+	} else if len(*r.IncludedConditionResourcesReferencedByCondition) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 condition, but found %d", len(*r.IncludedConditionResourcesReferencedByCondition))
+	} else if len(*r.IncludedConditionResourcesReferencedByCondition) == 1 {
+		condition = &(*r.IncludedConditionResourcesReferencedByCondition)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedPerformerPractitionerResource() (practitioner *Practitioner, err error) {
-	if r.IncludedPerformerPractitionerResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPerformer() (practitioner *Practitioner, err error) {
+	if r.IncludedPractitionerResourcesReferencedByPerformer == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*r.IncludedPerformerPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedPerformerPractitionerResources))
-	} else if len(*r.IncludedPerformerPractitionerResources) == 1 {
-		practitioner = &(*r.IncludedPerformerPractitionerResources)[0]
+	} else if len(*r.IncludedPractitionerResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*r.IncludedPractitionerResourcesReferencedByPerformer))
+	} else if len(*r.IncludedPractitionerResourcesReferencedByPerformer) == 1 {
+		practitioner = &(*r.IncludedPractitionerResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedPerformerDeviceResource() (device *Device, err error) {
-	if r.IncludedPerformerDeviceResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedDeviceResourceReferencedByPerformer() (device *Device, err error) {
+	if r.IncludedDeviceResourcesReferencedByPerformer == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*r.IncludedPerformerDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*r.IncludedPerformerDeviceResources))
-	} else if len(*r.IncludedPerformerDeviceResources) == 1 {
-		device = &(*r.IncludedPerformerDeviceResources)[0]
+	} else if len(*r.IncludedDeviceResourcesReferencedByPerformer) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*r.IncludedDeviceResourcesReferencedByPerformer))
+	} else if len(*r.IncludedDeviceResourcesReferencedByPerformer) == 1 {
+		device = &(*r.IncludedDeviceResourcesReferencedByPerformer)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if r.IncludedSubjectGroupResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if r.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*r.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*r.IncludedSubjectGroupResources))
-	} else if len(*r.IncludedSubjectGroupResources) == 1 {
-		group = &(*r.IncludedSubjectGroupResources)[0]
+	} else if len(*r.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*r.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*r.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*r.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if r.IncludedSubjectPatientResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if r.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*r.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedSubjectPatientResources))
-	} else if len(*r.IncludedSubjectPatientResources) == 1 {
-		patient = &(*r.IncludedSubjectPatientResources)[0]
+	} else if len(*r.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*r.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*r.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if r.IncludedPatientResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if r.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*r.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResources))
-	} else if len(*r.IncludedPatientResources) == 1 {
-		patient = &(*r.IncludedPatientResources)[0]
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*r.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*r.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*r.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if r.IncludedEncounterResources == nil {
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if r.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*r.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*r.IncludedEncounterResources))
-	} else if len(*r.IncludedEncounterResources) == 1 {
-		encounter = &(*r.IncludedEncounterResources)[0]
+	} else if len(*r.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*r.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*r.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*r.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (r *RiskAssessmentPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if r.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *r.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *r.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if r.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *r.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if r.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *r.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if r.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *r.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if r.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *r.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if r.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *r.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *r.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *r.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if r.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *r.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *r.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if r.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *r.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if r.IncludedConditionResources != nil {
-		for _, r := range *r.IncludedConditionResources {
+	if r.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *r.IncludedConditionResourcesReferencedByCondition {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedPerformerPractitionerResources != nil {
-		for _, r := range *r.IncludedPerformerPractitionerResources {
+	if r.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedPerformerDeviceResources != nil {
-		for _, r := range *r.IncludedPerformerDeviceResources {
+	if r.IncludedDeviceResourcesReferencedByPerformer != nil {
+		for _, r := range *r.IncludedDeviceResourcesReferencedByPerformer {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedSubjectGroupResources != nil {
-		for _, r := range *r.IncludedSubjectGroupResources {
+	if r.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *r.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedSubjectPatientResources != nil {
-		for _, r := range *r.IncludedSubjectPatientResources {
+	if r.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedPatientResources != nil {
-		for _, r := range *r.IncludedPatientResources {
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if r.IncludedEncounterResources != nil {
-		for _, r := range *r.IncludedEncounterResources {
+	if r.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *r.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (r *RiskAssessmentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if r.IncludedConditionResourcesReferencedByCondition != nil {
+		for _, r := range *r.IncludedConditionResourcesReferencedByCondition {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPractitionerResourcesReferencedByPerformer != nil {
+		for _, r := range *r.IncludedPractitionerResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedDeviceResourcesReferencedByPerformer != nil {
+		for _, r := range *r.IncludedDeviceResourcesReferencedByPerformer {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *r.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *r.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *r.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -84,114 +84,494 @@ func (x *Schedule) checkResourceType() error {
 }
 
 type SchedulePlus struct {
-	Schedule             `bson:",inline"`
-	SchedulePlusIncludes `bson:",inline"`
+	Schedule                     `bson:",inline"`
+	SchedulePlusRelatedResources `bson:",inline"`
 }
 
-type SchedulePlusIncludes struct {
-	IncludedActorPractitionerResources      *[]Practitioner      `bson:"_includedActorPractitionerResources,omitempty"`
-	IncludedActorDeviceResources            *[]Device            `bson:"_includedActorDeviceResources,omitempty"`
-	IncludedActorPatientResources           *[]Patient           `bson:"_includedActorPatientResources,omitempty"`
-	IncludedActorHealthcareServiceResources *[]HealthcareService `bson:"_includedActorHealthcareServiceResources,omitempty"`
-	IncludedActorRelatedPersonResources     *[]RelatedPerson     `bson:"_includedActorRelatedPersonResources,omitempty"`
-	IncludedActorLocationResources          *[]Location          `bson:"_includedActorLocationResources,omitempty"`
+type SchedulePlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByActor              *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByActor,omitempty"`
+	IncludedDeviceResourcesReferencedByActor                    *[]Device                `bson:"_includedDeviceResourcesReferencedByActor,omitempty"`
+	IncludedPatientResourcesReferencedByActor                   *[]Patient               `bson:"_includedPatientResourcesReferencedByActor,omitempty"`
+	IncludedHealthcareServiceResourcesReferencedByActor         *[]HealthcareService     `bson:"_includedHealthcareServiceResourcesReferencedByActor,omitempty"`
+	IncludedRelatedPersonResourcesReferencedByActor             *[]RelatedPerson         `bson:"_includedRelatedPersonResourcesReferencedByActor,omitempty"`
+	IncludedLocationResourcesReferencedByActor                  *[]Location              `bson:"_includedLocationResourcesReferencedByActor,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedSlotResourcesReferencingSchedule                 *[]Slot                  `bson:"_revIncludedSlotResourcesReferencingSchedule,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorPractitionerResource() (practitioner *Practitioner, err error) {
-	if s.IncludedActorPractitionerResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedPractitionerResourceReferencedByActor() (practitioner *Practitioner, err error) {
+	if s.IncludedPractitionerResourcesReferencedByActor == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*s.IncludedActorPractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedActorPractitionerResources))
-	} else if len(*s.IncludedActorPractitionerResources) == 1 {
-		practitioner = &(*s.IncludedActorPractitionerResources)[0]
+	} else if len(*s.IncludedPractitionerResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedPractitionerResourcesReferencedByActor))
+	} else if len(*s.IncludedPractitionerResourcesReferencedByActor) == 1 {
+		practitioner = &(*s.IncludedPractitionerResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorDeviceResource() (device *Device, err error) {
-	if s.IncludedActorDeviceResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedDeviceResourceReferencedByActor() (device *Device, err error) {
+	if s.IncludedDeviceResourcesReferencedByActor == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*s.IncludedActorDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedActorDeviceResources))
-	} else if len(*s.IncludedActorDeviceResources) == 1 {
-		device = &(*s.IncludedActorDeviceResources)[0]
+	} else if len(*s.IncludedDeviceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedDeviceResourcesReferencedByActor))
+	} else if len(*s.IncludedDeviceResourcesReferencedByActor) == 1 {
+		device = &(*s.IncludedDeviceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorPatientResource() (patient *Patient, err error) {
-	if s.IncludedActorPatientResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedPatientResourceReferencedByActor() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedByActor == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedActorPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedActorPatientResources))
-	} else if len(*s.IncludedActorPatientResources) == 1 {
-		patient = &(*s.IncludedActorPatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedByActor))
+	} else if len(*s.IncludedPatientResourcesReferencedByActor) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorHealthcareServiceResource() (healthcareService *HealthcareService, err error) {
-	if s.IncludedActorHealthcareServiceResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedHealthcareServiceResourceReferencedByActor() (healthcareService *HealthcareService, err error) {
+	if s.IncludedHealthcareServiceResourcesReferencedByActor == nil {
 		err = errors.New("Included healthcareservices not requested")
-	} else if len(*s.IncludedActorHealthcareServiceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*s.IncludedActorHealthcareServiceResources))
-	} else if len(*s.IncludedActorHealthcareServiceResources) == 1 {
-		healthcareService = &(*s.IncludedActorHealthcareServiceResources)[0]
+	} else if len(*s.IncludedHealthcareServiceResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 healthcareService, but found %d", len(*s.IncludedHealthcareServiceResourcesReferencedByActor))
+	} else if len(*s.IncludedHealthcareServiceResourcesReferencedByActor) == 1 {
+		healthcareService = &(*s.IncludedHealthcareServiceResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorRelatedPersonResource() (relatedPerson *RelatedPerson, err error) {
-	if s.IncludedActorRelatedPersonResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedRelatedPersonResourceReferencedByActor() (relatedPerson *RelatedPerson, err error) {
+	if s.IncludedRelatedPersonResourcesReferencedByActor == nil {
 		err = errors.New("Included relatedpeople not requested")
-	} else if len(*s.IncludedActorRelatedPersonResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*s.IncludedActorRelatedPersonResources))
-	} else if len(*s.IncludedActorRelatedPersonResources) == 1 {
-		relatedPerson = &(*s.IncludedActorRelatedPersonResources)[0]
+	} else if len(*s.IncludedRelatedPersonResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 relatedPerson, but found %d", len(*s.IncludedRelatedPersonResourcesReferencedByActor))
+	} else if len(*s.IncludedRelatedPersonResourcesReferencedByActor) == 1 {
+		relatedPerson = &(*s.IncludedRelatedPersonResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedActorLocationResource() (location *Location, err error) {
-	if s.IncludedActorLocationResources == nil {
+func (s *SchedulePlusRelatedResources) GetIncludedLocationResourceReferencedByActor() (location *Location, err error) {
+	if s.IncludedLocationResourcesReferencedByActor == nil {
 		err = errors.New("Included locations not requested")
-	} else if len(*s.IncludedActorLocationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*s.IncludedActorLocationResources))
-	} else if len(*s.IncludedActorLocationResources) == 1 {
-		location = &(*s.IncludedActorLocationResources)[0]
+	} else if len(*s.IncludedLocationResourcesReferencedByActor) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 location, but found %d", len(*s.IncludedLocationResourcesReferencedByActor))
+	} else if len(*s.IncludedLocationResourcesReferencedByActor) == 1 {
+		location = &(*s.IncludedLocationResourcesReferencedByActor)[0]
 	}
 	return
 }
 
-func (s *SchedulePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SchedulePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedSlotResourcesReferencingSchedule() (slots []Slot, err error) {
+	if s.RevIncludedSlotResourcesReferencingSchedule == nil {
+		err = errors.New("RevIncluded slots not requested")
+	} else {
+		slots = *s.RevIncludedSlotResourcesReferencingSchedule
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SchedulePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedActorPractitionerResources != nil {
-		for _, r := range *s.IncludedActorPractitionerResources {
+	if s.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedActorDeviceResources != nil {
-		for _, r := range *s.IncludedActorDeviceResources {
+	if s.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedDeviceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedActorPatientResources != nil {
-		for _, r := range *s.IncludedActorPatientResources {
+	if s.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedActorHealthcareServiceResources != nil {
-		for _, r := range *s.IncludedActorHealthcareServiceResources {
+	if s.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedActorRelatedPersonResources != nil {
-		for _, r := range *s.IncludedActorRelatedPersonResources {
+	if s.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedRelatedPersonResourcesReferencedByActor {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedActorLocationResources != nil {
-		for _, r := range *s.IncludedActorLocationResources {
+	if s.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedLocationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SchedulePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSlotResourcesReferencingSchedule != nil {
+		for _, r := range *s.RevIncludedSlotResourcesReferencingSchedule {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SchedulePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedPractitionerResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedDeviceResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedDeviceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedHealthcareServiceResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedRelatedPersonResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedRelatedPersonResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedLocationResourcesReferencedByActor != nil {
+		for _, r := range *s.IncludedLocationResourcesReferencedByActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSlotResourcesReferencingSchedule != nil {
+		for _, r := range *s.RevIncludedSlotResourcesReferencingSchedule {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/searchparameter.go
+++ b/models/searchparameter.go
@@ -99,14 +99,344 @@ type SearchParameterContactComponent struct {
 }
 
 type SearchParameterPlus struct {
-	SearchParameter             `bson:",inline"`
-	SearchParameterPlusIncludes `bson:",inline"`
+	SearchParameter                     `bson:",inline"`
+	SearchParameterPlusRelatedResources `bson:",inline"`
 }
 
-type SearchParameterPlusIncludes struct {
+type SearchParameterPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SearchParameterPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SearchParameterPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (s *SearchParameterPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SearchParameterPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/slot.go
+++ b/models/slot.go
@@ -87,29 +87,364 @@ func (x *Slot) checkResourceType() error {
 }
 
 type SlotPlus struct {
-	Slot             `bson:",inline"`
-	SlotPlusIncludes `bson:",inline"`
+	Slot                     `bson:",inline"`
+	SlotPlusRelatedResources `bson:",inline"`
 }
 
-type SlotPlusIncludes struct {
-	IncludedScheduleResources *[]Schedule `bson:"_includedScheduleResources,omitempty"`
+type SlotPlusRelatedResources struct {
+	IncludedScheduleResourcesReferencedBySchedule               *[]Schedule              `bson:"_includedScheduleResourcesReferencedBySchedule,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SlotPlusIncludes) GetIncludedScheduleResource() (schedule *Schedule, err error) {
-	if s.IncludedScheduleResources == nil {
+func (s *SlotPlusRelatedResources) GetIncludedScheduleResourceReferencedBySchedule() (schedule *Schedule, err error) {
+	if s.IncludedScheduleResourcesReferencedBySchedule == nil {
 		err = errors.New("Included schedules not requested")
-	} else if len(*s.IncludedScheduleResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 schedule, but found %d", len(*s.IncludedScheduleResources))
-	} else if len(*s.IncludedScheduleResources) == 1 {
-		schedule = &(*s.IncludedScheduleResources)[0]
+	} else if len(*s.IncludedScheduleResourcesReferencedBySchedule) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 schedule, but found %d", len(*s.IncludedScheduleResourcesReferencedBySchedule))
+	} else if len(*s.IncludedScheduleResourcesReferencedBySchedule) == 1 {
+		schedule = &(*s.IncludedScheduleResourcesReferencedBySchedule)[0]
 	}
 	return
 }
 
-func (s *SlotPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SlotPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SlotPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedScheduleResources != nil {
-		for _, r := range *s.IncludedScheduleResources {
+	if s.IncludedScheduleResourcesReferencedBySchedule != nil {
+		for _, r := range *s.IncludedScheduleResourcesReferencedBySchedule {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SlotPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SlotPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedScheduleResourcesReferencedBySchedule != nil {
+		for _, r := range *s.IncludedScheduleResourcesReferencedBySchedule {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/specimen.go
+++ b/models/specimen.go
@@ -115,129 +115,614 @@ type SpecimenContainerComponent struct {
 }
 
 type SpecimenPlus struct {
-	Specimen             `bson:",inline"`
-	SpecimenPlusIncludes `bson:",inline"`
+	Specimen                     `bson:",inline"`
+	SpecimenPlusRelatedResources `bson:",inline"`
 }
 
-type SpecimenPlusIncludes struct {
-	IncludedParentResources           *[]Specimen     `bson:"_includedParentResources,omitempty"`
-	IncludedSubjectGroupResources     *[]Group        `bson:"_includedSubjectGroupResources,omitempty"`
-	IncludedSubjectDeviceResources    *[]Device       `bson:"_includedSubjectDeviceResources,omitempty"`
-	IncludedSubjectPatientResources   *[]Patient      `bson:"_includedSubjectPatientResources,omitempty"`
-	IncludedSubjectSubstanceResources *[]Substance    `bson:"_includedSubjectSubstanceResources,omitempty"`
-	IncludedPatientResources          *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedCollectorResources        *[]Practitioner `bson:"_includedCollectorResources,omitempty"`
+type SpecimenPlusRelatedResources struct {
+	IncludedSpecimenResourcesReferencedByParent                 *[]Specimen              `bson:"_includedSpecimenResourcesReferencedByParent,omitempty"`
+	IncludedGroupResourcesReferencedBySubject                   *[]Group                 `bson:"_includedGroupResourcesReferencedBySubject,omitempty"`
+	IncludedDeviceResourcesReferencedBySubject                  *[]Device                `bson:"_includedDeviceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedBySubject                 *[]Patient               `bson:"_includedPatientResourcesReferencedBySubject,omitempty"`
+	IncludedSubstanceResourcesReferencedBySubject               *[]Substance             `bson:"_includedSubstanceResourcesReferencedBySubject,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedByCollector          *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByCollector,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedSpecimenResourcesReferencingParent               *[]Specimen              `bson:"_revIncludedSpecimenResourcesReferencingParent,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedMediaResourcesReferencingSubject                 *[]Media                 `bson:"_revIncludedMediaResourcesReferencingSubject,omitempty"`
+	RevIncludedObservationResourcesReferencingSpecimen          *[]Observation           `bson:"_revIncludedObservationResourcesReferencingSpecimen,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedDiagnosticReportResourcesReferencingSpecimen     *[]DiagnosticReport      `bson:"_revIncludedDiagnosticReportResourcesReferencingSpecimen,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 *[]DiagnosticOrder       `bson:"_revIncludedDiagnosticOrderResourcesReferencingSpecimenPath1,omitempty"`
+	RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 *[]DiagnosticOrder       `bson:"_revIncludedDiagnosticOrderResourcesReferencingSpecimenPath2,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedParentResources() (specimen []Specimen, err error) {
-	if s.IncludedParentResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedSpecimenResourcesReferencedByParent() (specimen []Specimen, err error) {
+	if s.IncludedSpecimenResourcesReferencedByParent == nil {
 		err = errors.New("Included specimen not requested")
 	} else {
-		specimen = *s.IncludedParentResources
+		specimen = *s.IncludedSpecimenResourcesReferencedByParent
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedSubjectGroupResource() (group *Group, err error) {
-	if s.IncludedSubjectGroupResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedGroupResourceReferencedBySubject() (group *Group, err error) {
+	if s.IncludedGroupResourcesReferencedBySubject == nil {
 		err = errors.New("Included groups not requested")
-	} else if len(*s.IncludedSubjectGroupResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*s.IncludedSubjectGroupResources))
-	} else if len(*s.IncludedSubjectGroupResources) == 1 {
-		group = &(*s.IncludedSubjectGroupResources)[0]
+	} else if len(*s.IncludedGroupResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 group, but found %d", len(*s.IncludedGroupResourcesReferencedBySubject))
+	} else if len(*s.IncludedGroupResourcesReferencedBySubject) == 1 {
+		group = &(*s.IncludedGroupResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedSubjectDeviceResource() (device *Device, err error) {
-	if s.IncludedSubjectDeviceResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedDeviceResourceReferencedBySubject() (device *Device, err error) {
+	if s.IncludedDeviceResourcesReferencedBySubject == nil {
 		err = errors.New("Included devices not requested")
-	} else if len(*s.IncludedSubjectDeviceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedSubjectDeviceResources))
-	} else if len(*s.IncludedSubjectDeviceResources) == 1 {
-		device = &(*s.IncludedSubjectDeviceResources)[0]
+	} else if len(*s.IncludedDeviceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 device, but found %d", len(*s.IncludedDeviceResourcesReferencedBySubject))
+	} else if len(*s.IncludedDeviceResourcesReferencedBySubject) == 1 {
+		device = &(*s.IncludedDeviceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedSubjectPatientResource() (patient *Patient, err error) {
-	if s.IncludedSubjectPatientResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedPatientResourceReferencedBySubject() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedBySubject == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedSubjectPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedSubjectPatientResources))
-	} else if len(*s.IncludedSubjectPatientResources) == 1 {
-		patient = &(*s.IncludedSubjectPatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedBySubject))
+	} else if len(*s.IncludedPatientResourcesReferencedBySubject) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedSubjectSubstanceResource() (substance *Substance, err error) {
-	if s.IncludedSubjectSubstanceResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedSubstanceResourceReferencedBySubject() (substance *Substance, err error) {
+	if s.IncludedSubstanceResourcesReferencedBySubject == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*s.IncludedSubjectSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*s.IncludedSubjectSubstanceResources))
-	} else if len(*s.IncludedSubjectSubstanceResources) == 1 {
-		substance = &(*s.IncludedSubjectSubstanceResources)[0]
+	} else if len(*s.IncludedSubstanceResourcesReferencedBySubject) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*s.IncludedSubstanceResourcesReferencedBySubject))
+	} else if len(*s.IncludedSubstanceResourcesReferencedBySubject) == 1 {
+		substance = &(*s.IncludedSubstanceResourcesReferencedBySubject)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if s.IncludedPatientResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResources))
-	} else if len(*s.IncludedPatientResources) == 1 {
-		patient = &(*s.IncludedPatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedCollectorResource() (practitioner *Practitioner, err error) {
-	if s.IncludedCollectorResources == nil {
+func (s *SpecimenPlusRelatedResources) GetIncludedPractitionerResourceReferencedByCollector() (practitioner *Practitioner, err error) {
+	if s.IncludedPractitionerResourcesReferencedByCollector == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*s.IncludedCollectorResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedCollectorResources))
-	} else if len(*s.IncludedCollectorResources) == 1 {
-		practitioner = &(*s.IncludedCollectorResources)[0]
+	} else if len(*s.IncludedPractitionerResourcesReferencedByCollector) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedPractitionerResourcesReferencedByCollector))
+	} else if len(*s.IncludedPractitionerResourcesReferencedByCollector) == 1 {
+		practitioner = &(*s.IncludedPractitionerResourcesReferencedByCollector)[0]
 	}
 	return
 }
 
-func (s *SpecimenPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SpecimenPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingParent() (specimen []Specimen, err error) {
+	if s.RevIncludedSpecimenResourcesReferencingParent == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *s.RevIncludedSpecimenResourcesReferencingParent
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedMediaResourcesReferencingSubject() (media []Media, err error) {
+	if s.RevIncludedMediaResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded media not requested")
+	} else {
+		media = *s.RevIncludedMediaResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedObservationResourcesReferencingSpecimen() (observations []Observation, err error) {
+	if s.RevIncludedObservationResourcesReferencingSpecimen == nil {
+		err = errors.New("RevIncluded observations not requested")
+	} else {
+		observations = *s.RevIncludedObservationResourcesReferencingSpecimen
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDiagnosticReportResourcesReferencingSpecimen() (diagnosticReports []DiagnosticReport, err error) {
+	if s.RevIncludedDiagnosticReportResourcesReferencingSpecimen == nil {
+		err = errors.New("RevIncluded diagnosticReports not requested")
+	} else {
+		diagnosticReports = *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1() (diagnosticOrders []DiagnosticOrder, err error) {
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2() (diagnosticOrders []DiagnosticOrder, err error) {
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 == nil {
+		err = errors.New("RevIncluded diagnosticOrders not requested")
+	} else {
+		diagnosticOrders = *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SpecimenPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedParentResources != nil {
-		for _, r := range *s.IncludedParentResources {
+	if s.IncludedSpecimenResourcesReferencedByParent != nil {
+		for _, r := range *s.IncludedSpecimenResourcesReferencedByParent {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSubjectGroupResources != nil {
-		for _, r := range *s.IncludedSubjectGroupResources {
+	if s.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedGroupResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSubjectDeviceResources != nil {
-		for _, r := range *s.IncludedSubjectDeviceResources {
+	if s.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedDeviceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSubjectPatientResources != nil {
-		for _, r := range *s.IncludedSubjectPatientResources {
+	if s.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSubjectSubstanceResources != nil {
-		for _, r := range *s.IncludedSubjectSubstanceResources {
+	if s.IncludedSubstanceResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubject {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedPatientResources != nil {
-		for _, r := range *s.IncludedPatientResources {
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedCollectorResources != nil {
-		for _, r := range *s.IncludedCollectorResources {
+	if s.IncludedPractitionerResourcesReferencedByCollector != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByCollector {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SpecimenPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSpecimenResourcesReferencingParent != nil {
+		for _, r := range *s.RevIncludedSpecimenResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedObservationResourcesReferencingSpecimen != nil {
+		for _, r := range *s.RevIncludedObservationResourcesReferencingSpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticReportResourcesReferencingSpecimen != nil {
+		for _, r := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 != nil {
+		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 != nil {
+		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SpecimenPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedSpecimenResourcesReferencedByParent != nil {
+		for _, r := range *s.IncludedSpecimenResourcesReferencedByParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedGroupResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedGroupResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedDeviceResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedDeviceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedSubstanceResourcesReferencedBySubject != nil {
+		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPractitionerResourcesReferencedByCollector != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByCollector {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSpecimenResourcesReferencingParent != nil {
+		for _, r := range *s.RevIncludedSpecimenResourcesReferencingParent {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMediaResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedMediaResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedObservationResourcesReferencingSpecimen != nil {
+		for _, r := range *s.RevIncludedObservationResourcesReferencingSpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticReportResourcesReferencingSpecimen != nil {
+		for _, r := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 != nil {
+		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 != nil {
+		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/structuredefinition.go
+++ b/models/structuredefinition.go
@@ -124,29 +124,484 @@ type StructureDefinitionDifferentialComponent struct {
 }
 
 type StructureDefinitionPlus struct {
-	StructureDefinition             `bson:",inline"`
-	StructureDefinitionPlusIncludes `bson:",inline"`
+	StructureDefinition                     `bson:",inline"`
+	StructureDefinitionPlusRelatedResources `bson:",inline"`
 }
 
-type StructureDefinitionPlusIncludes struct {
-	IncludedValuesetResources *[]ValueSet `bson:"_includedValuesetResources,omitempty"`
+type StructureDefinitionPlusRelatedResources struct {
+	IncludedValueSetResourcesReferencedByValueset               *[]ValueSet              `bson:"_includedValueSetResourcesReferencedByValueset,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedConceptMapResourcesReferencingSource             *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingSource,omitempty"`
+	RevIncludedConceptMapResourcesReferencingTarget             *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingTarget,omitempty"`
+	RevIncludedConceptMapResourcesReferencingSourceuri          *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingSourceuri,omitempty"`
+	RevIncludedOperationDefinitionResourcesReferencingProfile   *[]OperationDefinition   `bson:"_revIncludedOperationDefinitionResourcesReferencingProfile,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedConformanceResourcesReferencingProfile           *[]Conformance           `bson:"_revIncludedConformanceResourcesReferencingProfile,omitempty"`
+	RevIncludedConformanceResourcesReferencingSupportedprofile  *[]Conformance           `bson:"_revIncludedConformanceResourcesReferencingSupportedprofile,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *StructureDefinitionPlusIncludes) GetIncludedValuesetResource() (valueSet *ValueSet, err error) {
-	if s.IncludedValuesetResources == nil {
+func (s *StructureDefinitionPlusRelatedResources) GetIncludedValueSetResourceReferencedByValueset() (valueSet *ValueSet, err error) {
+	if s.IncludedValueSetResourcesReferencedByValueset == nil {
 		err = errors.New("Included valuesets not requested")
-	} else if len(*s.IncludedValuesetResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*s.IncludedValuesetResources))
-	} else if len(*s.IncludedValuesetResources) == 1 {
-		valueSet = &(*s.IncludedValuesetResources)[0]
+	} else if len(*s.IncludedValueSetResourcesReferencedByValueset) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 valueSet, but found %d", len(*s.IncludedValueSetResourcesReferencedByValueset))
+	} else if len(*s.IncludedValueSetResourcesReferencedByValueset) == 1 {
+		valueSet = &(*s.IncludedValueSetResourcesReferencedByValueset)[0]
 	}
 	return
 }
 
-func (s *StructureDefinitionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingSource() (conceptMaps []ConceptMap, err error) {
+	if s.RevIncludedConceptMapResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *s.RevIncludedConceptMapResourcesReferencingSource
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingTarget() (conceptMaps []ConceptMap, err error) {
+	if s.RevIncludedConceptMapResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *s.RevIncludedConceptMapResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingSourceuri() (conceptMaps []ConceptMap, err error) {
+	if s.RevIncludedConceptMapResourcesReferencingSourceuri == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *s.RevIncludedConceptMapResourcesReferencingSourceuri
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedOperationDefinitionResourcesReferencingProfile() (operationDefinitions []OperationDefinition, err error) {
+	if s.RevIncludedOperationDefinitionResourcesReferencingProfile == nil {
+		err = errors.New("RevIncluded operationDefinitions not requested")
+	} else {
+		operationDefinitions = *s.RevIncludedOperationDefinitionResourcesReferencingProfile
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedConformanceResourcesReferencingProfile() (conformances []Conformance, err error) {
+	if s.RevIncludedConformanceResourcesReferencingProfile == nil {
+		err = errors.New("RevIncluded conformances not requested")
+	} else {
+		conformances = *s.RevIncludedConformanceResourcesReferencingProfile
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedConformanceResourcesReferencingSupportedprofile() (conformances []Conformance, err error) {
+	if s.RevIncludedConformanceResourcesReferencingSupportedprofile == nil {
+		err = errors.New("RevIncluded conformances not requested")
+	} else {
+		conformances = *s.RevIncludedConformanceResourcesReferencingSupportedprofile
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedValuesetResources != nil {
-		for _, r := range *s.IncludedValuesetResources {
+	if s.IncludedValueSetResourcesReferencedByValueset != nil {
+		for _, r := range *s.IncludedValueSetResourcesReferencedByValueset {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingSource != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOperationDefinitionResourcesReferencingProfile != nil {
+		for _, r := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConformanceResourcesReferencingProfile != nil {
+		for _, r := range *s.RevIncludedConformanceResourcesReferencingProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConformanceResourcesReferencingSupportedprofile != nil {
+		for _, r := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *StructureDefinitionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedValueSetResourcesReferencedByValueset != nil {
+		for _, r := range *s.IncludedValueSetResourcesReferencedByValueset {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingSource != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
+		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOperationDefinitionResourcesReferencingProfile != nil {
+		for _, r := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConformanceResourcesReferencingProfile != nil {
+		for _, r := range *s.RevIncludedConformanceResourcesReferencingProfile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedConformanceResourcesReferencingSupportedprofile != nil {
+		for _, r := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -94,14 +94,344 @@ type SubscriptionChannelComponent struct {
 }
 
 type SubscriptionPlus struct {
-	Subscription             `bson:",inline"`
-	SubscriptionPlusIncludes `bson:",inline"`
+	Subscription                     `bson:",inline"`
+	SubscriptionPlusRelatedResources `bson:",inline"`
 }
 
-type SubscriptionPlusIncludes struct {
+type SubscriptionPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SubscriptionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SubscriptionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (s *SubscriptionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SubscriptionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/substance.go
+++ b/models/substance.go
@@ -96,29 +96,484 @@ type SubstanceIngredientComponent struct {
 }
 
 type SubstancePlus struct {
-	Substance             `bson:",inline"`
-	SubstancePlusIncludes `bson:",inline"`
+	Substance                     `bson:",inline"`
+	SubstancePlusRelatedResources `bson:",inline"`
 }
 
-type SubstancePlusIncludes struct {
-	IncludedSubstanceResources *[]Substance `bson:"_includedSubstanceResources,omitempty"`
+type SubstancePlusRelatedResources struct {
+	IncludedSubstanceResourcesReferencedBySubstance             *[]Substance             `bson:"_includedSubstanceResourcesReferencedBySubstance,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedSpecimenResourcesReferencingSubject              *[]Specimen              `bson:"_revIncludedSpecimenResourcesReferencingSubject,omitempty"`
+	RevIncludedMedicationResourcesReferencingIngredient         *[]Medication            `bson:"_revIncludedMedicationResourcesReferencingIngredient,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingSubject                 *[]Order                 `bson:"_revIncludedOrderResourcesReferencingSubject,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedContractResourcesReferencingActor                *[]Contract              `bson:"_revIncludedContractResourcesReferencingActor,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedGroupResourcesReferencingMember                  *[]Group                 `bson:"_revIncludedGroupResourcesReferencingMember,omitempty"`
+	RevIncludedSubstanceResourcesReferencingSubstance           *[]Substance             `bson:"_revIncludedSubstanceResourcesReferencingSubstance,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SubstancePlusIncludes) GetIncludedSubstanceResource() (substance *Substance, err error) {
-	if s.IncludedSubstanceResources == nil {
+func (s *SubstancePlusRelatedResources) GetIncludedSubstanceResourceReferencedBySubstance() (substance *Substance, err error) {
+	if s.IncludedSubstanceResourcesReferencedBySubstance == nil {
 		err = errors.New("Included substances not requested")
-	} else if len(*s.IncludedSubstanceResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*s.IncludedSubstanceResources))
-	} else if len(*s.IncludedSubstanceResources) == 1 {
-		substance = &(*s.IncludedSubstanceResources)[0]
+	} else if len(*s.IncludedSubstanceResourcesReferencedBySubstance) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 substance, but found %d", len(*s.IncludedSubstanceResourcesReferencedBySubstance))
+	} else if len(*s.IncludedSubstanceResourcesReferencedBySubstance) == 1 {
+		substance = &(*s.IncludedSubstanceResourcesReferencedBySubstance)[0]
 	}
 	return
 }
 
-func (s *SubstancePlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SubstancePlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedSpecimenResourcesReferencingSubject() (specimen []Specimen, err error) {
+	if s.RevIncludedSpecimenResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded specimen not requested")
+	} else {
+		specimen = *s.RevIncludedSpecimenResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedMedicationResourcesReferencingIngredient() (medications []Medication, err error) {
+	if s.RevIncludedMedicationResourcesReferencingIngredient == nil {
+		err = errors.New("RevIncluded medications not requested")
+	} else {
+		medications = *s.RevIncludedMedicationResourcesReferencingIngredient
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedOrderResourcesReferencingSubject() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedContractResourcesReferencingActor() (contracts []Contract, err error) {
+	if s.RevIncludedContractResourcesReferencingActor == nil {
+		err = errors.New("RevIncluded contracts not requested")
+	} else {
+		contracts = *s.RevIncludedContractResourcesReferencingActor
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedGroupResourcesReferencingMember() (groups []Group, err error) {
+	if s.RevIncludedGroupResourcesReferencingMember == nil {
+		err = errors.New("RevIncluded groups not requested")
+	} else {
+		groups = *s.RevIncludedGroupResourcesReferencingMember
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedSubstanceResourcesReferencingSubstance() (substances []Substance, err error) {
+	if s.RevIncludedSubstanceResourcesReferencingSubstance == nil {
+		err = errors.New("RevIncluded substances not requested")
+	} else {
+		substances = *s.RevIncludedSubstanceResourcesReferencingSubstance
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SubstancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedSubstanceResources != nil {
-		for _, r := range *s.IncludedSubstanceResources {
+	if s.IncludedSubstanceResourcesReferencedBySubstance != nil {
+		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubstance {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SubstancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMedicationResourcesReferencingIngredient != nil {
+		for _, r := range *s.RevIncludedMedicationResourcesReferencingIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *s.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *s.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSubstanceResourcesReferencingSubstance != nil {
+		for _, r := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SubstancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedSubstanceResourcesReferencedBySubstance != nil {
+		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubstance {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSpecimenResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedSpecimenResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMedicationResourcesReferencingIngredient != nil {
+		for _, r := range *s.RevIncludedMedicationResourcesReferencingIngredient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedContractResourcesReferencingActor != nil {
+		for _, r := range *s.RevIncludedContractResourcesReferencingActor {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedGroupResourcesReferencingMember != nil {
+		for _, r := range *s.RevIncludedGroupResourcesReferencingMember {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedSubstanceResourcesReferencingSubstance != nil {
+		for _, r := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/supplydelivery.go
+++ b/models/supplydelivery.go
@@ -90,61 +90,406 @@ func (x *SupplyDelivery) checkResourceType() error {
 }
 
 type SupplyDeliveryPlus struct {
-	SupplyDelivery             `bson:",inline"`
-	SupplyDeliveryPlusIncludes `bson:",inline"`
+	SupplyDelivery                     `bson:",inline"`
+	SupplyDeliveryPlusRelatedResources `bson:",inline"`
 }
 
-type SupplyDeliveryPlusIncludes struct {
-	IncludedReceiverResources *[]Practitioner `bson:"_includedReceiverResources,omitempty"`
-	IncludedPatientResources  *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedSupplierResources *[]Practitioner `bson:"_includedSupplierResources,omitempty"`
+type SupplyDeliveryPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByReceiver           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByReceiver,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedPractitionerResourcesReferencedBySupplier           *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySupplier,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SupplyDeliveryPlusIncludes) GetIncludedReceiverResources() (practitioners []Practitioner, err error) {
-	if s.IncludedReceiverResources == nil {
+func (s *SupplyDeliveryPlusRelatedResources) GetIncludedPractitionerResourcesReferencedByReceiver() (practitioners []Practitioner, err error) {
+	if s.IncludedPractitionerResourcesReferencedByReceiver == nil {
 		err = errors.New("Included practitioners not requested")
 	} else {
-		practitioners = *s.IncludedReceiverResources
+		practitioners = *s.IncludedPractitionerResourcesReferencedByReceiver
 	}
 	return
 }
 
-func (s *SupplyDeliveryPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if s.IncludedPatientResources == nil {
+func (s *SupplyDeliveryPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResources))
-	} else if len(*s.IncludedPatientResources) == 1 {
-		patient = &(*s.IncludedPatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (s *SupplyDeliveryPlusIncludes) GetIncludedSupplierResource() (practitioner *Practitioner, err error) {
-	if s.IncludedSupplierResources == nil {
+func (s *SupplyDeliveryPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySupplier() (practitioner *Practitioner, err error) {
+	if s.IncludedPractitionerResourcesReferencedBySupplier == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*s.IncludedSupplierResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedSupplierResources))
-	} else if len(*s.IncludedSupplierResources) == 1 {
-		practitioner = &(*s.IncludedSupplierResources)[0]
+	} else if len(*s.IncludedPractitionerResourcesReferencedBySupplier) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedPractitionerResourcesReferencedBySupplier))
+	} else if len(*s.IncludedPractitionerResourcesReferencedBySupplier) == 1 {
+		practitioner = &(*s.IncludedPractitionerResourcesReferencedBySupplier)[0]
 	}
 	return
 }
 
-func (s *SupplyDeliveryPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedReceiverResources != nil {
-		for _, r := range *s.IncludedReceiverResources {
+	if s.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByReceiver {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedPatientResources != nil {
-		for _, r := range *s.IncludedPatientResources {
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSupplierResources != nil {
-		for _, r := range *s.IncludedSupplierResources {
+	if s.IncludedPractitionerResourcesReferencedBySupplier != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedBySupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SupplyDeliveryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedPractitionerResourcesReferencedByReceiver != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedByReceiver {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPractitionerResourcesReferencedBySupplier != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedBySupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/supplyrequest.go
+++ b/models/supplyrequest.go
@@ -95,95 +95,510 @@ type SupplyRequestWhenComponent struct {
 }
 
 type SupplyRequestPlus struct {
-	SupplyRequest             `bson:",inline"`
-	SupplyRequestPlusIncludes `bson:",inline"`
+	SupplyRequest                     `bson:",inline"`
+	SupplyRequestPlusRelatedResources `bson:",inline"`
 }
 
-type SupplyRequestPlusIncludes struct {
-	IncludedPatientResources            *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedSupplierResources           *[]Organization `bson:"_includedSupplierResources,omitempty"`
-	IncludedSourcePractitionerResources *[]Practitioner `bson:"_includedSourcePractitionerResources,omitempty"`
-	IncludedSourceOrganizationResources *[]Organization `bson:"_includedSourceOrganizationResources,omitempty"`
-	IncludedSourcePatientResources      *[]Patient      `bson:"_includedSourcePatientResources,omitempty"`
+type SupplyRequestPlusRelatedResources struct {
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedOrganizationResourcesReferencedBySupplier           *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySupplier,omitempty"`
+	IncludedPractitionerResourcesReferencedBySource             *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedBySource,omitempty"`
+	IncludedOrganizationResourcesReferencedBySource             *[]Organization          `bson:"_includedOrganizationResourcesReferencedBySource,omitempty"`
+	IncludedPatientResourcesReferencedBySource                  *[]Patient               `bson:"_includedPatientResourcesReferencedBySource,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingAction     *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingAction,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if s.IncludedPatientResources == nil {
+func (s *SupplyRequestPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResources))
-	} else if len(*s.IncludedPatientResources) == 1 {
-		patient = &(*s.IncludedPatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*s.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedSupplierResources() (organizations []Organization, err error) {
-	if s.IncludedSupplierResources == nil {
+func (s *SupplyRequestPlusRelatedResources) GetIncludedOrganizationResourcesReferencedBySupplier() (organizations []Organization, err error) {
+	if s.IncludedOrganizationResourcesReferencedBySupplier == nil {
 		err = errors.New("Included organizations not requested")
 	} else {
-		organizations = *s.IncludedSupplierResources
+		organizations = *s.IncludedOrganizationResourcesReferencedBySupplier
 	}
 	return
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedSourcePractitionerResource() (practitioner *Practitioner, err error) {
-	if s.IncludedSourcePractitionerResources == nil {
+func (s *SupplyRequestPlusRelatedResources) GetIncludedPractitionerResourceReferencedBySource() (practitioner *Practitioner, err error) {
+	if s.IncludedPractitionerResourcesReferencedBySource == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*s.IncludedSourcePractitionerResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedSourcePractitionerResources))
-	} else if len(*s.IncludedSourcePractitionerResources) == 1 {
-		practitioner = &(*s.IncludedSourcePractitionerResources)[0]
+	} else if len(*s.IncludedPractitionerResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*s.IncludedPractitionerResourcesReferencedBySource))
+	} else if len(*s.IncludedPractitionerResourcesReferencedBySource) == 1 {
+		practitioner = &(*s.IncludedPractitionerResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedSourceOrganizationResource() (organization *Organization, err error) {
-	if s.IncludedSourceOrganizationResources == nil {
+func (s *SupplyRequestPlusRelatedResources) GetIncludedOrganizationResourceReferencedBySource() (organization *Organization, err error) {
+	if s.IncludedOrganizationResourcesReferencedBySource == nil {
 		err = errors.New("Included organizations not requested")
-	} else if len(*s.IncludedSourceOrganizationResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*s.IncludedSourceOrganizationResources))
-	} else if len(*s.IncludedSourceOrganizationResources) == 1 {
-		organization = &(*s.IncludedSourceOrganizationResources)[0]
+	} else if len(*s.IncludedOrganizationResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 organization, but found %d", len(*s.IncludedOrganizationResourcesReferencedBySource))
+	} else if len(*s.IncludedOrganizationResourcesReferencedBySource) == 1 {
+		organization = &(*s.IncludedOrganizationResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedSourcePatientResource() (patient *Patient, err error) {
-	if s.IncludedSourcePatientResources == nil {
+func (s *SupplyRequestPlusRelatedResources) GetIncludedPatientResourceReferencedBySource() (patient *Patient, err error) {
+	if s.IncludedPatientResourcesReferencedBySource == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*s.IncludedSourcePatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedSourcePatientResources))
-	} else if len(*s.IncludedSourcePatientResources) == 1 {
-		patient = &(*s.IncludedSourcePatientResources)[0]
+	} else if len(*s.IncludedPatientResourcesReferencedBySource) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*s.IncludedPatientResourcesReferencedBySource))
+	} else if len(*s.IncludedPatientResourcesReferencedBySource) == 1 {
+		patient = &(*s.IncludedPatientResourcesReferencedBySource)[0]
 	}
 	return
 }
 
-func (s *SupplyRequestPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if s.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *s.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *s.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if s.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *s.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if s.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *s.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if s.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *s.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if s.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *s.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if s.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *s.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if s.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *s.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *s.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *s.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if s.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *s.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingAction() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingAction == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingAction
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if s.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *s.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if s.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *s.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if s.IncludedPatientResources != nil {
-		for _, r := range *s.IncludedPatientResources {
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSupplierResources != nil {
-		for _, r := range *s.IncludedSupplierResources {
+	if s.IncludedOrganizationResourcesReferencedBySupplier != nil {
+		for _, r := range *s.IncludedOrganizationResourcesReferencedBySupplier {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSourcePractitionerResources != nil {
-		for _, r := range *s.IncludedSourcePractitionerResources {
+	if s.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSourceOrganizationResources != nil {
-		for _, r := range *s.IncludedSourceOrganizationResources {
+	if s.IncludedOrganizationResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedOrganizationResourcesReferencedBySource {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if s.IncludedSourcePatientResources != nil {
-		for _, r := range *s.IncludedSourcePatientResources {
+	if s.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (s *SupplyRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if s.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedOrganizationResourcesReferencedBySupplier != nil {
+		for _, r := range *s.IncludedOrganizationResourcesReferencedBySupplier {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPractitionerResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedPractitionerResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedOrganizationResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedOrganizationResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.IncludedPatientResourcesReferencedBySource != nil {
+		for _, r := range *s.IncludedPatientResourcesReferencedBySource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *s.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/models/testscript.go
+++ b/models/testscript.go
@@ -210,14 +210,344 @@ type TestScriptTeardownActionComponent struct {
 }
 
 type TestScriptPlus struct {
-	TestScript             `bson:",inline"`
-	TestScriptPlusIncludes `bson:",inline"`
+	TestScript                     `bson:",inline"`
+	TestScriptPlusRelatedResources `bson:",inline"`
 }
 
-type TestScriptPlusIncludes struct {
+type TestScriptPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (t *TestScriptPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (t *TestScriptPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if t.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *t.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if t.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *t.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if t.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *t.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if t.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *t.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if t.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if t.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *t.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if t.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *t.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if t.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *t.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if t.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *t.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if t.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *t.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if t.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *t.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if t.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *t.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if t.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if t.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *t.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if t.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *t.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if t.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *t.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (t *TestScriptPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (t *TestScriptPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if t.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *t.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *t.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *t.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *t.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *t.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *t.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (t *TestScriptPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if t.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *t.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *t.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *t.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *t.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *t.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if t.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *t.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/valueset.go
+++ b/models/valueset.go
@@ -178,14 +178,424 @@ type ValueSetExpansionContainsComponent struct {
 }
 
 type ValueSetPlus struct {
-	ValueSet             `bson:",inline"`
-	ValueSetPlusIncludes `bson:",inline"`
+	ValueSet                     `bson:",inline"`
+	ValueSetPlusRelatedResources `bson:",inline"`
 }
 
-type ValueSetPlusIncludes struct {
+type ValueSetPlusRelatedResources struct {
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedStructureDefinitionResourcesReferencingValueset  *[]StructureDefinition   `bson:"_revIncludedStructureDefinitionResourcesReferencingValueset,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedConceptMapResourcesReferencingSource             *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingSource,omitempty"`
+	RevIncludedConceptMapResourcesReferencingTarget             *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingTarget,omitempty"`
+	RevIncludedConceptMapResourcesReferencingSourceuri          *[]ConceptMap            `bson:"_revIncludedConceptMapResourcesReferencingSourceuri,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (v *ValueSetPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (v *ValueSetPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if v.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *v.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *v.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *v.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedStructureDefinitionResourcesReferencingValueset() (structureDefinitions []StructureDefinition, err error) {
+	if v.RevIncludedStructureDefinitionResourcesReferencingValueset == nil {
+		err = errors.New("RevIncluded structureDefinitions not requested")
+	} else {
+		structureDefinitions = *v.RevIncludedStructureDefinitionResourcesReferencingValueset
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if v.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *v.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingSource() (conceptMaps []ConceptMap, err error) {
+	if v.RevIncludedConceptMapResourcesReferencingSource == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *v.RevIncludedConceptMapResourcesReferencingSource
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingTarget() (conceptMaps []ConceptMap, err error) {
+	if v.RevIncludedConceptMapResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *v.RevIncludedConceptMapResourcesReferencingTarget
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedConceptMapResourcesReferencingSourceuri() (conceptMaps []ConceptMap, err error) {
+	if v.RevIncludedConceptMapResourcesReferencingSourceuri == nil {
+		err = errors.New("RevIncluded conceptMaps not requested")
+	} else {
+		conceptMaps = *v.RevIncludedConceptMapResourcesReferencingSourceuri
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if v.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *v.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if v.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *v.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if v.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *v.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if v.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *v.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if v.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *v.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *v.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *v.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if v.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *v.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *v.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if v.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *v.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (v *ValueSetPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
+	return resourceMap
+}
+
+func (v *ValueSetPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedStructureDefinitionResourcesReferencingValueset != nil {
+		for _, r := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *v.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingSource != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (v *ValueSetPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedStructureDefinitionResourcesReferencingValueset != nil {
+		for _, r := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *v.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingSource != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSource {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
+		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
 	return resourceMap
 }

--- a/models/visionprescription.go
+++ b/models/visionprescription.go
@@ -105,63 +105,448 @@ type VisionPrescriptionDispenseComponent struct {
 }
 
 type VisionPrescriptionPlus struct {
-	VisionPrescription             `bson:",inline"`
-	VisionPrescriptionPlusIncludes `bson:",inline"`
+	VisionPrescription                     `bson:",inline"`
+	VisionPrescriptionPlusRelatedResources `bson:",inline"`
 }
 
-type VisionPrescriptionPlusIncludes struct {
-	IncludedPrescriberResources *[]Practitioner `bson:"_includedPrescriberResources,omitempty"`
-	IncludedPatientResources    *[]Patient      `bson:"_includedPatientResources,omitempty"`
-	IncludedEncounterResources  *[]Encounter    `bson:"_includedEncounterResources,omitempty"`
+type VisionPrescriptionPlusRelatedResources struct {
+	IncludedPractitionerResourcesReferencedByPrescriber         *[]Practitioner          `bson:"_includedPractitionerResourcesReferencedByPrescriber,omitempty"`
+	IncludedPatientResourcesReferencedByPatient                 *[]Patient               `bson:"_includedPatientResourcesReferencedByPatient,omitempty"`
+	IncludedEncounterResourcesReferencedByEncounter             *[]Encounter             `bson:"_includedEncounterResourcesReferencedByEncounter,omitempty"`
+	RevIncludedProvenanceResourcesReferencingTarget             *[]Provenance            `bson:"_revIncludedProvenanceResourcesReferencingTarget,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingContentref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingContentref,omitempty"`
+	RevIncludedDocumentManifestResourcesReferencingRelatedref   *[]DocumentManifest      `bson:"_revIncludedDocumentManifestResourcesReferencingRelatedref,omitempty"`
+	RevIncludedCarePlanResourcesReferencingActivityreference    *[]CarePlan              `bson:"_revIncludedCarePlanResourcesReferencingActivityreference,omitempty"`
+	RevIncludedListResourcesReferencingItem                     *[]List                  `bson:"_revIncludedListResourcesReferencingItem,omitempty"`
+	RevIncludedDocumentReferenceResourcesReferencingRelatedref  *[]DocumentReference     `bson:"_revIncludedDocumentReferenceResourcesReferencingRelatedref,omitempty"`
+	RevIncludedOrderResourcesReferencingDetail                  *[]Order                 `bson:"_revIncludedOrderResourcesReferencingDetail,omitempty"`
+	RevIncludedBasicResourcesReferencingSubject                 *[]Basic                 `bson:"_revIncludedBasicResourcesReferencingSubject,omitempty"`
+	RevIncludedAuditEventResourcesReferencingReference          *[]AuditEvent            `bson:"_revIncludedAuditEventResourcesReferencingReference,omitempty"`
+	RevIncludedCompositionResourcesReferencingSubject           *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingSubject,omitempty"`
+	RevIncludedCompositionResourcesReferencingEntry             *[]Composition           `bson:"_revIncludedCompositionResourcesReferencingEntry,omitempty"`
+	RevIncludedDetectedIssueResourcesReferencingImplicated      *[]DetectedIssue         `bson:"_revIncludedDetectedIssueResourcesReferencingImplicated,omitempty"`
+	RevIncludedOrderResponseResourcesReferencingFulfillment     *[]OrderResponse         `bson:"_revIncludedOrderResponseResourcesReferencingFulfillment,omitempty"`
+	RevIncludedQuestionnaireResponseResourcesReferencingSubject *[]QuestionnaireResponse `bson:"_revIncludedQuestionnaireResponseResourcesReferencingSubject,omitempty"`
+	RevIncludedProcessResponseResourcesReferencingRequest       *[]ProcessResponse       `bson:"_revIncludedProcessResponseResourcesReferencingRequest,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingTrigger    *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingTrigger,omitempty"`
+	RevIncludedClinicalImpressionResourcesReferencingPlan       *[]ClinicalImpression    `bson:"_revIncludedClinicalImpressionResourcesReferencingPlan,omitempty"`
+	RevIncludedMessageHeaderResourcesReferencingData            *[]MessageHeader         `bson:"_revIncludedMessageHeaderResourcesReferencingData,omitempty"`
 }
 
-func (v *VisionPrescriptionPlusIncludes) GetIncludedPrescriberResource() (practitioner *Practitioner, err error) {
-	if v.IncludedPrescriberResources == nil {
+func (v *VisionPrescriptionPlusRelatedResources) GetIncludedPractitionerResourceReferencedByPrescriber() (practitioner *Practitioner, err error) {
+	if v.IncludedPractitionerResourcesReferencedByPrescriber == nil {
 		err = errors.New("Included practitioners not requested")
-	} else if len(*v.IncludedPrescriberResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*v.IncludedPrescriberResources))
-	} else if len(*v.IncludedPrescriberResources) == 1 {
-		practitioner = &(*v.IncludedPrescriberResources)[0]
+	} else if len(*v.IncludedPractitionerResourcesReferencedByPrescriber) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 practitioner, but found %d", len(*v.IncludedPractitionerResourcesReferencedByPrescriber))
+	} else if len(*v.IncludedPractitionerResourcesReferencedByPrescriber) == 1 {
+		practitioner = &(*v.IncludedPractitionerResourcesReferencedByPrescriber)[0]
 	}
 	return
 }
 
-func (v *VisionPrescriptionPlusIncludes) GetIncludedPatientResource() (patient *Patient, err error) {
-	if v.IncludedPatientResources == nil {
+func (v *VisionPrescriptionPlusRelatedResources) GetIncludedPatientResourceReferencedByPatient() (patient *Patient, err error) {
+	if v.IncludedPatientResourcesReferencedByPatient == nil {
 		err = errors.New("Included patients not requested")
-	} else if len(*v.IncludedPatientResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*v.IncludedPatientResources))
-	} else if len(*v.IncludedPatientResources) == 1 {
-		patient = &(*v.IncludedPatientResources)[0]
+	} else if len(*v.IncludedPatientResourcesReferencedByPatient) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 patient, but found %d", len(*v.IncludedPatientResourcesReferencedByPatient))
+	} else if len(*v.IncludedPatientResourcesReferencedByPatient) == 1 {
+		patient = &(*v.IncludedPatientResourcesReferencedByPatient)[0]
 	}
 	return
 }
 
-func (v *VisionPrescriptionPlusIncludes) GetIncludedEncounterResource() (encounter *Encounter, err error) {
-	if v.IncludedEncounterResources == nil {
+func (v *VisionPrescriptionPlusRelatedResources) GetIncludedEncounterResourceReferencedByEncounter() (encounter *Encounter, err error) {
+	if v.IncludedEncounterResourcesReferencedByEncounter == nil {
 		err = errors.New("Included encounters not requested")
-	} else if len(*v.IncludedEncounterResources) > 1 {
-		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*v.IncludedEncounterResources))
-	} else if len(*v.IncludedEncounterResources) == 1 {
-		encounter = &(*v.IncludedEncounterResources)[0]
+	} else if len(*v.IncludedEncounterResourcesReferencedByEncounter) > 1 {
+		err = fmt.Errorf("Expected 0 or 1 encounter, but found %d", len(*v.IncludedEncounterResourcesReferencedByEncounter))
+	} else if len(*v.IncludedEncounterResourcesReferencedByEncounter) == 1 {
+		encounter = &(*v.IncludedEncounterResourcesReferencedByEncounter)[0]
 	}
 	return
 }
 
-func (v *VisionPrescriptionPlusIncludes) GetIncludedResources() map[string]interface{} {
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedProvenanceResourcesReferencingTarget() (provenances []Provenance, err error) {
+	if v.RevIncludedProvenanceResourcesReferencingTarget == nil {
+		err = errors.New("RevIncluded provenances not requested")
+	} else {
+		provenances = *v.RevIncludedProvenanceResourcesReferencingTarget
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingContentref() (documentManifests []DocumentManifest, err error) {
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *v.RevIncludedDocumentManifestResourcesReferencingContentref
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedDocumentManifestResourcesReferencingRelatedref() (documentManifests []DocumentManifest, err error) {
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentManifests not requested")
+	} else {
+		documentManifests = *v.RevIncludedDocumentManifestResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedCarePlanResourcesReferencingActivityreference() (carePlans []CarePlan, err error) {
+	if v.RevIncludedCarePlanResourcesReferencingActivityreference == nil {
+		err = errors.New("RevIncluded carePlans not requested")
+	} else {
+		carePlans = *v.RevIncludedCarePlanResourcesReferencingActivityreference
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedListResourcesReferencingItem() (lists []List, err error) {
+	if v.RevIncludedListResourcesReferencingItem == nil {
+		err = errors.New("RevIncluded lists not requested")
+	} else {
+		lists = *v.RevIncludedListResourcesReferencingItem
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedDocumentReferenceResourcesReferencingRelatedref() (documentReferences []DocumentReference, err error) {
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref == nil {
+		err = errors.New("RevIncluded documentReferences not requested")
+	} else {
+		documentReferences = *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedOrderResourcesReferencingDetail() (orders []Order, err error) {
+	if v.RevIncludedOrderResourcesReferencingDetail == nil {
+		err = errors.New("RevIncluded orders not requested")
+	} else {
+		orders = *v.RevIncludedOrderResourcesReferencingDetail
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedBasicResourcesReferencingSubject() (basics []Basic, err error) {
+	if v.RevIncludedBasicResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded basics not requested")
+	} else {
+		basics = *v.RevIncludedBasicResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedAuditEventResourcesReferencingReference() (auditEvents []AuditEvent, err error) {
+	if v.RevIncludedAuditEventResourcesReferencingReference == nil {
+		err = errors.New("RevIncluded auditEvents not requested")
+	} else {
+		auditEvents = *v.RevIncludedAuditEventResourcesReferencingReference
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingSubject() (compositions []Composition, err error) {
+	if v.RevIncludedCompositionResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *v.RevIncludedCompositionResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedCompositionResourcesReferencingEntry() (compositions []Composition, err error) {
+	if v.RevIncludedCompositionResourcesReferencingEntry == nil {
+		err = errors.New("RevIncluded compositions not requested")
+	} else {
+		compositions = *v.RevIncludedCompositionResourcesReferencingEntry
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedDetectedIssueResourcesReferencingImplicated() (detectedIssues []DetectedIssue, err error) {
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated == nil {
+		err = errors.New("RevIncluded detectedIssues not requested")
+	} else {
+		detectedIssues = *v.RevIncludedDetectedIssueResourcesReferencingImplicated
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedOrderResponseResourcesReferencingFulfillment() (orderResponses []OrderResponse, err error) {
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment == nil {
+		err = errors.New("RevIncluded orderResponses not requested")
+	} else {
+		orderResponses = *v.RevIncludedOrderResponseResourcesReferencingFulfillment
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedQuestionnaireResponseResourcesReferencingSubject() (questionnaireResponses []QuestionnaireResponse, err error) {
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject == nil {
+		err = errors.New("RevIncluded questionnaireResponses not requested")
+	} else {
+		questionnaireResponses = *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedProcessResponseResourcesReferencingRequest() (processResponses []ProcessResponse, err error) {
+	if v.RevIncludedProcessResponseResourcesReferencingRequest == nil {
+		err = errors.New("RevIncluded processResponses not requested")
+	} else {
+		processResponses = *v.RevIncludedProcessResponseResourcesReferencingRequest
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingTrigger() (clinicalImpressions []ClinicalImpression, err error) {
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *v.RevIncludedClinicalImpressionResourcesReferencingTrigger
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedClinicalImpressionResourcesReferencingPlan() (clinicalImpressions []ClinicalImpression, err error) {
+	if v.RevIncludedClinicalImpressionResourcesReferencingPlan == nil {
+		err = errors.New("RevIncluded clinicalImpressions not requested")
+	} else {
+		clinicalImpressions = *v.RevIncludedClinicalImpressionResourcesReferencingPlan
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferencingData() (messageHeaders []MessageHeader, err error) {
+	if v.RevIncludedMessageHeaderResourcesReferencingData == nil {
+		err = errors.New("RevIncluded messageHeaders not requested")
+	} else {
+		messageHeaders = *v.RevIncludedMessageHeaderResourcesReferencingData
+	}
+	return
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
-	if v.IncludedPrescriberResources != nil {
-		for _, r := range *v.IncludedPrescriberResources {
+	if v.IncludedPractitionerResourcesReferencedByPrescriber != nil {
+		for _, r := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if v.IncludedPatientResources != nil {
-		for _, r := range *v.IncludedPatientResources {
+	if v.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *v.IncludedPatientResourcesReferencedByPatient {
 			resourceMap[r.Id] = &r
 		}
 	}
-	if v.IncludedEncounterResources != nil {
-		for _, r := range *v.IncludedEncounterResources {
+	if v.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *v.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *v.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			resourceMap[r.Id] = &r
+		}
+	}
+	return resourceMap
+}
+
+func (v *VisionPrescriptionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
+	resourceMap := make(map[string]interface{})
+	if v.IncludedPractitionerResourcesReferencedByPrescriber != nil {
+		for _, r := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.IncludedPatientResourcesReferencedByPatient != nil {
+		for _, r := range *v.IncludedPatientResourcesReferencedByPatient {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.IncludedEncounterResourcesReferencedByEncounter != nil {
+		for _, r := range *v.IncludedEncounterResourcesReferencedByEncounter {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
+		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
+		for _, r := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedListResourcesReferencingItem != nil {
+		for _, r := range *v.RevIncludedListResourcesReferencingItem {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
+		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResourcesReferencingDetail != nil {
+		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedBasicResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
+		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
+		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
+		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
+		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
+		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
+		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
+		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			resourceMap[r.Id] = &r
+		}
+	}
+	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
+		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
 			resourceMap[r.Id] = &r
 		}
 	}

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -1311,18 +1311,86 @@ func (m *MongoSearchSuite) TestObservationCodeQueryForInclude(c *C) {
 	c.Assert(obs.Subject.ReferencedID, Equals, "4954037118555241963")
 	c.Assert(obs.Encounter.ReferencedID, Equals, "6648204100111387580")
 
-	patient, err := obs.GetIncludedPatientResource()
+	inclRevIncl := obs.GetIncludedAndRevIncludedResources()
+	c.Assert(inclRevIncl, HasLen, 2)
+
+	incl := obs.GetIncludedResources()
+	c.Assert(incl, HasLen, 2)
+
+	revincl := obs.GetRevIncludedResources()
+	c.Assert(revincl, HasLen, 0)
+
+	patient, err := obs.GetIncludedPatientResourceReferencedByPatient()
 	util.CheckErr(err)
 	c.Assert(patient.Id, Equals, "4954037118555241963")
 	c.Assert(patient.Name[0].Given[0], Equals, "John")
 	c.Assert(patient.Name[0].Family[0], Equals, "Peters")
 
-	encounter, err := obs.GetIncludedEncounterResource()
+	encounter, err := obs.GetIncludedEncounterResourceReferencedByEncounter()
 	util.CheckErr(err)
 	c.Assert(encounter.Id, Equals, "6648204100111387580")
 	c.Assert(encounter.Type, HasLen, 1)
 	c.Assert(encounter.Type[0].Coding, HasLen, 1)
 	c.Assert(encounter.Type[0].Text, Equals, "Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)")
+}
+
+func (m *MongoSearchSuite) TestPatientGenderQueryOptionsForRevInclude(c *C) {
+	q := Query{"Patient", "gender=male&_revinclude=Condition:patient&_revinclude=Encounter:patient"}
+
+	// Make sure it doesn't somehow mess up the query object
+	obj := m.MongoSearcher.createQueryObject(q)
+	c.Assert(obj, DeepEquals, bson.M{
+		"gender": bson.RegEx{Pattern: "^male$", Options: "i"},
+	})
+
+	// Check that the options are parsed correctly
+	opt := q.Options()
+	c.Assert(opt.RevInclude, HasLen, 2)
+	c.Assert(opt.RevInclude[0].Resource, Equals, "Condition")
+	c.Assert(opt.RevInclude[0].Parameter.Name, Equals, "patient")
+	c.Assert(opt.RevInclude[1].Resource, Equals, "Encounter")
+	c.Assert(opt.RevInclude[1].Parameter.Name, Equals, "patient")
+}
+
+func (m *MongoSearchSuite) TestPatientGenderQueryForRevInclude(c *C) {
+	q := Query{"Patient", "gender=male&_revinclude=Condition:patient&_revinclude=Encounter:patient"}
+
+	var results []models.PatientPlus
+	err := m.MongoSearcher.CreatePipeline(q).All(&results)
+	util.CheckErr(err)
+	c.Assert(results, HasLen, 1)
+
+	patient := results[0]
+	c.Assert(patient.Id, Equals, "4954037118555241963")
+	c.Assert(patient.Name[0].Given[0], Equals, "John")
+	c.Assert(patient.Name[0].Family[0], Equals, "Peters")
+
+	inclRevIncl := patient.GetIncludedAndRevIncludedResources()
+	c.Assert(inclRevIncl, HasLen, 9)
+
+	incl := patient.GetIncludedResources()
+	c.Assert(incl, HasLen, 0)
+
+	revincl := patient.GetRevIncludedResources()
+	c.Assert(revincl, HasLen, 9)
+
+	conditions, err := patient.GetRevIncludedConditionResourcesReferencingPatient()
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 5)
+	// Just ensure they are populated to some degree
+	for _, condition := range conditions {
+		c.Assert(condition.Id, NotNil)
+		c.Assert(condition.Patient.ReferencedID, Equals, "4954037118555241963")
+	}
+
+	encounters, err := patient.GetRevIncludedEncounterResourcesReferencingPatient()
+	util.CheckErr(err)
+	c.Assert(encounters, HasLen, 4)
+	// Just ensure they are populated to some degree
+	for _, encounter := range encounters {
+		c.Assert(encounter.Id, NotNil)
+		c.Assert(encounter.Patient.ReferencedID, Equals, "4954037118555241963")
+	}
 }
 
 // Test that invalid search parameters PANIC (to ensure people know they are broken)

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1508,7 +1508,7 @@ func (s *SearchPTSuite) TestNormalizedQueryValue(c *C) {
 }
 
 func (s *SearchPTSuite) TestQueryOptions(c *C) {
-	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=M&_count=10&_offset=20&_include=Patient:careprovider&_include=Patient:organization"}
+	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=M&_count=10&_offset=20&_include=Patient:careprovider&_include=Patient:organization&_revinclude=Condition:patient&_revinclude=Encounter:patient"}
 	o := q.Options()
 	c.Assert(o.Count, Equals, 10)
 	c.Assert(o.Offset, Equals, 20)
@@ -1517,6 +1517,10 @@ func (s *SearchPTSuite) TestQueryOptions(c *C) {
 	c.Assert(o.Include[0].Parameter.Name, Equals, "careprovider")
 	c.Assert(o.Include[1].Resource, Equals, "Patient")
 	c.Assert(o.Include[1].Parameter.Name, Equals, "organization")
+	c.Assert(o.RevInclude[0].Resource, Equals, "Condition")
+	c.Assert(o.RevInclude[0].Parameter.Name, Equals, "patient")
+	c.Assert(o.RevInclude[1].Resource, Equals, "Encounter")
+	c.Assert(o.RevInclude[1].Parameter.Name, Equals, "patient")
 }
 
 func (s *SearchPTSuite) TestReconstructQueryWithDefaultOptions(c *C) {
@@ -1531,9 +1535,9 @@ func (s *SearchPTSuite) TestReconstructQueryWithDefaultOptions(c *C) {
 }
 
 func (s *SearchPTSuite) TestReconstructQueryWithPassedInOptions(c *C) {
-	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=M&_count=10&_offset=20&_include=Patient:careprovider&_include=Patient:organization"}
+	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=M&_count=10&_offset=20&_include=Patient:careprovider&_include=Patient:organization&_revinclude=Condition:patient&_revinclude=Encounter:patient"}
 	v := q.NormalizedQueryValues(true)
-	c.Assert(v, HasLen, 5)
+	c.Assert(v, HasLen, 6)
 	c.Assert(v.Get("name:exact"), Equals, "Robert Smith")
 	c.Assert(v.Get("gender"), Equals, "M")
 	c.Assert(v[CountParam], HasLen, 1)
@@ -1543,6 +1547,9 @@ func (s *SearchPTSuite) TestReconstructQueryWithPassedInOptions(c *C) {
 	c.Assert(v[IncludeParam], HasLen, 2)
 	c.Assert(v[IncludeParam][0], Equals, "Patient:careprovider")
 	c.Assert(v[IncludeParam][1], Equals, "Patient:organization")
+	c.Assert(v[RevIncludeParam], HasLen, 2)
+	c.Assert(v[RevIncludeParam][0], Equals, "Condition:patient")
+	c.Assert(v[RevIncludeParam][1], Equals, "Encounter:patient")
 }
 
 func (s *SearchPTSuite) TestQueryOptionsQueryValues(c *C) {

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1523,15 +1523,97 @@ func (s *SearchPTSuite) TestQueryOptions(c *C) {
 	c.Assert(o.RevInclude[1].Parameter.Name, Equals, "patient")
 }
 
-func (s *SearchPTSuite) TestReconstructQueryWithDefaultOptions(c *C) {
-	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=M"}
-	v := q.NormalizedQueryValues(true)
-	c.Assert(v, HasLen, 4)
-	c.Assert(v.Get("name:exact"), Equals, "Robert Smith")
-	c.Assert(v.Get("gender"), Equals, "M")
-	c.Assert(v.Get(CountParam), Equals, "100")
-	c.Assert(v.Get(OffsetParam), Equals, "0")
-	c.Assert(v.Get(IncludeParam), Equals, "")
+func (s *SearchPTSuite) TestQueryOptionsIncludeTargets(c *C) {
+	q := Query{Resource: "Patient", Query: "_include=Patient:careprovider:Organization"}
+	o := q.Options()
+	c.Assert(o.Include, HasLen, 1)
+	c.Assert(o.Include[0].Resource, Equals, "Patient")
+	c.Assert(o.Include[0].Parameter.Name, Equals, "careprovider")
+	c.Assert(o.Include[0].Parameter.Targets, HasLen, 1)
+	c.Assert(o.Include[0].Parameter.Targets[0], Equals, "Organization")
+
+	q = Query{Resource: "Patient", Query: "_include=Patient:careprovider:Practitioner"}
+	o = q.Options()
+	c.Assert(o.Include, HasLen, 1)
+	c.Assert(o.Include[0].Resource, Equals, "Patient")
+	c.Assert(o.Include[0].Parameter.Name, Equals, "careprovider")
+	c.Assert(o.Include[0].Parameter.Targets, HasLen, 1)
+	c.Assert(o.Include[0].Parameter.Targets[0], Equals, "Practitioner")
+
+	q = Query{Resource: "Patient", Query: "_include=Patient:careprovider"}
+	o = q.Options()
+	c.Assert(o.Include, HasLen, 1)
+	c.Assert(o.Include[0].Resource, Equals, "Patient")
+	c.Assert(o.Include[0].Parameter.Name, Equals, "careprovider")
+	c.Assert(o.Include[0].Parameter.Targets, HasLen, 2)
+	c.Assert(o.Include[0].Parameter.Targets[0], Equals, "Organization")
+	c.Assert(o.Include[0].Parameter.Targets[1], Equals, "Practitioner")
+}
+
+func (s *SearchPTSuite) TestQueryOptionsInvalidIncludeParams(c *C) {
+	// Non-existent parameter
+	q := Query{Resource: "Patient", Query: "_include=Patient:foo"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+
+	// Non-reference parameter
+	q = Query{Resource: "Patient", Query: "_include=Patient:name"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+
+	// Invalid target
+	q = Query{Resource: "Patient", Query: "_include=Patient:careprovider:Procedure"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+
+	// Too few parts
+	q = Query{Resource: "Patient", Query: "_include=careprovider"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+
+	// Too many parts
+	q = Query{Resource: "Patient", Query: "_include=Patient:careprovider:Procedure:0"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+}
+
+func (s *SearchPTSuite) TestQueryOptionsRevIncludeTargets(c *C) {
+	q := Query{Resource: "Patient", Query: "_revinclude=Observation:subject:Patient"}
+	o := q.Options()
+	c.Assert(o.RevInclude, HasLen, 1)
+	c.Assert(o.RevInclude[0].Resource, Equals, "Observation")
+	c.Assert(o.RevInclude[0].Parameter.Name, Equals, "subject")
+	c.Assert(o.RevInclude[0].Parameter.Targets, HasLen, 1)
+	c.Assert(o.RevInclude[0].Parameter.Targets[0], Equals, "Patient")
+
+	q = Query{Resource: "Patient", Query: "_revinclude=Observation:subject"}
+	o = q.Options()
+	c.Assert(o.RevInclude, HasLen, 1)
+	c.Assert(o.RevInclude[0].Resource, Equals, "Observation")
+	c.Assert(o.RevInclude[0].Parameter.Name, Equals, "subject")
+	c.Assert(o.RevInclude[0].Parameter.Targets, HasLen, 1)
+	c.Assert(o.RevInclude[0].Parameter.Targets[0], Equals, "Patient")
+}
+
+func (s *SearchPTSuite) TestQueryOptionsInvalidRevIncludeParams(c *C) {
+	// Non-existent parameter
+	q := Query{Resource: "Patient", Query: "_revinclude=Observation:foo"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+
+	// Non-reference parameter
+	q = Query{Resource: "Patient", Query: "_revinclude=Observation:code"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+
+	// Reference parameter to wrong type
+	q = Query{Resource: "Patient", Query: "_revinclude=Observation:device"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+
+	// Valid reference but invalid target
+	q = Query{Resource: "Patient", Query: "_revinclude=Observation:subject:Device"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+
+	// Too few parts
+	q = Query{Resource: "Patient", Query: "_revinclude=subject"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+
+	// Too many parts
+	q = Query{Resource: "Patient", Query: "_revinclude=Observation:subject:Patient:0"}
+	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
 }
 
 func (s *SearchPTSuite) TestReconstructQueryWithPassedInOptions(c *C) {

--- a/search/search_parameter_dictionary.go
+++ b/search/search_parameter_dictionary.go
@@ -8,64 +8,73 @@ package search
 var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	"Account": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Account",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Account",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Account",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Account",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Account",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"balance": SearchParamInfo{
-			Name: "balance",
-			Type: "quantity",
+			Resource: "Account",
+			Name:     "balance",
+			Type:     "quantity",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "balance", Type: "Money"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Account",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Account",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"owner": SearchParamInfo{
-			Name: "owner",
-			Type: "reference",
+			Resource: "Account",
+			Name:     "owner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "owner", Type: "Reference"},
 			},
@@ -74,8 +83,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Account",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -84,22 +94,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"period": SearchParamInfo{
-			Name: "period",
-			Type: "date",
+			Resource: "Account",
+			Name:     "period",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "coveragePeriod", Type: "Period"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Account",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Account",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -113,8 +126,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Account",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -122,92 +136,105 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"AllergyIntolerance": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "AllergyIntolerance",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "AllergyIntolerance",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "code"},
 			},
 		},
 		"criticality": SearchParamInfo{
-			Name: "criticality",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "criticality",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "criticality", Type: "code"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "AllergyIntolerance",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "recordedDate", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"last-date": SearchParamInfo{
-			Name: "last-date",
-			Type: "date",
+			Resource: "AllergyIntolerance",
+			Name:     "last-date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "lastOccurence", Type: "dateTime"},
 			},
 		},
 		"manifestation": SearchParamInfo{
-			Name: "manifestation",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "manifestation",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.[]manifestation", Type: "CodeableConcept"},
 			},
 		},
 		"onset": SearchParamInfo{
-			Name: "onset",
-			Type: "date",
+			Resource: "AllergyIntolerance",
+			Name:     "onset",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.onset", Type: "dateTime"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "AllergyIntolerance",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -216,8 +243,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"recorder": SearchParamInfo{
-			Name: "recorder",
-			Type: "reference",
+			Resource: "AllergyIntolerance",
+			Name:     "recorder",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "recorder", Type: "Reference"},
 			},
@@ -227,8 +255,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"reporter": SearchParamInfo{
-			Name: "reporter",
-			Type: "reference",
+			Resource: "AllergyIntolerance",
+			Name:     "reporter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "reporter", Type: "Reference"},
 			},
@@ -239,37 +268,42 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"route": SearchParamInfo{
-			Name: "route",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "route",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.exposureRoute", Type: "CodeableConcept"},
 			},
 		},
 		"severity": SearchParamInfo{
-			Name: "severity",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "severity",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.severity", Type: "code"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"substance": SearchParamInfo{
-			Name: "substance",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "substance",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.substance", Type: "CodeableConcept"},
 				SearchParamPath{Path: "substance", Type: "CodeableConcept"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "AllergyIntolerance",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "code"},
 			},
@@ -277,43 +311,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Appointment": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Appointment",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Appointment",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actor": SearchParamInfo{
-			Name: "actor",
-			Type: "reference",
+			Resource: "Appointment",
+			Name:     "actor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.actor", Type: "Reference"},
 			},
@@ -327,22 +367,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Appointment",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "start", Type: "instant"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Appointment",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.actor", Type: "Reference"},
 			},
@@ -351,15 +394,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"part-status": SearchParamInfo{
-			Name: "part-status",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "part-status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.status", Type: "code"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Appointment",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.actor", Type: "Reference"},
 			},
@@ -368,8 +413,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"practitioner": SearchParamInfo{
-			Name: "practitioner",
-			Type: "reference",
+			Resource: "Appointment",
+			Name:     "practitioner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.actor", Type: "Reference"},
 			},
@@ -378,8 +424,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Appointment",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
@@ -387,43 +434,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"AppointmentResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "AppointmentResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "AppointmentResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "AppointmentResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "AppointmentResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "AppointmentResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actor": SearchParamInfo{
-			Name: "actor",
-			Type: "reference",
+			Resource: "AppointmentResponse",
+			Name:     "actor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actor", Type: "Reference"},
 			},
@@ -437,8 +490,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"appointment": SearchParamInfo{
-			Name: "appointment",
-			Type: "reference",
+			Resource: "AppointmentResponse",
+			Name:     "appointment",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "appointment", Type: "Reference"},
 			},
@@ -447,15 +501,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "AppointmentResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "AppointmentResponse",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actor", Type: "Reference"},
 			},
@@ -464,15 +520,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"part-status": SearchParamInfo{
-			Name: "part-status",
-			Type: "token",
+			Resource: "AppointmentResponse",
+			Name:     "part-status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "participantStatus", Type: "code"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "AppointmentResponse",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actor", Type: "Reference"},
 			},
@@ -481,8 +539,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"practitioner": SearchParamInfo{
-			Name: "practitioner",
-			Type: "reference",
+			Resource: "AppointmentResponse",
+			Name:     "practitioner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actor", Type: "Reference"},
 			},
@@ -493,99 +552,113 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"AuditEvent": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "AuditEvent",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "AuditEvent",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"action": SearchParamInfo{
-			Name: "action",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "action",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "event.action", Type: "code"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "address",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.network.address", Type: "string"},
 			},
 		},
 		"altid": SearchParamInfo{
-			Name: "altid",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "altid",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.altId", Type: "string"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "AuditEvent",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "event.dateTime", Type: "instant"},
 			},
 		},
 		"desc": SearchParamInfo{
-			Name: "desc",
-			Type: "string",
+			Resource: "AuditEvent",
+			Name:     "desc",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]object.name", Type: "string"},
 			},
 		},
 		"identity": SearchParamInfo{
-			Name: "identity",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "identity",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]object.identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "AuditEvent",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.name", Type: "string"},
 			},
 		},
 		"object-type": SearchParamInfo{
-			Name: "object-type",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "object-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]object.type", Type: "Coding"},
 			},
 		},
 		"participant": SearchParamInfo{
-			Name: "participant",
-			Type: "reference",
+			Resource: "AuditEvent",
+			Name:     "participant",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.reference", Type: "Reference"},
 			},
@@ -598,8 +671,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "AuditEvent",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]object.reference", Type: "Reference"},
 				SearchParamPath{Path: "[]participant.reference", Type: "Reference"},
@@ -609,15 +683,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"policy": SearchParamInfo{
-			Name: "policy",
-			Type: "uri",
+			Resource: "AuditEvent",
+			Name:     "policy",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.[]policy", Type: "uri"},
 			},
 		},
 		"reference": SearchParamInfo{
-			Name: "reference",
-			Type: "reference",
+			Resource: "AuditEvent",
+			Name:     "reference",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]object.reference", Type: "Reference"},
 			},
@@ -626,36 +702,41 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"site": SearchParamInfo{
-			Name: "site",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "site",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source.site", Type: "string"},
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "source",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source.identifier", Type: "Identifier"},
 			},
 		},
 		"subtype": SearchParamInfo{
-			Name: "subtype",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "subtype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "event.[]subtype", Type: "Coding"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "event.type", Type: "Coding"},
 			},
 		},
 		"user": SearchParamInfo{
-			Name: "user",
-			Type: "token",
+			Resource: "AuditEvent",
+			Name:     "user",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.userId", Type: "Identifier"},
 			},
@@ -663,43 +744,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Basic": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Basic",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Basic",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Basic",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Basic",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Basic",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "Basic",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -710,29 +797,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Basic",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"created": SearchParamInfo{
-			Name: "created",
-			Type: "date",
+			Resource: "Basic",
+			Name:     "created",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "created", Type: "date"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Basic",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Basic",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -741,8 +832,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Basic",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -753,43 +845,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Binary": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Binary",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Binary",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Binary",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Binary",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Binary",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"contenttype": SearchParamInfo{
-			Name: "contenttype",
-			Type: "token",
+			Resource: "Binary",
+			Name:     "contenttype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "contentType", Type: "code"},
 			},
@@ -797,57 +895,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"BodySite": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "BodySite",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "BodySite",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "BodySite",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "BodySite",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "BodySite",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "BodySite",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "BodySite",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "BodySite",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -858,57 +964,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Bundle": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Bundle",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Bundle",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Bundle",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Bundle",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Bundle",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"composition": SearchParamInfo{
-			Name: "composition",
-			Type: "reference",
+			Resource: "Bundle",
+			Name:     "composition",
+			Type:     "reference",
 			Targets: []string{
 				"Composition",
 			},
 		},
 		"message": SearchParamInfo{
-			Name: "message",
-			Type: "reference",
+			Resource: "Bundle",
+			Name:     "message",
+			Type:     "reference",
 			Targets: []string{
 				"MessageHeader",
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Bundle",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "code"},
 			},
@@ -916,58 +1030,66 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"CarePlan": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "CarePlan",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "CarePlan",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "CarePlan",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "CarePlan",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "CarePlan",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"activitycode": SearchParamInfo{
-			Name: "activitycode",
-			Type: "token",
+			Resource: "CarePlan",
+			Name:     "activitycode",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]activity.detail.code", Type: "CodeableConcept"},
 			},
 		},
 		"activitydate": SearchParamInfo{
-			Name: "activitydate",
-			Type: "date",
+			Resource: "CarePlan",
+			Name:     "activitydate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]activity.detail.scheduledPeriod", Type: "Period"},
 				SearchParamPath{Path: "[]activity.detail.scheduledTiming", Type: "Timing"},
 			},
 		},
 		"activityreference": SearchParamInfo{
-			Name: "activityreference",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "activityreference",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]activity.reference", Type: "Reference"},
 			},
@@ -987,8 +1109,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"condition": SearchParamInfo{
-			Name: "condition",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "condition",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]addresses", Type: "Reference"},
 			},
@@ -997,15 +1120,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "CarePlan",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period", Type: "Period"},
 			},
 		},
 		"goal": SearchParamInfo{
-			Name: "goal",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "goal",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]goal", Type: "Reference"},
 			},
@@ -1014,8 +1139,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"participant": SearchParamInfo{
-			Name: "participant",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "participant",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.member", Type: "Reference"},
 			},
@@ -1027,8 +1153,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1037,8 +1164,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]activity.detail.[]performer", Type: "Reference"},
 			},
@@ -1050,23 +1178,26 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"related": SearchParamInfo{
-			Name: "related",
-			Type: "composite",
+			Resource: "CarePlan",
+			Name:     "related",
+			Type:     "composite",
 			Composites: []string{
 				"relatedcode",
 				"relatedplan",
 			},
 		},
 		"relatedcode": SearchParamInfo{
-			Name: "relatedcode",
-			Type: "token",
+			Resource: "CarePlan",
+			Name:     "relatedcode",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]relatedPlan.code", Type: "code"},
 			},
 		},
 		"relatedplan": SearchParamInfo{
-			Name: "relatedplan",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "relatedplan",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]relatedPlan.plan", Type: "Reference"},
 			},
@@ -1075,8 +1206,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "CarePlan",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1088,50 +1220,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Claim": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Claim",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Claim",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Claim",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -1140,15 +1279,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"priority": SearchParamInfo{
-			Name: "priority",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "priority",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "priority", Type: "Coding"},
 			},
 		},
 		"provider": SearchParamInfo{
-			Name: "provider",
-			Type: "reference",
+			Resource: "Claim",
+			Name:     "provider",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "provider", Type: "Reference"},
 			},
@@ -1157,8 +1298,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"use": SearchParamInfo{
-			Name: "use",
-			Type: "token",
+			Resource: "Claim",
+			Name:     "use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "use", Type: "code"},
 			},
@@ -1166,43 +1308,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ClaimResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ClaimResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ClaimResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ClaimResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ClaimResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ClaimResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ClaimResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -1210,43 +1358,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ClinicalImpression": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ClinicalImpression",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ClinicalImpression",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"action": SearchParamInfo{
-			Name: "action",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "action",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]action", Type: "Reference"},
 			},
@@ -1262,8 +1416,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"assessor": SearchParamInfo{
-			Name: "assessor",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "assessor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "assessor", Type: "Reference"},
 			},
@@ -1272,22 +1427,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ClinicalImpression",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"finding": SearchParamInfo{
-			Name: "finding",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "finding",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]finding.item", Type: "CodeableConcept"},
 			},
 		},
 		"investigation": SearchParamInfo{
-			Name: "investigation",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "investigation",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]investigations.[]item", Type: "Reference"},
 			},
@@ -1299,8 +1457,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -1309,8 +1468,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"plan": SearchParamInfo{
-			Name: "plan",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "plan",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]plan", Type: "Reference"},
 			},
@@ -1331,8 +1491,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"previous": SearchParamInfo{
-			Name: "previous",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "previous",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "previous", Type: "Reference"},
 			},
@@ -1341,8 +1502,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"problem": SearchParamInfo{
-			Name: "problem",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "problem",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]problem", Type: "Reference"},
 			},
@@ -1352,29 +1514,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"resolved": SearchParamInfo{
-			Name: "resolved",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "resolved",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]resolved", Type: "CodeableConcept"},
 			},
 		},
 		"ruledout": SearchParamInfo{
-			Name: "ruledout",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "ruledout",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]ruledOut.item", Type: "CodeableConcept"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"trigger": SearchParamInfo{
-			Name: "trigger",
-			Type: "reference",
+			Resource: "ClinicalImpression",
+			Name:     "trigger",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "triggerReference", Type: "Reference"},
 			},
@@ -1383,8 +1549,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"trigger-code": SearchParamInfo{
-			Name: "trigger-code",
-			Type: "token",
+			Resource: "ClinicalImpression",
+			Name:     "trigger-code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "triggerCodeableConcept", Type: "CodeableConcept"},
 			},
@@ -1392,50 +1559,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Communication": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Communication",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Communication",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -1444,22 +1618,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"medium": SearchParamInfo{
-			Name: "medium",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "medium",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]medium", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1468,15 +1645,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"received": SearchParamInfo{
-			Name: "received",
-			Type: "date",
+			Resource: "Communication",
+			Name:     "received",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "received", Type: "dateTime"},
 			},
 		},
 		"recipient": SearchParamInfo{
-			Name: "recipient",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "recipient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recipient", Type: "Reference"},
 			},
@@ -1490,8 +1669,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"request": SearchParamInfo{
-			Name: "request",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "request",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requestDetail", Type: "Reference"},
 			},
@@ -1500,8 +1680,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"sender": SearchParamInfo{
-			Name: "sender",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "sender",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "sender", Type: "Reference"},
 			},
@@ -1514,22 +1695,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"sent": SearchParamInfo{
-			Name: "sent",
-			Type: "date",
+			Resource: "Communication",
+			Name:     "sent",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "sent", Type: "dateTime"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Communication",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Communication",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1540,50 +1724,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"CommunicationRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "CommunicationRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "CommunicationRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -1592,22 +1783,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"medium": SearchParamInfo{
-			Name: "medium",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "medium",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]medium", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1616,15 +1810,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"priority": SearchParamInfo{
-			Name: "priority",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "priority",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "priority", Type: "CodeableConcept"},
 			},
 		},
 		"recipient": SearchParamInfo{
-			Name: "recipient",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "recipient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recipient", Type: "Reference"},
 			},
@@ -1637,15 +1833,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"requested": SearchParamInfo{
-			Name: "requested",
-			Type: "date",
+			Resource: "CommunicationRequest",
+			Name:     "requested",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requestedOn", Type: "dateTime"},
 			},
 		},
 		"requester": SearchParamInfo{
-			Name: "requester",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "requester",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requester", Type: "Reference"},
 			},
@@ -1656,8 +1854,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"sender": SearchParamInfo{
-			Name: "sender",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "sender",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "sender", Type: "Reference"},
 			},
@@ -1670,15 +1869,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "CommunicationRequest",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "CommunicationRequest",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1687,8 +1888,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"time": SearchParamInfo{
-			Name: "time",
-			Type: "date",
+			Resource: "CommunicationRequest",
+			Name:     "time",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "scheduledDateTime", Type: "dateTime"},
 			},
@@ -1696,43 +1898,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Composition": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Composition",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Composition",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"attester": SearchParamInfo{
-			Name: "attester",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "attester",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]attester.party", Type: "Reference"},
 			},
@@ -1743,8 +1951,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]author", Type: "Reference"},
 			},
@@ -1756,36 +1965,41 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"class": SearchParamInfo{
-			Name: "class",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "class",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "class", Type: "CodeableConcept"},
 			},
 		},
 		"confidentiality": SearchParamInfo{
-			Name: "confidentiality",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "confidentiality",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "confidentiality", Type: "code"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]event.[]code", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Composition",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -1794,8 +2008,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"entry": SearchParamInfo{
-			Name: "entry",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "entry",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]section.[]entry", Type: "Reference"},
 			},
@@ -1804,15 +2019,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1821,29 +2038,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"period": SearchParamInfo{
-			Name: "period",
-			Type: "date",
+			Resource: "Composition",
+			Name:     "period",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]event.period", Type: "Period"},
 			},
 		},
 		"section": SearchParamInfo{
-			Name: "section",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "section",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]section.code", Type: "CodeableConcept"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Composition",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -1852,15 +2073,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"title": SearchParamInfo{
-			Name: "title",
-			Type: "string",
+			Resource: "Composition",
+			Name:     "title",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "title", Type: "string"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Composition",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -1868,99 +2091,113 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ConceptMap": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ConceptMap",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ConceptMap",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"dependson": SearchParamInfo{
-			Name: "dependson",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "dependson",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.[]target.[]dependsOn.element", Type: "uri"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "ConceptMap",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "ConceptMap",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"product": SearchParamInfo{
-			Name: "product",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "product",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.[]target.[]product.element", Type: "uri"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "ConceptMap",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "ConceptMap",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "sourceReference", Type: "Reference"},
 			},
@@ -1970,37 +2207,42 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"sourcecode": SearchParamInfo{
-			Name: "sourcecode",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "sourcecode",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.code", Type: "code"},
 			},
 		},
 		"sourcesystem": SearchParamInfo{
-			Name: "sourcesystem",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "sourcesystem",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.codeSystem", Type: "uri"},
 			},
 		},
 		"sourceuri": SearchParamInfo{
-			Name: "sourceuri",
-			Type: "reference",
+			Resource: "ConceptMap",
+			Name:     "sourceuri",
+			Type:     "reference",
 			Targets: []string{
 				"StructureDefinition",
 				"ValueSet",
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"target": SearchParamInfo{
-			Name: "target",
-			Type: "reference",
+			Resource: "ConceptMap",
+			Name:     "target",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "targetReference", Type: "Reference"},
 			},
@@ -2010,29 +2252,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"targetcode": SearchParamInfo{
-			Name: "targetcode",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "targetcode",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.[]target.code", Type: "code"},
 			},
 		},
 		"targetsystem": SearchParamInfo{
-			Name: "targetsystem",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "targetsystem",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.[]target.codeSystem", Type: "uri"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "ConceptMap",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "ConceptMap",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -2040,43 +2286,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Condition": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Condition",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Condition",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"asserter": SearchParamInfo{
-			Name: "asserter",
-			Type: "reference",
+			Resource: "Condition",
+			Name:     "asserter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "asserter", Type: "Reference"},
 			},
@@ -2086,43 +2338,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"body-site": SearchParamInfo{
-			Name: "body-site",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "body-site",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]bodySite", Type: "CodeableConcept"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"clinicalstatus": SearchParamInfo{
-			Name: "clinicalstatus",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "clinicalstatus",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "clinicalStatus", Type: "code"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"date-recorded": SearchParamInfo{
-			Name: "date-recorded",
-			Type: "date",
+			Resource: "Condition",
+			Name:     "date-recorded",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dateRecorded", Type: "date"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Condition",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -2131,37 +2389,42 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"evidence": SearchParamInfo{
-			Name: "evidence",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "evidence",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]evidence.code", Type: "CodeableConcept"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"onset": SearchParamInfo{
-			Name: "onset",
-			Type: "date",
+			Resource: "Condition",
+			Name:     "onset",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "onsetDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "onsetPeriod", Type: "Period"},
 			},
 		},
 		"onset-info": SearchParamInfo{
-			Name: "onset-info",
-			Type: "string",
+			Resource: "Condition",
+			Name:     "onset-info",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "onsetString", Type: "string"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Condition",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -2170,15 +2433,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"severity": SearchParamInfo{
-			Name: "severity",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "severity",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "severity", Type: "CodeableConcept"},
 			},
 		},
 		"stage": SearchParamInfo{
-			Name: "stage",
-			Type: "token",
+			Resource: "Condition",
+			Name:     "stage",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "stage.summary", Type: "CodeableConcept"},
 			},
@@ -2186,92 +2451,105 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Conformance": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Conformance",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Conformance",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Conformance",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "Conformance",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"event": SearchParamInfo{
-			Name: "event",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "event",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]messaging.[]event.code", Type: "Coding"},
 			},
 		},
 		"fhirversion": SearchParamInfo{
-			Name: "fhirversion",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "fhirversion",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
 		},
 		"format": SearchParamInfo{
-			Name: "format",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "format",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]format", Type: "code"},
 			},
 		},
 		"mode": SearchParamInfo{
-			Name: "mode",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "mode",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]rest.mode", Type: "code"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Conformance",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"profile": SearchParamInfo{
-			Name: "profile",
-			Type: "reference",
+			Resource: "Conformance",
+			Name:     "profile",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]rest.[]resource.profile", Type: "Reference"},
 			},
@@ -2280,43 +2558,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "Conformance",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"resource": SearchParamInfo{
-			Name: "resource",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "resource",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]rest.[]resource.type", Type: "code"},
 			},
 		},
 		"security": SearchParamInfo{
-			Name: "security",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]rest.security.[]service", Type: "CodeableConcept"},
 			},
 		},
 		"software": SearchParamInfo{
-			Name: "software",
-			Type: "string",
+			Resource: "Conformance",
+			Name:     "software",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "software.name", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"supported-profile": SearchParamInfo{
-			Name: "supported-profile",
-			Type: "reference",
+			Resource: "Conformance",
+			Name:     "supported-profile",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]profile", Type: "Reference"},
 			},
@@ -2325,15 +2609,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "Conformance",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "Conformance",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -2341,43 +2627,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Contract": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Contract",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Contract",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Contract",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Contract",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Contract",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actor": SearchParamInfo{
-			Name: "actor",
-			Type: "reference",
+			Resource: "Contract",
+			Name:     "actor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]actor.entity", Type: "Reference"},
 			},
@@ -2394,15 +2686,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Contract",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Contract",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]subject", Type: "Reference"},
 			},
@@ -2411,8 +2705,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"signer": SearchParamInfo{
-			Name: "signer",
-			Type: "reference",
+			Resource: "Contract",
+			Name:     "signer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]signer.party", Type: "Reference"},
 			},
@@ -2424,8 +2719,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Contract",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]subject", Type: "Reference"},
 			},
@@ -2436,64 +2732,73 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Coverage": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Coverage",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Coverage",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"dependent": SearchParamInfo{
-			Name: "dependent",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "dependent",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dependent", Type: "positiveInt"},
 			},
 		},
 		"group": SearchParamInfo{
-			Name: "group",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "group",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "group", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"issuer": SearchParamInfo{
-			Name: "issuer",
-			Type: "reference",
+			Resource: "Coverage",
+			Name:     "issuer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "issuer", Type: "Reference"},
 			},
@@ -2502,29 +2807,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"plan": SearchParamInfo{
-			Name: "plan",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "plan",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "plan", Type: "string"},
 			},
 		},
 		"sequence": SearchParamInfo{
-			Name: "sequence",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "sequence",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "sequence", Type: "positiveInt"},
 			},
 		},
 		"subplan": SearchParamInfo{
-			Name: "subplan",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "subplan",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subPlan", Type: "string"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Coverage",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "Coding"},
 			},
@@ -2532,113 +2841,129 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DataElement": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DataElement",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DataElement",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.[]code", Type: "Coding"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "DataElement",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "DataElement",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]element.definition", Type: "markdown"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "DataElement",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "DataElement",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"stringency": SearchParamInfo{
-			Name: "stringency",
-			Type: "token",
+			Resource: "DataElement",
+			Name:     "stringency",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "stringency", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "DataElement",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "string",
+			Resource: "DataElement",
+			Name:     "version",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -2646,43 +2971,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DetectedIssue": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DetectedIssue",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DetectedIssue",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DetectedIssue",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DetectedIssue",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DetectedIssue",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "DetectedIssue",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -2692,29 +3023,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "DetectedIssue",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "DetectedIssue",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DetectedIssue",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"implicated": SearchParamInfo{
-			Name: "implicated",
-			Type: "reference",
+			Resource: "DetectedIssue",
+			Name:     "implicated",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]implicated", Type: "Reference"},
 			},
@@ -2723,8 +3058,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DetectedIssue",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -2735,50 +3071,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Device": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Device",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Device",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Device",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Device",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Device",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Device",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Device",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "location", Type: "Reference"},
 			},
@@ -2787,22 +3130,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"manufacturer": SearchParamInfo{
-			Name: "manufacturer",
-			Type: "string",
+			Resource: "Device",
+			Name:     "manufacturer",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "manufacturer", Type: "string"},
 			},
 		},
 		"model": SearchParamInfo{
-			Name: "model",
-			Type: "string",
+			Resource: "Device",
+			Name:     "model",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "model", Type: "string"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "Device",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "owner", Type: "Reference"},
 			},
@@ -2811,8 +3157,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Device",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -2821,22 +3168,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Device",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
 		},
 		"udi": SearchParamInfo{
-			Name: "udi",
-			Type: "string",
+			Resource: "Device",
+			Name:     "udi",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "udi", Type: "string"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "Device",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
@@ -2844,43 +3194,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DeviceComponent": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DeviceComponent",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DeviceComponent",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DeviceComponent",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DeviceComponent",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DeviceComponent",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"parent": SearchParamInfo{
-			Name: "parent",
-			Type: "reference",
+			Resource: "DeviceComponent",
+			Name:     "parent",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "parent", Type: "Reference"},
 			},
@@ -2889,8 +3245,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "DeviceComponent",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -2899,8 +3256,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "DeviceComponent",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -2908,57 +3266,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DeviceMetric": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DeviceMetric",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DeviceMetric",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"parent": SearchParamInfo{
-			Name: "parent",
-			Type: "reference",
+			Resource: "DeviceMetric",
+			Name:     "parent",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "parent", Type: "Reference"},
 			},
@@ -2967,8 +3333,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "DeviceMetric",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -2977,8 +3344,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "DeviceMetric",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -2986,43 +3354,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DeviceUseRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DeviceUseRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DeviceUseRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DeviceUseRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DeviceUseRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DeviceUseRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"device": SearchParamInfo{
-			Name: "device",
-			Type: "reference",
+			Resource: "DeviceUseRequest",
+			Name:     "device",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "device", Type: "Reference"},
 			},
@@ -3031,8 +3405,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DeviceUseRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3041,8 +3416,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DeviceUseRequest",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3053,43 +3429,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DeviceUseStatement": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DeviceUseStatement",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DeviceUseStatement",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DeviceUseStatement",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DeviceUseStatement",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DeviceUseStatement",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"device": SearchParamInfo{
-			Name: "device",
-			Type: "reference",
+			Resource: "DeviceUseStatement",
+			Name:     "device",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "device", Type: "Reference"},
 			},
@@ -3098,8 +3480,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DeviceUseStatement",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3108,8 +3491,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DeviceUseStatement",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3120,43 +3504,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DiagnosticOrder": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DiagnosticOrder",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DiagnosticOrder",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actor": SearchParamInfo{
-			Name: "actor",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "actor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]event.actor", Type: "Reference"},
 				SearchParamPath{Path: "[]item.[]event.actor", Type: "Reference"},
@@ -3167,22 +3557,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"bodysite": SearchParamInfo{
-			Name: "bodysite",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "bodysite",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.bodySite", Type: "CodeableConcept"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.code", Type: "CodeableConcept"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -3191,66 +3584,75 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"event-date": SearchParamInfo{
-			Name: "event-date",
-			Type: "date",
+			Resource: "DiagnosticOrder",
+			Name:     "event-date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]event.dateTime", Type: "dateTime"},
 			},
 		},
 		"event-status": SearchParamInfo{
-			Name: "event-status",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "event-status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]event.status", Type: "code"},
 			},
 		},
 		"event-status-date": SearchParamInfo{
-			Name: "event-status-date",
-			Type: "composite",
+			Resource: "DiagnosticOrder",
+			Name:     "event-status-date",
+			Type:     "composite",
 			Composites: []string{
 				"event-date",
 				"event-status",
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"item-date": SearchParamInfo{
-			Name: "item-date",
-			Type: "date",
+			Resource: "DiagnosticOrder",
+			Name:     "item-date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.[]event.dateTime", Type: "dateTime"},
 			},
 		},
 		"item-past-status": SearchParamInfo{
-			Name: "item-past-status",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "item-past-status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.[]event.status", Type: "code"},
 			},
 		},
 		"item-status": SearchParamInfo{
-			Name: "item-status",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "item-status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.status", Type: "code"},
 			},
 		},
 		"item-status-date": SearchParamInfo{
-			Name: "item-status-date",
-			Type: "composite",
+			Resource: "DiagnosticOrder",
+			Name:     "item-status-date",
+			Type:     "composite",
 			Composites: []string{
 				"item-date",
 				"item-past-status",
 			},
 		},
 		"orderer": SearchParamInfo{
-			Name: "orderer",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "orderer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "orderer", Type: "Reference"},
 			},
@@ -3259,8 +3661,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3269,8 +3672,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"specimen": SearchParamInfo{
-			Name: "specimen",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "specimen",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]item.[]specimen", Type: "Reference"},
 				SearchParamPath{Path: "[]specimen", Type: "Reference"},
@@ -3280,15 +3684,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "DiagnosticOrder",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DiagnosticOrder",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3302,72 +3708,82 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DiagnosticReport": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DiagnosticReport",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DiagnosticReport",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "DiagnosticReport",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "effectiveDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "effectivePeriod", Type: "Period"},
 			},
 		},
 		"diagnosis": SearchParamInfo{
-			Name: "diagnosis",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "diagnosis",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]codedDiagnosis", Type: "CodeableConcept"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -3376,15 +3792,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"image": SearchParamInfo{
-			Name: "image",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "image",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]image.link", Type: "Reference"},
 			},
@@ -3393,15 +3811,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"issued": SearchParamInfo{
-			Name: "issued",
-			Type: "date",
+			Resource: "DiagnosticReport",
+			Name:     "issued",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "issued", Type: "instant"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3410,8 +3830,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "performer", Type: "Reference"},
 			},
@@ -3421,8 +3842,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"request": SearchParamInfo{
-			Name: "request",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "request",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]request", Type: "Reference"},
 			},
@@ -3433,8 +3855,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"result": SearchParamInfo{
-			Name: "result",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "result",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]result", Type: "Reference"},
 			},
@@ -3443,8 +3866,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"specimen": SearchParamInfo{
-			Name: "specimen",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "specimen",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]specimen", Type: "Reference"},
 			},
@@ -3453,15 +3877,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "DiagnosticReport",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DiagnosticReport",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3475,43 +3901,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DocumentManifest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DocumentManifest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DocumentManifest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]author", Type: "Reference"},
 			},
@@ -3524,8 +3956,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"content-ref": SearchParamInfo{
-			Name: "content-ref",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "content-ref",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]content.pReference", Type: "Reference"},
 			},
@@ -3534,30 +3967,34 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"created": SearchParamInfo{
-			Name: "created",
-			Type: "date",
+			Resource: "DocumentManifest",
+			Name:     "created",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "created", Type: "dateTime"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "DocumentManifest",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 				SearchParamPath{Path: "masterIdentifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3566,8 +4003,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"recipient": SearchParamInfo{
-			Name: "recipient",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "recipient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recipient", Type: "Reference"},
 			},
@@ -3579,15 +4017,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"related-id": SearchParamInfo{
-			Name: "related-id",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "related-id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]related.identifier", Type: "Identifier"},
 			},
 		},
 		"related-ref": SearchParamInfo{
-			Name: "related-ref",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "related-ref",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]related.ref", Type: "Reference"},
 			},
@@ -3596,22 +4036,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "uri",
+			Resource: "DocumentManifest",
+			Name:     "source",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "uri"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DocumentManifest",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3623,8 +4066,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "DocumentManifest",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -3632,43 +4076,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"DocumentReference": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "DocumentReference",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "DocumentReference",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"authenticator": SearchParamInfo{
-			Name: "authenticator",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "authenticator",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "authenticator", Type: "Reference"},
 			},
@@ -3678,8 +4128,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]author", Type: "Reference"},
 			},
@@ -3692,22 +4143,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"class": SearchParamInfo{
-			Name: "class",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "class",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "class", Type: "CodeableConcept"},
 			},
 		},
 		"created": SearchParamInfo{
-			Name: "created",
-			Type: "date",
+			Resource: "DocumentReference",
+			Name:     "created",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "created", Type: "dateTime"},
 			},
 		},
 		"custodian": SearchParamInfo{
-			Name: "custodian",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "custodian",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "custodian", Type: "Reference"},
 			},
@@ -3716,15 +4170,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "DocumentReference",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.encounter", Type: "Reference"},
 			},
@@ -3733,58 +4189,66 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"event": SearchParamInfo{
-			Name: "event",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "event",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.[]event", Type: "CodeableConcept"},
 			},
 		},
 		"facility": SearchParamInfo{
-			Name: "facility",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "facility",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.facilityType", Type: "CodeableConcept"},
 			},
 		},
 		"format": SearchParamInfo{
-			Name: "format",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "format",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]content.[]format", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 				SearchParamPath{Path: "masterIdentifier", Type: "Identifier"},
 			},
 		},
 		"indexed": SearchParamInfo{
-			Name: "indexed",
-			Type: "date",
+			Resource: "DocumentReference",
+			Name:     "indexed",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "indexed", Type: "instant"},
 			},
 		},
 		"language": SearchParamInfo{
-			Name: "language",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "language",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]content.attachment.language", Type: "code"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "uri",
+			Resource: "DocumentReference",
+			Name:     "location",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]content.attachment.url", Type: "uri"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3793,22 +4257,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"period": SearchParamInfo{
-			Name: "period",
-			Type: "date",
+			Resource: "DocumentReference",
+			Name:     "period",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.period", Type: "Period"},
 			},
 		},
 		"related-id": SearchParamInfo{
-			Name: "related-id",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "related-id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.[]related.identifier", Type: "Identifier"},
 			},
 		},
 		"related-ref": SearchParamInfo{
-			Name: "related-ref",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "related-ref",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.[]related.ref", Type: "Reference"},
 			},
@@ -3817,8 +4284,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"relatesto": SearchParamInfo{
-			Name: "relatesto",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "relatesto",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]relatesTo.target", Type: "Reference"},
 			},
@@ -3827,44 +4295,50 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"relation": SearchParamInfo{
-			Name: "relation",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "relation",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]relatesTo.code", Type: "code"},
 			},
 		},
 		"relationship": SearchParamInfo{
-			Name: "relationship",
-			Type: "composite",
+			Resource: "DocumentReference",
+			Name:     "relationship",
+			Type:     "composite",
 			Composites: []string{
 				"relatesto",
 				"relation",
 			},
 		},
 		"securitylabel": SearchParamInfo{
-			Name: "securitylabel",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "securitylabel",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]securityLabel", Type: "CodeableConcept"},
 			},
 		},
 		"setting": SearchParamInfo{
-			Name: "setting",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "setting",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "context.practiceSetting", Type: "CodeableConcept"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "DocumentReference",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -3876,8 +4350,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "DocumentReference",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -3885,43 +4360,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"EligibilityRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "EligibilityRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "EligibilityRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "EligibilityRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "EligibilityRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "EligibilityRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "EligibilityRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -3929,43 +4410,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"EligibilityResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "EligibilityResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "EligibilityResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "EligibilityResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "EligibilityResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "EligibilityResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "EligibilityResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -3973,43 +4460,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Encounter": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Encounter",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Encounter",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"appointment": SearchParamInfo{
-			Name: "appointment",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "appointment",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "appointment", Type: "Reference"},
 			},
@@ -4018,8 +4511,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"condition": SearchParamInfo{
-			Name: "condition",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "condition",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]indication", Type: "Reference"},
 			},
@@ -4028,15 +4522,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Encounter",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period", Type: "Period"},
 			},
 		},
 		"episodeofcare": SearchParamInfo{
-			Name: "episodeofcare",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "episodeofcare",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]episodeOfCare", Type: "Reference"},
 			},
@@ -4045,15 +4541,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"incomingreferral": SearchParamInfo{
-			Name: "incomingreferral",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "incomingreferral",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]incomingReferral", Type: "Reference"},
 			},
@@ -4062,8 +4560,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"indication": SearchParamInfo{
-			Name: "indication",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "indication",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]indication", Type: "Reference"},
 			},
@@ -4073,15 +4572,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"length": SearchParamInfo{
-			Name: "length",
-			Type: "number",
+			Resource: "Encounter",
+			Name:     "length",
+			Type:     "number",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "length", Type: "Duration"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]location.location", Type: "Reference"},
 			},
@@ -4090,15 +4591,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"location-period": SearchParamInfo{
-			Name: "location-period",
-			Type: "date",
+			Resource: "Encounter",
+			Name:     "location-period",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]location.period", Type: "Period"},
 			},
 		},
 		"part-of": SearchParamInfo{
-			Name: "part-of",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "part-of",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "partOf", Type: "Reference"},
 			},
@@ -4107,8 +4610,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"participant": SearchParamInfo{
-			Name: "participant",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "participant",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.individual", Type: "Reference"},
 			},
@@ -4118,15 +4622,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"participant-type": SearchParamInfo{
-			Name: "participant-type",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "participant-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.[]type", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -4135,8 +4641,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"practitioner": SearchParamInfo{
-			Name: "practitioner",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "practitioner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]participant.individual", Type: "Reference"},
 			},
@@ -4145,8 +4652,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"procedure": SearchParamInfo{
-			Name: "procedure",
-			Type: "reference",
+			Resource: "Encounter",
+			Name:     "procedure",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]indication", Type: "Reference"},
 			},
@@ -4155,29 +4663,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"reason": SearchParamInfo{
-			Name: "reason",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "reason",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reason", Type: "CodeableConcept"},
 			},
 		},
 		"special-arrangement": SearchParamInfo{
-			Name: "special-arrangement",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "special-arrangement",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "hospitalization.[]specialArrangement", Type: "CodeableConcept"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Encounter",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]type", Type: "CodeableConcept"},
 			},
@@ -4185,50 +4697,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"EnrollmentRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "EnrollmentRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "EnrollmentRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "EnrollmentRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "EnrollmentRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "EnrollmentRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "EnrollmentRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "EnrollmentRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4237,8 +4756,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "EnrollmentRequest",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4249,43 +4769,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"EnrollmentResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "EnrollmentResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "EnrollmentResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "EnrollmentResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "EnrollmentResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "EnrollmentResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "EnrollmentResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -4293,43 +4819,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"EpisodeOfCare": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "EpisodeOfCare",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "EpisodeOfCare",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"care-manager": SearchParamInfo{
-			Name: "care-manager",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "care-manager",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "careManager", Type: "Reference"},
 			},
@@ -4338,8 +4870,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"condition": SearchParamInfo{
-			Name: "condition",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "condition",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]condition", Type: "Reference"},
 			},
@@ -4348,22 +4881,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "EpisodeOfCare",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period", Type: "Period"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"incomingreferral": SearchParamInfo{
-			Name: "incomingreferral",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "incomingreferral",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]referralRequest", Type: "Reference"},
 			},
@@ -4372,8 +4908,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "managingOrganization", Type: "Reference"},
 			},
@@ -4382,8 +4919,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -4392,15 +4930,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"team-member": SearchParamInfo{
-			Name: "team-member",
-			Type: "reference",
+			Resource: "EpisodeOfCare",
+			Name:     "team-member",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]careTeam.member", Type: "Reference"},
 			},
@@ -4410,8 +4950,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "EpisodeOfCare",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]type", Type: "CodeableConcept"},
 			},
@@ -4419,43 +4960,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ExplanationOfBenefit": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ExplanationOfBenefit",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ExplanationOfBenefit",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ExplanationOfBenefit",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ExplanationOfBenefit",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ExplanationOfBenefit",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ExplanationOfBenefit",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -4463,71 +5010,81 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"FamilyMemberHistory": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "FamilyMemberHistory",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "FamilyMemberHistory",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]condition.code", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "FamilyMemberHistory",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"gender": SearchParamInfo{
-			Name: "gender",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "gender",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "gender", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "FamilyMemberHistory",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -4536,8 +5093,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"relationship": SearchParamInfo{
-			Name: "relationship",
-			Type: "token",
+			Resource: "FamilyMemberHistory",
+			Name:     "relationship",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "relationship", Type: "CodeableConcept"},
 			},
@@ -4545,43 +5103,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Flag": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Flag",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Flag",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Flag",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Flag",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Flag",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "Flag",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -4593,15 +5157,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Flag",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period", Type: "Period"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Flag",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -4610,8 +5176,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Flag",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4620,8 +5187,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Flag",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4636,57 +5204,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Goal": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Goal",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Goal",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]category", Type: "CodeableConcept"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Goal",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4695,15 +5271,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Goal",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Goal",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -4714,8 +5292,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"targetdate": SearchParamInfo{
-			Name: "targetdate",
-			Type: "date",
+			Resource: "Goal",
+			Name:     "targetdate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "targetDate", Type: "date"},
 			},
@@ -4723,86 +5302,98 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Group": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Group",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Group",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Group",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Group",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Group",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actual": SearchParamInfo{
-			Name: "actual",
-			Type: "token",
+			Resource: "Group",
+			Name:     "actual",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actual", Type: "boolean"},
 			},
 		},
 		"characteristic": SearchParamInfo{
-			Name: "characteristic",
-			Type: "token",
+			Resource: "Group",
+			Name:     "characteristic",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]characteristic.code", Type: "CodeableConcept"},
 			},
 		},
 		"characteristic-value": SearchParamInfo{
-			Name: "characteristic-value",
-			Type: "composite",
+			Resource: "Group",
+			Name:     "characteristic-value",
+			Type:     "composite",
 			Composites: []string{
 				"characteristic",
 				"value",
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Group",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"exclude": SearchParamInfo{
-			Name: "exclude",
-			Type: "token",
+			Resource: "Group",
+			Name:     "exclude",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]characteristic.exclude", Type: "boolean"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Group",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"member": SearchParamInfo{
-			Name: "member",
-			Type: "reference",
+			Resource: "Group",
+			Name:     "member",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]member.entity", Type: "Reference"},
 			},
@@ -4815,15 +5406,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Group",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "code"},
 			},
 		},
 		"value": SearchParamInfo{
-			Name: "value",
-			Type: "token",
+			Resource: "Group",
+			Name:     "value",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]characteristic.valueBoolean", Type: "boolean"},
 				SearchParamPath{Path: "[]characteristic.valueCodeableConcept", Type: "CodeableConcept"},
@@ -4832,57 +5425,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"HealthcareService": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "HealthcareService",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "HealthcareService",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"characteristic": SearchParamInfo{
-			Name: "characteristic",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "characteristic",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]characteristic", Type: "CodeableConcept"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "HealthcareService",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "location", Type: "Reference"},
 			},
@@ -4891,15 +5492,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "HealthcareService",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "serviceName", Type: "string"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "HealthcareService",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "providedBy", Type: "Reference"},
 			},
@@ -4908,22 +5511,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"programname": SearchParamInfo{
-			Name: "programname",
-			Type: "string",
+			Resource: "HealthcareService",
+			Name:     "programname",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]programName", Type: "string"},
 			},
 		},
 		"servicecategory": SearchParamInfo{
-			Name: "servicecategory",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "servicecategory",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "serviceCategory", Type: "CodeableConcept"},
 			},
 		},
 		"servicetype": SearchParamInfo{
-			Name: "servicetype",
-			Type: "token",
+			Resource: "HealthcareService",
+			Name:     "servicetype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]serviceType.type", Type: "CodeableConcept"},
 			},
@@ -4931,43 +5537,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ImagingObjectSelection": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ImagingObjectSelection",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ImagingObjectSelection",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ImagingObjectSelection",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ImagingObjectSelection",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ImagingObjectSelection",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "ImagingObjectSelection",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -4980,22 +5592,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"authoring-time": SearchParamInfo{
-			Name: "authoring-time",
-			Type: "date",
+			Resource: "ImagingObjectSelection",
+			Name:     "authoring-time",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "authoringTime", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "uri",
+			Resource: "ImagingObjectSelection",
+			Name:     "identifier",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "uid", Type: "oid"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ImagingObjectSelection",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -5004,15 +5619,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"selected-study": SearchParamInfo{
-			Name: "selected-study",
-			Type: "uri",
+			Resource: "ImagingObjectSelection",
+			Name:     "selected-study",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]study.uid", Type: "oid"},
 			},
 		},
 		"title": SearchParamInfo{
-			Name: "title",
-			Type: "token",
+			Resource: "ImagingObjectSelection",
+			Name:     "title",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "title", Type: "CodeableConcept"},
 			},
@@ -5020,71 +5637,81 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ImagingStudy": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ImagingStudy",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ImagingStudy",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"accession": SearchParamInfo{
-			Name: "accession",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "accession",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "accession", Type: "Identifier"},
 			},
 		},
 		"bodysite": SearchParamInfo{
-			Name: "bodysite",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "bodysite",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]series.bodySite", Type: "Coding"},
 			},
 		},
 		"dicom-class": SearchParamInfo{
-			Name: "dicom-class",
-			Type: "uri",
+			Resource: "ImagingStudy",
+			Name:     "dicom-class",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]series.[]instance.sopClass", Type: "oid"},
 			},
 		},
 		"modality": SearchParamInfo{
-			Name: "modality",
-			Type: "token",
+			Resource: "ImagingStudy",
+			Name:     "modality",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]series.modality", Type: "Coding"},
 			},
 		},
 		"order": SearchParamInfo{
-			Name: "order",
-			Type: "reference",
+			Resource: "ImagingStudy",
+			Name:     "order",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]order", Type: "Reference"},
 			},
@@ -5093,8 +5720,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ImagingStudy",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -5103,29 +5731,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"series": SearchParamInfo{
-			Name: "series",
-			Type: "uri",
+			Resource: "ImagingStudy",
+			Name:     "series",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]series.uid", Type: "oid"},
 			},
 		},
 		"started": SearchParamInfo{
-			Name: "started",
-			Type: "date",
+			Resource: "ImagingStudy",
+			Name:     "started",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "started", Type: "dateTime"},
 			},
 		},
 		"study": SearchParamInfo{
-			Name: "study",
-			Type: "uri",
+			Resource: "ImagingStudy",
+			Name:     "study",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "uid", Type: "oid"},
 			},
 		},
 		"uid": SearchParamInfo{
-			Name: "uid",
-			Type: "uri",
+			Resource: "ImagingStudy",
+			Name:     "uid",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]series.[]instance.uid", Type: "oid"},
 			},
@@ -5133,64 +5765,73 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Immunization": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Immunization",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Immunization",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Immunization",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"dose-sequence": SearchParamInfo{
-			Name: "dose-sequence",
-			Type: "number",
+			Resource: "Immunization",
+			Name:     "dose-sequence",
+			Type:     "number",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]vaccinationProtocol.doseSequence", Type: "positiveInt"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "location", Type: "Reference"},
 			},
@@ -5199,15 +5840,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"lot-number": SearchParamInfo{
-			Name: "lot-number",
-			Type: "string",
+			Resource: "Immunization",
+			Name:     "lot-number",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "lotNumber", Type: "string"},
 			},
 		},
 		"manufacturer": SearchParamInfo{
-			Name: "manufacturer",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "manufacturer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "manufacturer", Type: "Reference"},
 			},
@@ -5216,15 +5859,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"notgiven": SearchParamInfo{
-			Name: "notgiven",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "notgiven",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "wasNotGiven", Type: "boolean"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -5233,8 +5878,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "performer", Type: "Reference"},
 			},
@@ -5243,8 +5889,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"reaction": SearchParamInfo{
-			Name: "reaction",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "reaction",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.detail", Type: "Reference"},
 			},
@@ -5253,29 +5900,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"reaction-date": SearchParamInfo{
-			Name: "reaction-date",
-			Type: "date",
+			Resource: "Immunization",
+			Name:     "reaction-date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]reaction.date", Type: "dateTime"},
 			},
 		},
 		"reason": SearchParamInfo{
-			Name: "reason",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "reason",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "explanation.[]reason", Type: "CodeableConcept"},
 			},
 		},
 		"reason-not-given": SearchParamInfo{
-			Name: "reason-not-given",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "reason-not-given",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "explanation.[]reasonNotGiven", Type: "CodeableConcept"},
 			},
 		},
 		"requester": SearchParamInfo{
-			Name: "requester",
-			Type: "reference",
+			Resource: "Immunization",
+			Name:     "requester",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requester", Type: "Reference"},
 			},
@@ -5284,15 +5935,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"vaccine-code": SearchParamInfo{
-			Name: "vaccine-code",
-			Type: "token",
+			Resource: "Immunization",
+			Name:     "vaccine-code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "vaccineCode", Type: "CodeableConcept"},
 			},
@@ -5300,71 +5953,81 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ImmunizationRecommendation": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ImmunizationRecommendation",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ImmunizationRecommendation",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ImmunizationRecommendation",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.date", Type: "dateTime"},
 			},
 		},
 		"dose-number": SearchParamInfo{
-			Name: "dose-number",
-			Type: "number",
+			Resource: "ImmunizationRecommendation",
+			Name:     "dose-number",
+			Type:     "number",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.doseNumber", Type: "positiveInt"},
 			},
 		},
 		"dose-sequence": SearchParamInfo{
-			Name: "dose-sequence",
-			Type: "number",
+			Resource: "ImmunizationRecommendation",
+			Name:     "dose-sequence",
+			Type:     "number",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.protocol.doseSequence", Type: "integer"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"information": SearchParamInfo{
-			Name: "information",
-			Type: "reference",
+			Resource: "ImmunizationRecommendation",
+			Name:     "information",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.[]supportingPatientInformation", Type: "Reference"},
 			},
@@ -5374,8 +6037,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ImmunizationRecommendation",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -5384,15 +6048,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.forecastStatus", Type: "CodeableConcept"},
 			},
 		},
 		"support": SearchParamInfo{
-			Name: "support",
-			Type: "reference",
+			Resource: "ImmunizationRecommendation",
+			Name:     "support",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.[]supportingImmunization", Type: "Reference"},
 			},
@@ -5401,8 +6067,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"vaccine-type": SearchParamInfo{
-			Name: "vaccine-type",
-			Type: "token",
+			Resource: "ImmunizationRecommendation",
+			Name:     "vaccine-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recommendation.vaccineCode", Type: "CodeableConcept"},
 			},
@@ -5410,106 +6077,121 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ImplementationGuide": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ImplementationGuide",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ImplementationGuide",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ImplementationGuide",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"dependency": SearchParamInfo{
-			Name: "dependency",
-			Type: "uri",
+			Resource: "ImplementationGuide",
+			Name:     "dependency",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]dependency.uri", Type: "uri"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "ImplementationGuide",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"experimental": SearchParamInfo{
-			Name: "experimental",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "experimental",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "experimental", Type: "boolean"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "ImplementationGuide",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "ImplementationGuide",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "ImplementationGuide",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "ImplementationGuide",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -5517,64 +6199,73 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"List": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "List",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "List",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "List",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "List",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "List",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "List",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "List",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"empty-reason": SearchParamInfo{
-			Name: "empty-reason",
-			Type: "token",
+			Resource: "List",
+			Name:     "empty-reason",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "emptyReason", Type: "CodeableConcept"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "List",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -5583,8 +6274,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"item": SearchParamInfo{
-			Name: "item",
-			Type: "reference",
+			Resource: "List",
+			Name:     "item",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]entry.item", Type: "Reference"},
 			},
@@ -5593,15 +6285,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"notes": SearchParamInfo{
-			Name: "notes",
-			Type: "string",
+			Resource: "List",
+			Name:     "notes",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "note", Type: "string"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "List",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -5610,8 +6304,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "List",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -5622,15 +6317,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "List",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "List",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -5642,8 +6339,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"title": SearchParamInfo{
-			Name: "title",
-			Type: "string",
+			Resource: "List",
+			Name:     "title",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "title", Type: "string"},
 			},
@@ -5651,107 +6349,123 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Location": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Location",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Location",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Location",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Location",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Location",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "Location",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "Location",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "Location",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "Location",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "Location",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "Location",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "address.use", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Location",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Location",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"near": SearchParamInfo{
-			Name: "near",
-			Type: "token",
+			Resource: "Location",
+			Name:     "near",
+			Type:     "token",
 		},
 		"near-distance": SearchParamInfo{
-			Name: "near-distance",
-			Type: "token",
+			Resource: "Location",
+			Name:     "near-distance",
+			Type:     "token",
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "Location",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "managingOrganization", Type: "Reference"},
 			},
@@ -5760,8 +6474,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"partof": SearchParamInfo{
-			Name: "partof",
-			Type: "reference",
+			Resource: "Location",
+			Name:     "partof",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "partOf", Type: "Reference"},
 			},
@@ -5770,15 +6485,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Location",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Location",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -5786,57 +6503,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Media": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Media",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Media",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Media",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Media",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Media",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"created": SearchParamInfo{
-			Name: "created",
-			Type: "date",
+			Resource: "Media",
+			Name:     "created",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "content.creation", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Media",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"operator": SearchParamInfo{
-			Name: "operator",
-			Type: "reference",
+			Resource: "Media",
+			Name:     "operator",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "operator", Type: "Reference"},
 			},
@@ -5845,8 +6570,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Media",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -5855,8 +6581,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Media",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -5869,22 +6596,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subtype": SearchParamInfo{
-			Name: "subtype",
-			Type: "token",
+			Resource: "Media",
+			Name:     "subtype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subtype", Type: "CodeableConcept"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Media",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "code"},
 			},
 		},
 		"view": SearchParamInfo{
-			Name: "view",
-			Type: "token",
+			Resource: "Media",
+			Name:     "view",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "view", Type: "CodeableConcept"},
 			},
@@ -5892,57 +6622,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Medication": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Medication",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Medication",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"container": SearchParamInfo{
-			Name: "container",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "container",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "package.container", Type: "CodeableConcept"},
 			},
 		},
 		"content": SearchParamInfo{
-			Name: "content",
-			Type: "reference",
+			Resource: "Medication",
+			Name:     "content",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "package.[]content.item", Type: "Reference"},
 			},
@@ -5951,15 +6689,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"form": SearchParamInfo{
-			Name: "form",
-			Type: "token",
+			Resource: "Medication",
+			Name:     "form",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "product.form", Type: "CodeableConcept"},
 			},
 		},
 		"ingredient": SearchParamInfo{
-			Name: "ingredient",
-			Type: "reference",
+			Resource: "Medication",
+			Name:     "ingredient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "product.[]ingredient.item", Type: "Reference"},
 			},
@@ -5969,8 +6709,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"manufacturer": SearchParamInfo{
-			Name: "manufacturer",
-			Type: "reference",
+			Resource: "Medication",
+			Name:     "manufacturer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "manufacturer", Type: "Reference"},
 			},
@@ -5981,50 +6722,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"MedicationAdministration": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "MedicationAdministration",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "MedicationAdministration",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"device": SearchParamInfo{
-			Name: "device",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "device",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]device", Type: "Reference"},
 			},
@@ -6033,16 +6781,18 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"effectivetime": SearchParamInfo{
-			Name: "effectivetime",
-			Type: "date",
+			Resource: "MedicationAdministration",
+			Name:     "effectivetime",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "effectiveTimeDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "effectiveTimePeriod", Type: "Period"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -6051,15 +6801,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"medication": SearchParamInfo{
-			Name: "medication",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "medication",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationReference", Type: "Reference"},
 			},
@@ -6068,15 +6820,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"notgiven": SearchParamInfo{
-			Name: "notgiven",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "notgiven",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "wasNotGiven", Type: "boolean"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -6085,8 +6839,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"practitioner": SearchParamInfo{
-			Name: "practitioner",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "practitioner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "practitioner", Type: "Reference"},
 			},
@@ -6097,8 +6852,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"prescription": SearchParamInfo{
-			Name: "prescription",
-			Type: "reference",
+			Resource: "MedicationAdministration",
+			Name:     "prescription",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "prescription", Type: "Reference"},
 			},
@@ -6107,8 +6863,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "MedicationAdministration",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
@@ -6116,50 +6873,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"MedicationDispense": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "MedicationDispense",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "MedicationDispense",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"destination": SearchParamInfo{
-			Name: "destination",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "destination",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "destination", Type: "Reference"},
 			},
@@ -6168,8 +6932,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"dispenser": SearchParamInfo{
-			Name: "dispenser",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "dispenser",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dispenser", Type: "Reference"},
 			},
@@ -6178,15 +6943,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"medication": SearchParamInfo{
-			Name: "medication",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "medication",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationReference", Type: "Reference"},
 			},
@@ -6195,8 +6962,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -6205,8 +6973,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"prescription": SearchParamInfo{
-			Name: "prescription",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "prescription",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]authorizingPrescription", Type: "Reference"},
 			},
@@ -6215,8 +6984,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"receiver": SearchParamInfo{
-			Name: "receiver",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "receiver",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]receiver", Type: "Reference"},
 			},
@@ -6226,8 +6996,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"responsibleparty": SearchParamInfo{
-			Name: "responsibleparty",
-			Type: "reference",
+			Resource: "MedicationDispense",
+			Name:     "responsibleparty",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "substitution.[]responsibleParty", Type: "Reference"},
 			},
@@ -6236,29 +7007,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "MedicationDispense",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
 		},
 		"whenhandedover": SearchParamInfo{
-			Name: "whenhandedover",
-			Type: "date",
+			Resource: "MedicationDispense",
+			Name:     "whenhandedover",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "whenHandedOver", Type: "dateTime"},
 			},
 		},
 		"whenprepared": SearchParamInfo{
-			Name: "whenprepared",
-			Type: "date",
+			Resource: "MedicationDispense",
+			Name:     "whenprepared",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "whenPrepared", Type: "dateTime"},
 			},
@@ -6266,57 +7041,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"MedicationOrder": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "MedicationOrder",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "MedicationOrder",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"datewritten": SearchParamInfo{
-			Name: "datewritten",
-			Type: "date",
+			Resource: "MedicationOrder",
+			Name:     "datewritten",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dateWritten", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "MedicationOrder",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -6325,15 +7108,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"medication": SearchParamInfo{
-			Name: "medication",
-			Type: "reference",
+			Resource: "MedicationOrder",
+			Name:     "medication",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationReference", Type: "Reference"},
 			},
@@ -6342,8 +7127,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "MedicationOrder",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -6352,8 +7138,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"prescriber": SearchParamInfo{
-			Name: "prescriber",
-			Type: "reference",
+			Resource: "MedicationOrder",
+			Name:     "prescriber",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "prescriber", Type: "Reference"},
 			},
@@ -6362,8 +7149,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "MedicationOrder",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
@@ -6371,65 +7159,74 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"MedicationStatement": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "MedicationStatement",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "MedicationStatement",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"effectivedate": SearchParamInfo{
-			Name: "effectivedate",
-			Type: "date",
+			Resource: "MedicationStatement",
+			Name:     "effectivedate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "effectiveDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "effectivePeriod", Type: "Period"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"medication": SearchParamInfo{
-			Name: "medication",
-			Type: "reference",
+			Resource: "MedicationStatement",
+			Name:     "medication",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "medicationReference", Type: "Reference"},
 			},
@@ -6438,8 +7235,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "MedicationStatement",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -6448,8 +7246,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "MedicationStatement",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "informationSource", Type: "Reference"},
 			},
@@ -6460,8 +7259,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "MedicationStatement",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
@@ -6469,43 +7269,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"MessageHeader": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "MessageHeader",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "MessageHeader",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -6514,15 +7320,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "response.code", Type: "code"},
 			},
 		},
 		"data": SearchParamInfo{
-			Name: "data",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "data",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]data", Type: "Reference"},
 			},
@@ -6531,22 +7339,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"destination": SearchParamInfo{
-			Name: "destination",
-			Type: "string",
+			Resource: "MessageHeader",
+			Name:     "destination",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]destination.name", Type: "string"},
 			},
 		},
 		"destination-uri": SearchParamInfo{
-			Name: "destination-uri",
-			Type: "uri",
+			Resource: "MessageHeader",
+			Name:     "destination-uri",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]destination.endpoint", Type: "uri"},
 			},
 		},
 		"enterer": SearchParamInfo{
-			Name: "enterer",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "enterer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "enterer", Type: "Reference"},
 			},
@@ -6555,15 +7366,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"event": SearchParamInfo{
-			Name: "event",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "event",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "event", Type: "Coding"},
 			},
 		},
 		"receiver": SearchParamInfo{
-			Name: "receiver",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "receiver",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "receiver", Type: "Reference"},
 			},
@@ -6573,15 +7386,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"response-id": SearchParamInfo{
-			Name: "response-id",
-			Type: "token",
+			Resource: "MessageHeader",
+			Name:     "response-id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "response.identifier", Type: "id"},
 			},
 		},
 		"responsible": SearchParamInfo{
-			Name: "responsible",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "responsible",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "responsible", Type: "Reference"},
 			},
@@ -6591,22 +7406,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "string",
+			Resource: "MessageHeader",
+			Name:     "source",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source.name", Type: "string"},
 			},
 		},
 		"source-uri": SearchParamInfo{
-			Name: "source-uri",
-			Type: "uri",
+			Resource: "MessageHeader",
+			Name:     "source-uri",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source.endpoint", Type: "uri"},
 			},
 		},
 		"target": SearchParamInfo{
-			Name: "target",
-			Type: "reference",
+			Resource: "MessageHeader",
+			Name:     "target",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]destination.target", Type: "Reference"},
 			},
@@ -6615,8 +7433,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"timestamp": SearchParamInfo{
-			Name: "timestamp",
-			Type: "date",
+			Resource: "MessageHeader",
+			Name:     "timestamp",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "timestamp", Type: "instant"},
 			},
@@ -6624,99 +7443,113 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"NamingSystem": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "NamingSystem",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "NamingSystem",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"contact": SearchParamInfo{
-			Name: "contact",
-			Type: "string",
+			Resource: "NamingSystem",
+			Name:     "contact",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]contact.name", Type: "string"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "NamingSystem",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"id-type": SearchParamInfo{
-			Name: "id-type",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "id-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]uniqueId.type", Type: "code"},
 			},
 		},
 		"kind": SearchParamInfo{
-			Name: "kind",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "kind",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "kind", Type: "code"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "NamingSystem",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"period": SearchParamInfo{
-			Name: "period",
-			Type: "date",
+			Resource: "NamingSystem",
+			Name:     "period",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]uniqueId.period", Type: "Period"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "NamingSystem",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"replaced-by": SearchParamInfo{
-			Name: "replaced-by",
-			Type: "reference",
+			Resource: "NamingSystem",
+			Name:     "replaced-by",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "replacedBy", Type: "Reference"},
 			},
@@ -6725,36 +7558,41 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"responsible": SearchParamInfo{
-			Name: "responsible",
-			Type: "string",
+			Resource: "NamingSystem",
+			Name:     "responsible",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "responsible", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"telecom": SearchParamInfo{
-			Name: "telecom",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "telecom",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]contact.[]telecom", Type: "ContactPoint"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "NamingSystem",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
 		},
 		"value": SearchParamInfo{
-			Name: "value",
-			Type: "string",
+			Resource: "NamingSystem",
+			Name:     "value",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]uniqueId.value", Type: "string"},
 			},
@@ -6762,57 +7600,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"NutritionOrder": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "NutritionOrder",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "NutritionOrder",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"additive": SearchParamInfo{
-			Name: "additive",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "additive",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "enteralFormula.additiveType", Type: "CodeableConcept"},
 			},
 		},
 		"datetime": SearchParamInfo{
-			Name: "datetime",
-			Type: "date",
+			Resource: "NutritionOrder",
+			Name:     "datetime",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dateTime", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "NutritionOrder",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -6821,29 +7667,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"formula": SearchParamInfo{
-			Name: "formula",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "formula",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "enteralFormula.baseFormulaType", Type: "CodeableConcept"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"oraldiet": SearchParamInfo{
-			Name: "oraldiet",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "oraldiet",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "oralDiet.[]type", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "NutritionOrder",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -6852,8 +7702,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"provider": SearchParamInfo{
-			Name: "provider",
-			Type: "reference",
+			Resource: "NutritionOrder",
+			Name:     "provider",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "orderer", Type: "Reference"},
 			},
@@ -6862,15 +7713,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"supplement": SearchParamInfo{
-			Name: "supplement",
-			Type: "token",
+			Resource: "NutritionOrder",
+			Name:     "supplement",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]supplement.type", Type: "CodeableConcept"},
 			},
@@ -6878,123 +7731,140 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Observation": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Observation",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Observation",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "category", Type: "CodeableConcept"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"code-value-[x]": SearchParamInfo{
-			Name: "code-value-[x]",
-			Type: "composite",
+			Resource: "Observation",
+			Name:     "code-value-[x]",
+			Type:     "composite",
 			Composites: []string{
 				"code",
 				"value[x]",
 			},
 		},
 		"component-code": SearchParamInfo{
-			Name: "component-code",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "component-code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]component.code", Type: "CodeableConcept"},
 			},
 		},
 		"component-code-value-[x]": SearchParamInfo{
-			Name: "component-code-value-[x]",
-			Type: "composite",
+			Resource: "Observation",
+			Name:     "component-code-value-[x]",
+			Type:     "composite",
 			Composites: []string{
 				"component-code",
 				"component-value[x]",
 			},
 		},
 		"component-data-absent-reason": SearchParamInfo{
-			Name: "component-data-absent-reason",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "component-data-absent-reason",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]component.dataAbsentReason", Type: "CodeableConcept"},
 			},
 		},
 		"component-value-concept": SearchParamInfo{
-			Name: "component-value-concept",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "component-value-concept",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]component.valueCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"component-value-quantity": SearchParamInfo{
-			Name: "component-value-quantity",
-			Type: "quantity",
+			Resource: "Observation",
+			Name:     "component-value-quantity",
+			Type:     "quantity",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]component.valueQuantity", Type: "Quantity"},
 			},
 		},
 		"component-value-string": SearchParamInfo{
-			Name: "component-value-string",
-			Type: "string",
+			Resource: "Observation",
+			Name:     "component-value-string",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]component.valueString", Type: "string"},
 			},
 		},
 		"data-absent-reason": SearchParamInfo{
-			Name: "data-absent-reason",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "data-absent-reason",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dataAbsentReason", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Observation",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "effectiveDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "effectivePeriod", Type: "Period"},
 			},
 		},
 		"device": SearchParamInfo{
-			Name: "device",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "device",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "device", Type: "Reference"},
 			},
@@ -7004,8 +7874,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -7014,15 +7885,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -7031,8 +7904,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]performer", Type: "Reference"},
 			},
@@ -7044,16 +7918,18 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"related": SearchParamInfo{
-			Name: "related",
-			Type: "composite",
+			Resource: "Observation",
+			Name:     "related",
+			Type:     "composite",
 			Composites: []string{
 				"related-target",
 				"related-type",
 			},
 		},
 		"related-target": SearchParamInfo{
-			Name: "related-target",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "related-target",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]related.target", Type: "Reference"},
 			},
@@ -7063,15 +7939,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"related-type": SearchParamInfo{
-			Name: "related-type",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "related-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]related.type", Type: "code"},
 			},
 		},
 		"specimen": SearchParamInfo{
-			Name: "specimen",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "specimen",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "specimen", Type: "Reference"},
 			},
@@ -7080,15 +7958,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Observation",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -7100,30 +7980,34 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"value-concept": SearchParamInfo{
-			Name: "value-concept",
-			Type: "token",
+			Resource: "Observation",
+			Name:     "value-concept",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "valueCodeableConcept", Type: "CodeableConcept"},
 			},
 		},
 		"value-date": SearchParamInfo{
-			Name: "value-date",
-			Type: "date",
+			Resource: "Observation",
+			Name:     "value-date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "valueDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "valuePeriod", Type: "Period"},
 			},
 		},
 		"value-quantity": SearchParamInfo{
-			Name: "value-quantity",
-			Type: "quantity",
+			Resource: "Observation",
+			Name:     "value-quantity",
+			Type:     "quantity",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "valueQuantity", Type: "Quantity"},
 			},
 		},
 		"value-string": SearchParamInfo{
-			Name: "value-string",
-			Type: "string",
+			Resource: "Observation",
+			Name:     "value-string",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "valueString", Type: "string"},
 			},
@@ -7131,43 +8015,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"OperationDefinition": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "OperationDefinition",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "OperationDefinition",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"base": SearchParamInfo{
-			Name: "base",
-			Type: "reference",
+			Resource: "OperationDefinition",
+			Name:     "base",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "base", Type: "Reference"},
 			},
@@ -7176,43 +8066,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "code"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "OperationDefinition",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"instance": SearchParamInfo{
-			Name: "instance",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "instance",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "instance", Type: "boolean"},
 			},
 		},
 		"kind": SearchParamInfo{
-			Name: "kind",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "kind",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "kind", Type: "code"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "OperationDefinition",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"profile": SearchParamInfo{
-			Name: "profile",
-			Type: "reference",
+			Resource: "OperationDefinition",
+			Name:     "profile",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]parameter.profile", Type: "Reference"},
 			},
@@ -7221,43 +8117,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "OperationDefinition",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"system": SearchParamInfo{
-			Name: "system",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "system",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "system", Type: "boolean"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]type", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "OperationDefinition",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "OperationDefinition",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -7265,36 +8167,41 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"OperationOutcome": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "OperationOutcome",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "OperationOutcome",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "OperationOutcome",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "OperationOutcome",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "OperationOutcome",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
@@ -7302,50 +8209,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Order": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Order",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Order",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Order",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Order",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Order",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Order",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"detail": SearchParamInfo{
-			Name: "detail",
-			Type: "reference",
+			Resource: "Order",
+			Name:     "detail",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]detail", Type: "Reference"},
 			},
@@ -7354,15 +8268,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Order",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Order",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -7371,8 +8287,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "Order",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -7382,8 +8299,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Order",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -7395,8 +8313,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"target": SearchParamInfo{
-			Name: "target",
-			Type: "reference",
+			Resource: "Order",
+			Name:     "target",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "target", Type: "Reference"},
 			},
@@ -7407,15 +8326,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"when": SearchParamInfo{
-			Name: "when",
-			Type: "date",
+			Resource: "Order",
+			Name:     "when",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "when.schedule", Type: "Timing"},
 			},
 		},
 		"when_code": SearchParamInfo{
-			Name: "when_code",
-			Type: "token",
+			Resource: "Order",
+			Name:     "when_code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "when.code", Type: "CodeableConcept"},
 			},
@@ -7423,57 +8344,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"OrderResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "OrderResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "OrderResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "OrderResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "OrderResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "OrderResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "OrderResponse",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "orderStatus", Type: "code"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "OrderResponse",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"fulfillment": SearchParamInfo{
-			Name: "fulfillment",
-			Type: "reference",
+			Resource: "OrderResponse",
+			Name:     "fulfillment",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]fulfillment", Type: "Reference"},
 			},
@@ -7482,15 +8411,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "OrderResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"request": SearchParamInfo{
-			Name: "request",
-			Type: "reference",
+			Resource: "OrderResponse",
+			Name:     "request",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "request", Type: "Reference"},
 			},
@@ -7499,8 +8430,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"who": SearchParamInfo{
-			Name: "who",
-			Type: "reference",
+			Resource: "OrderResponse",
+			Name:     "who",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "who", Type: "Reference"},
 			},
@@ -7513,106 +8445,121 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Organization": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Organization",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Organization",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"active": SearchParamInfo{
-			Name: "active",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "active",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "active", Type: "boolean"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.use", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"partof": SearchParamInfo{
-			Name: "partof",
-			Type: "reference",
+			Resource: "Organization",
+			Name:     "partof",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "partOf", Type: "Reference"},
 			},
@@ -7621,15 +8568,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"phonetic": SearchParamInfo{
-			Name: "phonetic",
-			Type: "string",
+			Resource: "Organization",
+			Name:     "phonetic",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Organization",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -7637,113 +8586,129 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Patient": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Patient",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Patient",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"active": SearchParamInfo{
-			Name: "active",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "active",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "active", Type: "boolean"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.use", Type: "code"},
 			},
 		},
 		"animal-breed": SearchParamInfo{
-			Name: "animal-breed",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "animal-breed",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "animal.breed", Type: "CodeableConcept"},
 			},
 		},
 		"animal-species": SearchParamInfo{
-			Name: "animal-species",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "animal-species",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "animal.species", Type: "CodeableConcept"},
 			},
 		},
 		"birthdate": SearchParamInfo{
-			Name: "birthdate",
-			Type: "date",
+			Resource: "Patient",
+			Name:     "birthdate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "birthDate", Type: "date"},
 			},
 		},
 		"careprovider": SearchParamInfo{
-			Name: "careprovider",
-			Type: "reference",
+			Resource: "Patient",
+			Name:     "careprovider",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]careProvider", Type: "Reference"},
 			},
@@ -7753,61 +8718,70 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"deathdate": SearchParamInfo{
-			Name: "deathdate",
-			Type: "date",
+			Resource: "Patient",
+			Name:     "deathdate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "deceasedDateTime", Type: "dateTime"},
 			},
 		},
 		"deceased": SearchParamInfo{
-			Name: "deceased",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "deceased",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "deceasedBoolean", Type: "boolean"},
 			},
 		},
 		"email": SearchParamInfo{
-			Name: "email",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "email",
+			Type:     "token",
 		},
 		"family": SearchParamInfo{
-			Name: "family",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "family",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name.[]family", Type: "string"},
 			},
 		},
 		"gender": SearchParamInfo{
-			Name: "gender",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "gender",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "gender", Type: "code"},
 			},
 		},
 		"given": SearchParamInfo{
-			Name: "given",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "given",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name.[]given", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"language": SearchParamInfo{
-			Name: "language",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "language",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]communication.language", Type: "CodeableConcept"},
 			},
 		},
 		"link": SearchParamInfo{
-			Name: "link",
-			Type: "reference",
+			Resource: "Patient",
+			Name:     "link",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]link.other", Type: "Reference"},
 			},
@@ -7816,15 +8790,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name", Type: "HumanName"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "Patient",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "managingOrganization", Type: "Reference"},
 			},
@@ -7833,19 +8809,22 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"phone": SearchParamInfo{
-			Name: "phone",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "phone",
+			Type:     "token",
 		},
 		"phonetic": SearchParamInfo{
-			Name: "phonetic",
-			Type: "string",
+			Resource: "Patient",
+			Name:     "phonetic",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name", Type: "HumanName"},
 			},
 		},
 		"telecom": SearchParamInfo{
-			Name: "telecom",
-			Type: "token",
+			Resource: "Patient",
+			Name:     "telecom",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]telecom", Type: "ContactPoint"},
 			},
@@ -7853,43 +8832,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"PaymentNotice": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "PaymentNotice",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "PaymentNotice",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "PaymentNotice",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "PaymentNotice",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "PaymentNotice",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "PaymentNotice",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -7897,43 +8882,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"PaymentReconciliation": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "PaymentReconciliation",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "PaymentReconciliation",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "PaymentReconciliation",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "PaymentReconciliation",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "PaymentReconciliation",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "PaymentReconciliation",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
@@ -7941,110 +8932,126 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Person": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Person",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Person",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Person",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Person",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Person",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "Person",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "Person",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "Person",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "Person",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "Person",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "Person",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.use", Type: "code"},
 			},
 		},
 		"birthdate": SearchParamInfo{
-			Name: "birthdate",
-			Type: "date",
+			Resource: "Person",
+			Name:     "birthdate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "birthDate", Type: "date"},
 			},
 		},
 		"email": SearchParamInfo{
-			Name: "email",
-			Type: "token",
+			Resource: "Person",
+			Name:     "email",
+			Type:     "token",
 		},
 		"gender": SearchParamInfo{
-			Name: "gender",
-			Type: "token",
+			Resource: "Person",
+			Name:     "gender",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "gender", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Person",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"link": SearchParamInfo{
-			Name: "link",
-			Type: "reference",
+			Resource: "Person",
+			Name:     "link",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]link.target", Type: "Reference"},
 			},
@@ -8056,15 +9063,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Person",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name", Type: "HumanName"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "Person",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "managingOrganization", Type: "Reference"},
 			},
@@ -8073,8 +9082,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Person",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]link.target", Type: "Reference"},
 			},
@@ -8083,19 +9093,22 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"phone": SearchParamInfo{
-			Name: "phone",
-			Type: "token",
+			Resource: "Person",
+			Name:     "phone",
+			Type:     "token",
 		},
 		"phonetic": SearchParamInfo{
-			Name: "phonetic",
-			Type: "string",
+			Resource: "Person",
+			Name:     "phonetic",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]name", Type: "HumanName"},
 			},
 		},
 		"practitioner": SearchParamInfo{
-			Name: "practitioner",
-			Type: "reference",
+			Resource: "Person",
+			Name:     "practitioner",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]link.target", Type: "Reference"},
 			},
@@ -8104,8 +9117,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"relatedperson": SearchParamInfo{
-			Name: "relatedperson",
-			Type: "reference",
+			Resource: "Person",
+			Name:     "relatedperson",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]link.target", Type: "Reference"},
 			},
@@ -8114,8 +9128,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"telecom": SearchParamInfo{
-			Name: "telecom",
-			Type: "token",
+			Resource: "Person",
+			Name:     "telecom",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]telecom", Type: "ContactPoint"},
 			},
@@ -8123,124 +9138,142 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Practitioner": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Practitioner",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Practitioner",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.use", Type: "code"},
 			},
 		},
 		"communication": SearchParamInfo{
-			Name: "communication",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "communication",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]communication", Type: "CodeableConcept"},
 			},
 		},
 		"email": SearchParamInfo{
-			Name: "email",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "email",
+			Type:     "token",
 		},
 		"family": SearchParamInfo{
-			Name: "family",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "family",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name.[]family", Type: "string"},
 			},
 		},
 		"gender": SearchParamInfo{
-			Name: "gender",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "gender",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "gender", Type: "code"},
 			},
 		},
 		"given": SearchParamInfo{
-			Name: "given",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "given",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name.[]given", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Practitioner",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]practitionerRole.[]location", Type: "Reference"},
 			},
@@ -8249,15 +9282,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "HumanName"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "Practitioner",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]practitionerRole.managingOrganization", Type: "Reference"},
 			},
@@ -8266,33 +9301,38 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"phone": SearchParamInfo{
-			Name: "phone",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "phone",
+			Type:     "token",
 		},
 		"phonetic": SearchParamInfo{
-			Name: "phonetic",
-			Type: "string",
+			Resource: "Practitioner",
+			Name:     "phonetic",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "HumanName"},
 			},
 		},
 		"role": SearchParamInfo{
-			Name: "role",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "role",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]practitionerRole.role", Type: "CodeableConcept"},
 			},
 		},
 		"specialty": SearchParamInfo{
-			Name: "specialty",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "specialty",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]practitionerRole.[]specialty", Type: "CodeableConcept"},
 			},
 		},
 		"telecom": SearchParamInfo{
-			Name: "telecom",
-			Type: "token",
+			Resource: "Practitioner",
+			Name:     "telecom",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]telecom", Type: "ContactPoint"},
 			},
@@ -8300,58 +9340,66 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Procedure": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Procedure",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Procedure",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Procedure",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Procedure",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Procedure",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Procedure",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Procedure",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "performedDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "performedPeriod", Type: "Period"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "Procedure",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -8360,15 +9408,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Procedure",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Procedure",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "location", Type: "Reference"},
 			},
@@ -8377,8 +9427,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Procedure",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8387,8 +9438,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "Procedure",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]performer.actor", Type: "Reference"},
 			},
@@ -8400,8 +9452,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Procedure",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8413,43 +9466,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ProcedureRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ProcedureRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ProcedureRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ProcedureRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ProcedureRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ProcedureRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "ProcedureRequest",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -8458,15 +9517,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ProcedureRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"orderer": SearchParamInfo{
-			Name: "orderer",
-			Type: "reference",
+			Resource: "ProcedureRequest",
+			Name:     "orderer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "orderer", Type: "Reference"},
 			},
@@ -8478,8 +9539,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ProcedureRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8488,8 +9550,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "ProcedureRequest",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "performer", Type: "Reference"},
 			},
@@ -8501,8 +9564,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "ProcedureRequest",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8514,57 +9578,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ProcessRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ProcessRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ProcessRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ProcessRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ProcessRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ProcessRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"action": SearchParamInfo{
-			Name: "action",
-			Type: "token",
+			Resource: "ProcessRequest",
+			Name:     "action",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "action", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ProcessRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "ProcessRequest",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "organization", Type: "Reference"},
 			},
@@ -8573,8 +9645,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"provider": SearchParamInfo{
-			Name: "provider",
-			Type: "reference",
+			Resource: "ProcessRequest",
+			Name:     "provider",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "provider", Type: "Reference"},
 			},
@@ -8585,50 +9658,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ProcessResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ProcessResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ProcessResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ProcessResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ProcessResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ProcessResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ProcessResponse",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"organization": SearchParamInfo{
-			Name: "organization",
-			Type: "reference",
+			Resource: "ProcessResponse",
+			Name:     "organization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "organization", Type: "Reference"},
 			},
@@ -8637,8 +9717,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"request": SearchParamInfo{
-			Name: "request",
-			Type: "reference",
+			Resource: "ProcessResponse",
+			Name:     "request",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "request", Type: "Reference"},
 			},
@@ -8647,8 +9728,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"requestorganization": SearchParamInfo{
-			Name: "requestorganization",
-			Type: "reference",
+			Resource: "ProcessResponse",
+			Name:     "requestorganization",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requestOrganization", Type: "Reference"},
 			},
@@ -8657,8 +9739,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"requestprovider": SearchParamInfo{
-			Name: "requestprovider",
-			Type: "reference",
+			Resource: "ProcessResponse",
+			Name:     "requestprovider",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requestProvider", Type: "Reference"},
 			},
@@ -8669,43 +9752,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Provenance": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Provenance",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Provenance",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"agent": SearchParamInfo{
-			Name: "agent",
-			Type: "reference",
+			Resource: "Provenance",
+			Name:     "agent",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]agent.actor", Type: "Reference"},
 			},
@@ -8718,29 +9807,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"end": SearchParamInfo{
-			Name: "end",
-			Type: "date",
+			Resource: "Provenance",
+			Name:     "end",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period.end", Type: "dateTime"},
 			},
 		},
 		"entity": SearchParamInfo{
-			Name: "entity",
-			Type: "uri",
+			Resource: "Provenance",
+			Name:     "entity",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]entity.reference", Type: "uri"},
 			},
 		},
 		"entitytype": SearchParamInfo{
-			Name: "entitytype",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "entitytype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]entity.type", Type: "Coding"},
 			},
 		},
 		"location": SearchParamInfo{
-			Name: "location",
-			Type: "reference",
+			Resource: "Provenance",
+			Name:     "location",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "location", Type: "Reference"},
 			},
@@ -8749,8 +9842,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Provenance",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]target", Type: "Reference"},
 			},
@@ -8759,22 +9853,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"sigtype": SearchParamInfo{
-			Name: "sigtype",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "sigtype",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]signature.[]type", Type: "Coding"},
 			},
 		},
 		"start": SearchParamInfo{
-			Name: "start",
-			Type: "date",
+			Resource: "Provenance",
+			Name:     "start",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "period.start", Type: "dateTime"},
 			},
 		},
 		"target": SearchParamInfo{
-			Name: "target",
-			Type: "reference",
+			Resource: "Provenance",
+			Name:     "target",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]target", Type: "Reference"},
 			},
@@ -8783,8 +9880,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"userid": SearchParamInfo{
-			Name: "userid",
-			Type: "token",
+			Resource: "Provenance",
+			Name:     "userid",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]agent.userId", Type: "Identifier"},
 			},
@@ -8792,85 +9890,97 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Questionnaire": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Questionnaire",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Questionnaire",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "group.[]concept", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Questionnaire",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "Questionnaire",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Questionnaire",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"title": SearchParamInfo{
-			Name: "title",
-			Type: "string",
+			Resource: "Questionnaire",
+			Name:     "title",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "group.title", Type: "string"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "string",
+			Resource: "Questionnaire",
+			Name:     "version",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -8878,43 +9988,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"QuestionnaireResponse": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "QuestionnaireResponse",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "QuestionnaireResponse",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "QuestionnaireResponse",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "QuestionnaireResponse",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "QuestionnaireResponse",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"author": SearchParamInfo{
-			Name: "author",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "author",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "author", Type: "Reference"},
 			},
@@ -8926,15 +10042,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"authored": SearchParamInfo{
-			Name: "authored",
-			Type: "date",
+			Resource: "QuestionnaireResponse",
+			Name:     "authored",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "authored", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -8943,8 +10061,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8953,8 +10072,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"questionnaire": SearchParamInfo{
-			Name: "questionnaire",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "questionnaire",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "questionnaire", Type: "Reference"},
 			},
@@ -8963,8 +10083,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -8975,15 +10096,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "QuestionnaireResponse",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "QuestionnaireResponse",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -8994,50 +10117,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ReferralRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ReferralRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ReferralRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ReferralRequest",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "ReferralRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -9046,15 +10176,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"priority": SearchParamInfo{
-			Name: "priority",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "priority",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "priority", Type: "CodeableConcept"},
 			},
 		},
 		"recipient": SearchParamInfo{
-			Name: "recipient",
-			Type: "reference",
+			Resource: "ReferralRequest",
+			Name:     "recipient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]recipient", Type: "Reference"},
 			},
@@ -9064,8 +10196,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"requester": SearchParamInfo{
-			Name: "requester",
-			Type: "reference",
+			Resource: "ReferralRequest",
+			Name:     "requester",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "requester", Type: "Reference"},
 			},
@@ -9076,22 +10209,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"specialty": SearchParamInfo{
-			Name: "specialty",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "specialty",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "specialty", Type: "CodeableConcept"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "ReferralRequest",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -9099,117 +10235,134 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"RelatedPerson": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "RelatedPerson",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "RelatedPerson",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"address": SearchParamInfo{
-			Name: "address",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "address",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address", Type: "Address"},
 			},
 		},
 		"address-city": SearchParamInfo{
-			Name: "address-city",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "address-city",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.city", Type: "string"},
 			},
 		},
 		"address-country": SearchParamInfo{
-			Name: "address-country",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "address-country",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.country", Type: "string"},
 			},
 		},
 		"address-postalcode": SearchParamInfo{
-			Name: "address-postalcode",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "address-postalcode",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.postalCode", Type: "string"},
 			},
 		},
 		"address-state": SearchParamInfo{
-			Name: "address-state",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "address-state",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.state", Type: "string"},
 			},
 		},
 		"address-use": SearchParamInfo{
-			Name: "address-use",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "address-use",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]address.use", Type: "code"},
 			},
 		},
 		"birthdate": SearchParamInfo{
-			Name: "birthdate",
-			Type: "date",
+			Resource: "RelatedPerson",
+			Name:     "birthdate",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "birthDate", Type: "date"},
 			},
 		},
 		"email": SearchParamInfo{
-			Name: "email",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "email",
+			Type:     "token",
 		},
 		"gender": SearchParamInfo{
-			Name: "gender",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "gender",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "gender", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "HumanName"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "RelatedPerson",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -9218,19 +10371,22 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"phone": SearchParamInfo{
-			Name: "phone",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "phone",
+			Type:     "token",
 		},
 		"phonetic": SearchParamInfo{
-			Name: "phonetic",
-			Type: "string",
+			Resource: "RelatedPerson",
+			Name:     "phonetic",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "HumanName"},
 			},
 		},
 		"telecom": SearchParamInfo{
-			Name: "telecom",
-			Type: "token",
+			Resource: "RelatedPerson",
+			Name:     "telecom",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]telecom", Type: "ContactPoint"},
 			},
@@ -9238,43 +10394,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"RiskAssessment": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "RiskAssessment",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "RiskAssessment",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "RiskAssessment",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "RiskAssessment",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "RiskAssessment",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"condition": SearchParamInfo{
-			Name: "condition",
-			Type: "reference",
+			Resource: "RiskAssessment",
+			Name:     "condition",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "condition", Type: "Reference"},
 			},
@@ -9283,15 +10445,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "RiskAssessment",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "RiskAssessment",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -9300,22 +10464,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "RiskAssessment",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"method": SearchParamInfo{
-			Name: "method",
-			Type: "token",
+			Resource: "RiskAssessment",
+			Name:     "method",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "method", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "RiskAssessment",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -9324,8 +10491,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"performer": SearchParamInfo{
-			Name: "performer",
-			Type: "reference",
+			Resource: "RiskAssessment",
+			Name:     "performer",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "performer", Type: "Reference"},
 			},
@@ -9335,8 +10503,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "RiskAssessment",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -9348,43 +10517,49 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Schedule": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Schedule",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Schedule",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Schedule",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Schedule",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Schedule",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"actor": SearchParamInfo{
-			Name: "actor",
-			Type: "reference",
+			Resource: "Schedule",
+			Name:     "actor",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "actor", Type: "Reference"},
 			},
@@ -9398,22 +10573,25 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "Schedule",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "planningHorizon", Type: "Period"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Schedule",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Schedule",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]type", Type: "CodeableConcept"},
 			},
@@ -9421,85 +10599,97 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"SearchParameter": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "SearchParameter",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "SearchParameter",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"base": SearchParamInfo{
-			Name: "base",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "base",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "base", Type: "code"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "code"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "SearchParameter",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "SearchParameter",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"target": SearchParamInfo{
-			Name: "target",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "target",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]target", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "SearchParameter",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "SearchParameter",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
@@ -9507,57 +10697,65 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Slot": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Slot",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Slot",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"fb-type": SearchParamInfo{
-			Name: "fb-type",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "fb-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "freeBusyType", Type: "code"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"schedule": SearchParamInfo{
-			Name: "schedule",
-			Type: "reference",
+			Resource: "Slot",
+			Name:     "schedule",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "schedule", Type: "Reference"},
 			},
@@ -9566,15 +10764,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"slot-type": SearchParamInfo{
-			Name: "slot-type",
-			Type: "token",
+			Resource: "Slot",
+			Name:     "slot-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
 		},
 		"start": SearchParamInfo{
-			Name: "start",
-			Type: "date",
+			Resource: "Slot",
+			Name:     "start",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "start", Type: "instant"},
 			},
@@ -9582,65 +10782,74 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Specimen": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Specimen",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Specimen",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"accession": SearchParamInfo{
-			Name: "accession",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "accession",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "accessionIdentifier", Type: "Identifier"},
 			},
 		},
 		"bodysite": SearchParamInfo{
-			Name: "bodysite",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "bodysite",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "collection.bodySite", Type: "CodeableConcept"},
 			},
 		},
 		"collected": SearchParamInfo{
-			Name: "collected",
-			Type: "date",
+			Resource: "Specimen",
+			Name:     "collected",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "collection.collectedDateTime", Type: "dateTime"},
 				SearchParamPath{Path: "collection.collectedPeriod", Type: "Period"},
 			},
 		},
 		"collector": SearchParamInfo{
-			Name: "collector",
-			Type: "reference",
+			Resource: "Specimen",
+			Name:     "collector",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "collection.collector", Type: "Reference"},
 			},
@@ -9649,29 +10858,33 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"container": SearchParamInfo{
-			Name: "container",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "container",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]container.type", Type: "CodeableConcept"},
 			},
 		},
 		"container-id": SearchParamInfo{
-			Name: "container-id",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "container-id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]container.[]identifier", Type: "Identifier"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"parent": SearchParamInfo{
-			Name: "parent",
-			Type: "reference",
+			Resource: "Specimen",
+			Name:     "parent",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]parent", Type: "Reference"},
 			},
@@ -9680,8 +10893,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "Specimen",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -9690,8 +10904,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"subject": SearchParamInfo{
-			Name: "subject",
-			Type: "reference",
+			Resource: "Specimen",
+			Name:     "subject",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "subject", Type: "Reference"},
 			},
@@ -9703,8 +10918,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Specimen",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "type", Type: "CodeableConcept"},
 			},
@@ -9712,178 +10928,203 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"StructureDefinition": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "StructureDefinition",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "StructureDefinition",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"abstract": SearchParamInfo{
-			Name: "abstract",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "abstract",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "abstract", Type: "boolean"},
 			},
 		},
 		"base": SearchParamInfo{
-			Name: "base",
-			Type: "uri",
+			Resource: "StructureDefinition",
+			Name:     "base",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "base", Type: "uri"},
 			},
 		},
 		"base-path": SearchParamInfo{
-			Name: "base-path",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "base-path",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "differential.[]element.base.path", Type: "string"},
 				SearchParamPath{Path: "snapshot.[]element.base.path", Type: "string"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]code", Type: "Coding"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"context-type": SearchParamInfo{
-			Name: "context-type",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "context-type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "contextType", Type: "code"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "StructureDefinition",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "StructureDefinition",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"display": SearchParamInfo{
-			Name: "display",
-			Type: "string",
+			Resource: "StructureDefinition",
+			Name:     "display",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "display", Type: "string"},
 			},
 		},
 		"experimental": SearchParamInfo{
-			Name: "experimental",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "experimental",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "experimental", Type: "boolean"},
 			},
 		},
 		"ext-context": SearchParamInfo{
-			Name: "ext-context",
-			Type: "string",
+			Resource: "StructureDefinition",
+			Name:     "ext-context",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]context", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"kind": SearchParamInfo{
-			Name: "kind",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "kind",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "kind", Type: "code"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "StructureDefinition",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"path": SearchParamInfo{
-			Name: "path",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "path",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "differential.[]element.path", Type: "string"},
 				SearchParamPath{Path: "snapshot.[]element.path", Type: "string"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "StructureDefinition",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "constrainedType", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "StructureDefinition",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"valueset": SearchParamInfo{
-			Name: "valueset",
-			Type: "reference",
+			Resource: "StructureDefinition",
+			Name:     "valueset",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "snapshot.[]element.binding.valueSetReference", Type: "Reference"},
 			},
@@ -9892,8 +11133,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "StructureDefinition",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -9901,85 +11143,97 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Subscription": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Subscription",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Subscription",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"contact": SearchParamInfo{
-			Name: "contact",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "contact",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]contact", Type: "ContactPoint"},
 			},
 		},
 		"criteria": SearchParamInfo{
-			Name: "criteria",
-			Type: "string",
+			Resource: "Subscription",
+			Name:     "criteria",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "criteria", Type: "string"},
 			},
 		},
 		"payload": SearchParamInfo{
-			Name: "payload",
-			Type: "string",
+			Resource: "Subscription",
+			Name:     "payload",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "channel.payload", Type: "string"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"tag": SearchParamInfo{
-			Name: "tag",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]tag", Type: "Coding"},
 			},
 		},
 		"type": SearchParamInfo{
-			Name: "type",
-			Type: "token",
+			Resource: "Subscription",
+			Name:     "type",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "channel.type", Type: "code"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "Subscription",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "channel.endpoint", Type: "uri"},
 			},
@@ -9987,85 +11241,97 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"Substance": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "Substance",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "Substance",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"category": SearchParamInfo{
-			Name: "category",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "category",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]category", Type: "CodeableConcept"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "code", Type: "CodeableConcept"},
 			},
 		},
 		"container-identifier": SearchParamInfo{
-			Name: "container-identifier",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "container-identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]instance.identifier", Type: "Identifier"},
 			},
 		},
 		"expiry": SearchParamInfo{
-			Name: "expiry",
-			Type: "date",
+			Resource: "Substance",
+			Name:     "expiry",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]instance.expiry", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "Substance",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"quantity": SearchParamInfo{
-			Name: "quantity",
-			Type: "quantity",
+			Resource: "Substance",
+			Name:     "quantity",
+			Type:     "quantity",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]instance.quantity", Type: "SimpleQuantity"},
 			},
 		},
 		"substance": SearchParamInfo{
-			Name: "substance",
-			Type: "reference",
+			Resource: "Substance",
+			Name:     "substance",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]ingredient.substance", Type: "Reference"},
 			},
@@ -10076,50 +11342,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"SupplyDelivery": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "SupplyDelivery",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "SupplyDelivery",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "SupplyDelivery",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "SupplyDelivery",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "SupplyDelivery",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "SupplyDelivery",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "SupplyDelivery",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -10128,8 +11401,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"receiver": SearchParamInfo{
-			Name: "receiver",
-			Type: "reference",
+			Resource: "SupplyDelivery",
+			Name:     "receiver",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]receiver", Type: "Reference"},
 			},
@@ -10138,15 +11412,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "SupplyDelivery",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"supplier": SearchParamInfo{
-			Name: "supplier",
-			Type: "reference",
+			Resource: "SupplyDelivery",
+			Name:     "supplier",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "supplier", Type: "Reference"},
 			},
@@ -10157,64 +11433,73 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"SupplyRequest": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "SupplyRequest",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "SupplyRequest",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "SupplyRequest",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"kind": SearchParamInfo{
-			Name: "kind",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "kind",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "kind", Type: "CodeableConcept"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "SupplyRequest",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -10223,8 +11508,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"source": SearchParamInfo{
-			Name: "source",
-			Type: "reference",
+			Resource: "SupplyRequest",
+			Name:     "source",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "source", Type: "Reference"},
 			},
@@ -10235,15 +11521,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "SupplyRequest",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"supplier": SearchParamInfo{
-			Name: "supplier",
-			Type: "reference",
+			Resource: "SupplyRequest",
+			Name:     "supplier",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]supplier", Type: "Reference"},
 			},
@@ -10254,85 +11542,97 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"TestScript": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "TestScript",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "TestScript",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "TestScript",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "TestScript",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "TestScript",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "TestScript",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "TestScript",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "TestScript",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"testscript-capability": SearchParamInfo{
-			Name: "testscript-capability",
-			Type: "string",
+			Resource: "TestScript",
+			Name:     "testscript-capability",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "metadata.[]capability.description", Type: "string"},
 			},
 		},
 		"testscript-setup-capability": SearchParamInfo{
-			Name: "testscript-setup-capability",
-			Type: "string",
+			Resource: "TestScript",
+			Name:     "testscript-setup-capability",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "setup.metadata.[]capability.description", Type: "string"},
 			},
 		},
 		"testscript-test-capability": SearchParamInfo{
-			Name: "testscript-test-capability",
-			Type: "string",
+			Resource: "TestScript",
+			Name:     "testscript-test-capability",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]test.metadata.[]capability.description", Type: "string"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "TestScript",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
@@ -10340,127 +11640,145 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"ValueSet": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "ValueSet",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "ValueSet",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"code": SearchParamInfo{
-			Name: "code",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "code",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "codeSystem.[]concept.code", Type: "code"},
 			},
 		},
 		"context": SearchParamInfo{
-			Name: "context",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "context",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]useContext", Type: "CodeableConcept"},
 			},
 		},
 		"date": SearchParamInfo{
-			Name: "date",
-			Type: "date",
+			Resource: "ValueSet",
+			Name:     "date",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "date", Type: "dateTime"},
 			},
 		},
 		"description": SearchParamInfo{
-			Name: "description",
-			Type: "string",
+			Resource: "ValueSet",
+			Name:     "description",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "description", Type: "string"},
 			},
 		},
 		"expansion": SearchParamInfo{
-			Name: "expansion",
-			Type: "uri",
+			Resource: "ValueSet",
+			Name:     "expansion",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "expansion.identifier", Type: "uri"},
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "identifier", Type: "Identifier"},
 			},
 		},
 		"name": SearchParamInfo{
-			Name: "name",
-			Type: "string",
+			Resource: "ValueSet",
+			Name:     "name",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "name", Type: "string"},
 			},
 		},
 		"publisher": SearchParamInfo{
-			Name: "publisher",
-			Type: "string",
+			Resource: "ValueSet",
+			Name:     "publisher",
+			Type:     "string",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "publisher", Type: "string"},
 			},
 		},
 		"reference": SearchParamInfo{
-			Name: "reference",
-			Type: "uri",
+			Resource: "ValueSet",
+			Name:     "reference",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "compose.[]include.system", Type: "uri"},
 			},
 		},
 		"status": SearchParamInfo{
-			Name: "status",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "status",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "status", Type: "code"},
 			},
 		},
 		"system": SearchParamInfo{
-			Name: "system",
-			Type: "uri",
+			Resource: "ValueSet",
+			Name:     "system",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "codeSystem.system", Type: "uri"},
 			},
 		},
 		"url": SearchParamInfo{
-			Name: "url",
-			Type: "uri",
+			Resource: "ValueSet",
+			Name:     "url",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "url", Type: "uri"},
 			},
 		},
 		"version": SearchParamInfo{
-			Name: "version",
-			Type: "token",
+			Resource: "ValueSet",
+			Name:     "version",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "version", Type: "string"},
 			},
@@ -10468,50 +11786,57 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 	},
 	"VisionPrescription": map[string]SearchParamInfo{
 		"_id": SearchParamInfo{
-			Name: "_id",
-			Type: "token",
+			Resource: "VisionPrescription",
+			Name:     "_id",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "_id", Type: "id"},
 			},
 		},
 		"_lastUpdated": SearchParamInfo{
-			Name: "_lastUpdated",
-			Type: "date",
+			Resource: "VisionPrescription",
+			Name:     "_lastUpdated",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.lastUpdated", Type: "instant"},
 			},
 		},
 		"_profile": SearchParamInfo{
-			Name: "_profile",
-			Type: "uri",
+			Resource: "VisionPrescription",
+			Name:     "_profile",
+			Type:     "uri",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]profile", Type: "uri"},
 			},
 		},
 		"_security": SearchParamInfo{
-			Name: "_security",
-			Type: "token",
+			Resource: "VisionPrescription",
+			Name:     "_security",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]security", Type: "Coding"},
 			},
 		},
 		"_tag": SearchParamInfo{
-			Name: "_tag",
-			Type: "token",
+			Resource: "VisionPrescription",
+			Name:     "_tag",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "meta.[]tag", Type: "Coding"},
 			},
 		},
 		"datewritten": SearchParamInfo{
-			Name: "datewritten",
-			Type: "date",
+			Resource: "VisionPrescription",
+			Name:     "datewritten",
+			Type:     "date",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "dateWritten", Type: "dateTime"},
 			},
 		},
 		"encounter": SearchParamInfo{
-			Name: "encounter",
-			Type: "reference",
+			Resource: "VisionPrescription",
+			Name:     "encounter",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "encounter", Type: "Reference"},
 			},
@@ -10520,15 +11845,17 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"identifier": SearchParamInfo{
-			Name: "identifier",
-			Type: "token",
+			Resource: "VisionPrescription",
+			Name:     "identifier",
+			Type:     "token",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "[]identifier", Type: "Identifier"},
 			},
 		},
 		"patient": SearchParamInfo{
-			Name: "patient",
-			Type: "reference",
+			Resource: "VisionPrescription",
+			Name:     "patient",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "patient", Type: "Reference"},
 			},
@@ -10537,8 +11864,9 @@ var SearchParameterDictionary = map[string]map[string]SearchParamInfo{
 			},
 		},
 		"prescriber": SearchParamInfo{
-			Name: "prescriber",
-			Type: "reference",
+			Resource: "VisionPrescription",
+			Name:     "prescriber",
+			Type:     "reference",
 			Paths: []SearchParamPath{
 				SearchParamPath{Path: "prescriber", Type: "Reference"},
 			},


### PR DESCRIPTION
Added support for \_revinclude searches and added support for third part of include parameters (now you can state the target type of the include when there is more than one possibility; eg. _/Condition?\_include=Condition:asserter:Practitioner_).

Also renamed include-related structs and function names to make more sense for \_include and \_revinclude, as well as to be more descriptive.