### PR TITLE
Providing support for Parameters in Bundle entry

### DIFF
--- a/models/util.go
+++ b/models/util.go
@@ -539,6 +539,14 @@ func MapToResource(resourceMap interface{}, asPointer bool) interface{} {
 		} else {
 			return x
 		}
+	case "Parameters":
+		x := Parameters{}
+		json.Unmarshal(b, &x)
+		if asPointer {
+			return &x
+		} else {
+			return x
+		}
 	case "Patient":
 		x := Patient{}
 		json.Unmarshal(b, &x)


### PR DESCRIPTION
This change makes sure that Parameters has the proper marshal and unmarshal
code. Also makes sure that Parameters is in MapToResource so that the
BundleEntryComponent can properly unmarshal it.

Fixes #35