### PR TITLE
Search sort

### DIFF
--- a/fixtures/search_test_data.json
+++ b/fixtures/search_test_data.json
@@ -233,7 +233,7 @@
 		}],
 		"text": "Pertussis (disorder)"
 	},
-	"onsetDateTime": "2011-10-23T012:00:00-05:00"
+	"onsetDateTime": "2011-10-23T12:00:00-05:00"
 }, {
 	"resourceType": "Observation",
 	"id": "5637152931209212154",
@@ -668,10 +668,10 @@
           {
             "use": "official",
             "family": [
-              "Donald"
+              "Duck"
             ],
             "given": [
-              "Duck"
+              "Donald"
             ]
           }
         ],
@@ -687,11 +687,10 @@
           {
             "use": "official",
             "family": [
-              "Donald"
+              "Duck"
             ],
             "given": [
-              "Duck",
-              "D"
+              "Daffy"
             ]
           }
         ],

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -49,17 +49,21 @@ func (m *MongoSearcher) createQuery(query Query, withOptions bool) *mgo.Query {
 	q := m.createQueryObject(query)
 	mgoQuery := c.Find(q)
 
-	// Horrible, horrible hack (for now) to ensure patients are sorted by name.  This is needed by
-	// the frontend, else paging won't work correctly.  This should be removed when the general
-	// sorting feature is implemented.
-	if query.Resource == "Patient" {
-		// To add insult to injury, mongo will not let us sort by family *and* given name:
-		// Executor error: BadValue cannot sort with keys that are parallel arrays
-		mgoQuery = mgoQuery.Sort("name.0.family.0" /*", name.0.given.0"*/, "_id")
-	}
-
 	if withOptions {
 		o := query.Options()
+		removeParallelArraySorts(o)
+		if len(o.Sort) > 0 {
+			fields := make([]string, len(o.Sort))
+			for i := range o.Sort {
+				// Note: If there are multiple paths, we only look at the first one -- not ideal, but otherwise it gets tricky
+				field := convertSearchPathToMongoField(o.Sort[i].Parameter.Paths[0].Path)
+				if o.Sort[i].Descending {
+					field = "-" + field
+				}
+				fields[i] = field
+			}
+			mgoQuery = mgoQuery.Sort(fields...)
+		}
 		if o.Offset > 0 {
 			mgoQuery = mgoQuery.Skip(o.Offset)
 		}
@@ -617,9 +621,8 @@ func buildBSON(path string, criteria interface{}) bson.M {
 	result := bson.M{}
 
 	// First fix the indexers so "[0]entry.resource" becomes "entry.0.resource"
-	re := regexp.MustCompile("\\[(\\d+)\\]([^\\.]+)")
-	indexedPath := re.ReplaceAllString(path, "$2.$1")
-	normalizedPath := strings.Replace(indexedPath, "[]", "", -1)
+	indexedPath := convertBracketIndexesToDotIndexes(path)
+	normalizedPath := convertSearchPathToMongoField(path)
 	bCriteria, ok := criteria.(bson.M)
 	if ok {
 		pathRegex := regexp.MustCompile("(.*\\[\\][^\\.]*)\\.?([^\\[\\]]*)")
@@ -660,6 +663,64 @@ func buildBSON(path string, criteria interface{}) bson.M {
 	}
 
 	return result
+}
+
+// Fixes the array markers/indexers so "[]element.[0]target.[]product.element" becomes "element.target.product.element"
+func convertSearchPathToMongoField(path string) string {
+	indexedPath := convertBracketIndexesToDotIndexes(path)
+	return strings.Replace(indexedPath, "[]", "", -1)
+}
+
+// Fixes just the indexers so "[]element.[0]target.[]product.element" becomes "element.target.0.product.element"
+func convertBracketIndexesToDotIndexes(path string) string {
+	re := regexp.MustCompile("\\[(\\d+)\\]([^\\.]+)")
+	return re.ReplaceAllString(path, "$2.$1")
+}
+
+// MongoDB does not properly sort when keys are in parallel arrays ("Executor error: BadValue cannot sort with keys
+// that are parallel arrays"), so... remove any sort options that have parallel arrays (and log it)
+func removeParallelArraySorts(o *QueryOptions) {
+	npSorts := make([]SortOption, 0, len(o.Sort))
+	for i := range o.Sort {
+		sort := o.Sort[i]
+		isParallel := false
+		for _, npSort := range npSorts {
+			isParallel = isParallelArrayPath(sort.Parameter.Paths[0].Path, npSort.Parameter.Paths[0].Path)
+			if isParallel {
+				fmt.Printf("Cannot sub-sort on param '%s' because its path has parallel arrays with previous sort param '%s' (due to limitation in MongoDB)\n.", sort.Parameter.Name, npSort.Parameter.Name)
+				break
+			}
+		}
+		if !isParallel {
+			npSorts = append(npSorts, sort)
+		}
+	}
+	// If we ended up removing sort options, update the Options object to reflect that
+	if len(o.Sort) != len(npSorts) {
+		o.Sort = npSorts
+	}
+}
+
+func isParallelArrayPath(path1 string, path2 string) bool {
+	// If one of them doesn't have any arrays then there can't be any parallel arrays
+	if !strings.Contains(path1, "[") || !strings.Contains(path2, "[") {
+		return false
+	}
+
+	// Take out specific indexers for easier comparison (e.g., "[0]key" becomes "[]key")
+	re := regexp.MustCompile("\\[\\d+\\]")
+	path1 = re.ReplaceAllString(path1, "[]")
+	path2 = re.ReplaceAllString(path2, "[]")
+
+	// Now iterate through until non-matching character
+	for i := 0; i < len(path1) && i < len(path2); i++ {
+		if path1[i] != path2[i] {
+			// Check to see if any of the matching part of the path has an array
+			return strings.Contains(path1[:i], "[")
+		}
+	}
+
+	return false
 }
 
 func isQueryOperator(key string) bool {

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -1551,8 +1551,8 @@ func (m *MongoSearchSuite) TestModifierSearchPanics(c *C) {
 }
 
 func (m *MongoSearchSuite) TestUnsupportedSearchResultParameterPanics(c *C) {
-	q := Query{"Condition", "_sort:asc=onset"}
-	c.Assert(func() { m.MongoSearcher.CreateQuery(q) }, Panics, createUnsupportedSearchError("MSG_PARAM_UNKNOWN", "Parameter \"_sort\" not understood"))
+	q := Query{"Condition", "_contained=true"}
+	c.Assert(func() { m.MongoSearcher.CreateQuery(q) }, Panics, createUnsupportedSearchError("MSG_PARAM_UNKNOWN", "Parameter \"_contained\" not understood"))
 }
 
 func (m *MongoSearchSuite) TestUsupportedGlobalSearchParameterPanics(c *C) {

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -2,10 +2,12 @@ package search
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -140,6 +142,51 @@ func (m *MongoSearchSuite) TestConditionCodeQueryByCode(c *C) {
 	c.Assert(foundIvd && foundCad, Equals, true)
 }
 
+func (m *MongoSearchSuite) TestConditionSortByCodeAscending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort=code"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	var lastVal string
+	for _, cond := range conditions {
+		thisVal := getCodeableConceptComparisonValue(cond.Code)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestConditionSortByCodeDescending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort:desc=code"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	lastVal := "~"
+	for _, cond := range conditions {
+		thisVal := getCodeableConceptComparisonValue(cond.Code)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Approximating MongoDB sort strategy
+func getCodeableConceptComparisonValue(c *models.CodeableConcept) string {
+	//return getCodingsComparisonValue(c.Coding) + c.Text
+	if len(c.Coding) > 0 {
+		c0 := c.Coding[0]
+		var userSel string
+		if c0.UserSelected != nil {
+			userSel = fmt.Sprintf("%t", *c0.UserSelected)
+		}
+		return fmt.Sprintf("%s%s%s%s%s", c0.Code, c0.Display, c0.System, userSel, c0.Version) + c.Text
+	}
+
+	return c.Text
+}
+
 // Tests token searches on Coding
 
 func (m *MongoSearchSuite) TestImagingStudyBodySiteQueryObjectBySystemAndCode(c *C) {
@@ -202,6 +249,53 @@ func (m *MongoSearchSuite) TestEncounterIdentifierQueryByWrongSystem(c *C) {
 	c.Assert(num, Equals, 0)
 }
 
+func (m *MongoSearchSuite) TestEncounterSortByIdentifierAscending(c *C) {
+	var encounters []*models.Encounter
+	q := Query{"Encounter", "_sort=identifier"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&encounters)
+	util.CheckErr(err)
+	c.Assert(encounters, HasLen, 4)
+	var lastVal string
+	for _, enc := range encounters {
+		thisVal := getIdentifiersComparisonValue(enc.Identifier, false)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestEncounterSortByIdentifierDescending(c *C) {
+	var encounters []*models.Encounter
+	q := Query{"Encounter", "_sort:desc=identifier"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&encounters)
+	util.CheckErr(err)
+	c.Assert(encounters, HasLen, 4)
+	lastVal := "~"
+	for _, enc := range encounters {
+		thisVal := getIdentifiersComparisonValue(enc.Identifier, true)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Approximating MongoDB sort strategy
+func getIdentifiersComparisonValue(iSlice []models.Identifier, descending bool) string {
+	if len(iSlice) == 0 {
+		return ""
+	}
+
+	strs := make([]string, len(iSlice))
+	for i := range iSlice {
+		strs[i] = iSlice[i].System + iSlice[i].Use + iSlice[i].Value
+	}
+	sort.Strings(strs)
+	if descending {
+		return strs[len(strs)-1]
+	}
+	return strs[0]
+}
+
 // TODO: Test token searches on boolean, code, string, and ContactPoint
 
 // Tests reference searches by reference id
@@ -248,6 +342,45 @@ func (m *MongoSearchSuite) TestConditionReferenceQueryObjectByPatientURL(c *C) {
 
 	o := m.MongoSearcher.createQueryObject(q)
 	c.Assert(o, DeepEquals, bson.M{"patient.reference": bson.RegEx{Pattern: "^http://acme\\.com/Patient/123456789$", Options: "i"}})
+}
+
+func (m *MongoSearchSuite) TestConditionSortByPatientAscending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort=patient"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	var lastVal string
+	for _, cond := range conditions {
+		thisVal := getReferenceComparisonValue(cond.Patient)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestConditionSortByPatientDescending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort:desc=patient"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	lastVal := "~"
+	for _, cond := range conditions {
+		thisVal := getReferenceComparisonValue(cond.Patient)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Approximating MongoDB sort strategy
+func getReferenceComparisonValue(r *models.Reference) string {
+	var ext string
+	if r.External != nil {
+		ext = fmt.Sprintf("%t", *r.External)
+	}
+	return fmt.Sprintf("%s%s%s%s%s", r.Display, ext, r.Reference, r.ReferencedID, r.Type)
 }
 
 // These next tests ensure that the indexer is properly converted to a mongo
@@ -521,6 +654,36 @@ func (m *MongoSearchSuite) TestConditionOnsetLEQuery(c *C) {
 	c.Assert(num, Equals, 5)
 }
 
+func (m *MongoSearchSuite) TestConditionSortByOnsetAscending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort=onset"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	var lastVal time.Time
+	for _, cond := range conditions {
+		thisVal := cond.OnsetDateTime.Time
+		c.Assert(thisVal.Before(lastVal), Equals, false)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestConditionSortByOnsetDescending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort:desc=onset"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	lastVal := time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for _, cond := range conditions {
+		thisVal := cond.OnsetDateTime.Time
+		c.Assert(thisVal.After(lastVal), Equals, false)
+		lastVal = thisVal
+	}
+}
+
 // Test date searches on Period
 
 func (m *MongoSearchSuite) TestEncounterPeriodQueryObject(c *C) {
@@ -678,6 +841,36 @@ func (m *MongoSearchSuite) TestEncounterPeriodLEQuery(c *C) {
 	c.Assert(num, Equals, 4)
 }
 
+func (m *MongoSearchSuite) TestEncounterSortByPeriodAscending(c *C) {
+	var encounters []*models.Encounter
+	q := Query{"Encounter", "_sort=date"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&encounters)
+	util.CheckErr(err)
+	c.Assert(encounters, HasLen, 4)
+	var lastVal time.Time
+	for _, enc := range encounters {
+		thisVal := enc.Period.Start.Time
+		c.Assert(thisVal.Before(lastVal), Equals, false)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestEncounterSortByPeriodDescending(c *C) {
+	var encounters []*models.Encounter
+	q := Query{"Encounter", "_sort:desc=date"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&encounters)
+	util.CheckErr(err)
+	c.Assert(encounters, HasLen, 4)
+	lastVal := time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for _, enc := range encounters {
+		thisVal := enc.Period.Start.Time
+		c.Assert(thisVal.After(lastVal), Equals, false)
+		lastVal = thisVal
+	}
+}
+
 // TODO: Test date searches on date, instant, and Timing
 
 // Test number searches on positiveInt
@@ -756,6 +949,36 @@ func (m *MongoSearchSuite) TestNonMatchingDeviceStringQuery(c *C) {
 	c.Assert(num, Equals, 0)
 }
 
+func (m *MongoSearchSuite) TestPatientSortByGivenAscending(c *C) {
+	var patients []*models.Patient
+	q := Query{"Patient", "_sort=given"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&patients)
+	util.CheckErr(err)
+	c.Assert(patients, HasLen, 2)
+	var lastVal string
+	for _, p := range patients {
+		thisVal := p.Name[0].Given[0]
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestPatientSortByGivenDescending(c *C) {
+	var patients []*models.Patient
+	q := Query{"Patient", "_sort:desc=given"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&patients)
+	util.CheckErr(err)
+	c.Assert(patients, HasLen, 2)
+	lastVal := "~"
+	for _, p := range patients {
+		thisVal := p.Name[0].Given[0]
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
 // Test string searches on HumanName
 
 func (m *MongoSearchSuite) TestPatientNameStringQueryObject(c *C) {
@@ -791,6 +1014,66 @@ func (m *MongoSearchSuite) TestNonMatchingPatientNameStringQuery(c *C) {
 	num, err := mq.Count()
 	util.CheckErr(err)
 	c.Assert(num, Equals, 0)
+}
+
+func (m *MongoSearchSuite) TestPatientSortByNameAscending(c *C) {
+	var patients []*models.Patient
+	q := Query{"Patient", "_sort=name"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&patients)
+	util.CheckErr(err)
+	c.Assert(patients, HasLen, 2)
+	var lastVal string
+	for _, p := range patients {
+		thisVal := getHumanNamesComparisonValue(p.Name, false)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestPatientSortByNameDescending(c *C) {
+	var patients []*models.Patient
+	q := Query{"Patient", "_sort:desc=name"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&patients)
+	util.CheckErr(err)
+	c.Assert(patients, HasLen, 2)
+	lastVal := "~"
+	for _, p := range patients {
+		thisVal := getHumanNamesComparisonValue(p.Name, true)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Approximating MongoDB sort strategy
+func getHumanNamesComparisonValue(nSlice []models.HumanName, descending bool) string {
+	if len(nSlice) == 0 {
+		return ""
+	}
+
+	strs := make([]string, len(nSlice))
+	for i := range nSlice {
+		strs[i] = getHumanNameComparisonValue(nSlice[i])
+	}
+	sort.Strings(strs)
+	if descending {
+		return strs[len(strs)-1]
+	}
+	return strs[0]
+}
+
+// Approximating MongoDB sort strategy
+func getHumanNameComparisonValue(n models.HumanName) string {
+	var last string
+	if len(n.Family) > 0 {
+		last = n.Family[0]
+	}
+	var first string
+	if len(n.Given) > 0 {
+		first = n.Given[0]
+	}
+	return last + first
 }
 
 // Test string searches on Address
@@ -921,6 +1204,49 @@ func (m *MongoSearchSuite) TestValueQuantityQueryByValueAndSystemAndWrongCode(c 
 	c.Assert(num, Equals, 0)
 }
 
+func (m *MongoSearchSuite) TestObservationSortByValueQuantityAscending(c *C) {
+	var observations []*models.Observation
+	q := Query{"Observation", "_sort=value-quantity"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&observations)
+	util.CheckErr(err)
+	c.Assert(observations, HasLen, 5)
+	var lastVal string
+	for _, o := range observations {
+		thisVal := getQuantityComparisonValue(o.ValueQuantity)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestObservationSortByValueQuantityDescending(c *C) {
+	var observations []*models.Observation
+	q := Query{"Observation", "_sort:desc=value-quantity"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&observations)
+	util.CheckErr(err)
+	c.Assert(observations, HasLen, 5)
+	lastVal := "~"
+	for _, o := range observations {
+		thisVal := getQuantityComparisonValue(o.ValueQuantity)
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Approximating MongoDB sort strategy
+func getQuantityComparisonValue(q *models.Quantity) string {
+	if q == nil {
+		return ""
+	}
+
+	var value string
+	if q.Value != nil {
+		value = fmt.Sprintf("%f", *q.Value)
+	}
+	return fmt.Sprintf("%s%s%s%s%s", q.Code, q.Comparator, q.System, q.Unit, value)
+}
+
 // TODO: Test quantity searches on Money, SimpleQuantity, Duration, Count, Distance, and Age
 
 // Test URI searches on URI
@@ -968,6 +1294,38 @@ func (m *MongoSearchSuite) TestConditionIdQuery(c *C) {
 
 	c.Assert(cond, DeepEquals, cond2)
 }
+
+func (m *MongoSearchSuite) TestConditionSortByIdAscending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort=_id"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	var lastVal string
+	for _, cond := range conditions {
+		thisVal := cond.Id
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), 1)
+		lastVal = thisVal
+	}
+}
+
+func (m *MongoSearchSuite) TestConditionSortByIdDescending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort:desc=_id"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	lastVal := "~"
+	for _, cond := range conditions {
+		thisVal := cond.Id
+		c.Assert(strings.Compare(lastVal, thisVal), Not(Equals), -1)
+		lastVal = thisVal
+	}
+}
+
+// Tests special searches on _tag
 
 func (m *MongoSearchSuite) TestConditionTagQueryObject(c *C) {
 	q := Query{"Condition", "_tag=foo|bar"}
@@ -1324,6 +1682,71 @@ func (m *MongoSearchSuite) TestEncounterTypeQueryWithCountAndOffset(c *C) {
 
 	// Now make sure they are not the same
 	c.Assert(offset1.Id, Not(Equals), offset2.Id)
+}
+
+func (m *MongoSearchSuite) TestConditionSortWithMultipleSortParams(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort=patient&_sort=onset&_sort=code"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	var lastPatient string
+	var lastOnset time.Time
+	var lastCode string
+	for _, cond := range conditions {
+		thisPatient := getReferenceComparisonValue(cond.Patient)
+		thisOnset := cond.OnsetDateTime.Time
+		thisCode := getCodeableConceptComparisonValue(cond.Code)
+		c.Assert(strings.Compare(lastPatient, thisPatient), Not(Equals), 1)
+		if thisPatient == lastPatient {
+			c.Assert(thisOnset.Before(lastOnset), Equals, false)
+			if thisOnset.Equal(lastOnset) {
+				c.Assert(strings.Compare(lastCode, thisCode), Not(Equals), 1)
+			}
+		}
+		lastPatient = thisPatient
+		lastOnset = thisOnset
+		lastCode = thisCode
+	}
+}
+
+func (m *MongoSearchSuite) TestConditionSortWithMultipleSortParamsDescending(c *C) {
+	var conditions []*models.Condition
+	q := Query{"Condition", "_sort:desc=patient&_sort:desc=onset&_sort:desc=code"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&conditions)
+	util.CheckErr(err)
+	c.Assert(conditions, HasLen, 6)
+	lastPatient := "~"
+	lastOnset := time.Date(3000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	lastCode := "~"
+	for _, cond := range conditions {
+		thisPatient := getReferenceComparisonValue(cond.Patient)
+		thisOnset := cond.OnsetDateTime.Time
+		thisCode := getCodeableConceptComparisonValue(cond.Code)
+		c.Assert(strings.Compare(lastPatient, thisPatient), Not(Equals), -1)
+		if thisPatient == lastPatient {
+			c.Assert(thisOnset.After(lastOnset), Equals, false)
+			if thisOnset.Equal(lastOnset) {
+				c.Assert(strings.Compare(lastCode, thisCode), Not(Equals), -1)
+			}
+		}
+		lastPatient = thisPatient
+		lastOnset = thisOnset
+		lastCode = thisCode
+	}
+}
+
+func (m *MongoSearchSuite) TestSortingOnParallelArrayPathsDoesntPanic(c *C) {
+	var patients []*models.Patient
+	// NOTE: Sorting on family and patient normally causes MongoDB to balk because they have "parallel arrays", but we
+	// should just drop the second sort param instead of panicing
+	q := Query{"Patient", "_sort=family&_sort=given"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	err := mq.All(&patients)
+	util.CheckErr(err)
+	c.Assert(patients, HasLen, 2)
 }
 
 func (m *MongoSearchSuite) TestObservationCodeQueryOptionsForInclude(c *C) {

--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -65,9 +65,9 @@ type Query struct {
 // slice containing a ReferenceParam (for patient) and a DateParam (for onset).
 func (q *Query) Params() []SearchParam {
 	var results []SearchParam
-	queryMap, _ := url.ParseQuery(q.Query)
-	for param, values := range queryMap {
-		param, modifier, postfix := ParseParamNameModifierAndPostFix(param)
+	queryParams, _ := ParseQuery(q.Query)
+	for _, queryParam := range queryParams.All() {
+		param, modifier, postfix := ParseParamNameModifierAndPostFix(queryParam.Key)
 		if isSearchResultParam(param) {
 			continue
 		}
@@ -76,9 +76,7 @@ func (q *Query) Params() []SearchParam {
 		if ok {
 			info.Postfix = postfix
 			info.Modifier = modifier
-			for _, value := range values {
-				results = append(results, info.CreateSearchParam(value))
-			}
+			results = append(results, info.CreateSearchParam(queryParam.Value))
 		} else {
 			// Check if it's a global search parameter. If so, we must not support it yet.
 			if isGlobalSearchParam(param) {
@@ -94,17 +92,16 @@ func (q *Query) Params() []SearchParam {
 // Options parses the query string and returns the QueryOptions.
 func (q *Query) Options() *QueryOptions {
 	options := NewQueryOptions()
-	queryMap, _ := url.ParseQuery(q.Query)
-	for param, values := range queryMap {
-		param, modifier, _ := ParseParamNameModifierAndPostFix(param)
+	queryParams, _ := ParseQuery(q.Query)
+	for _, queryParam := range queryParams.All() {
+		param, modifier, _ := ParseParamNameModifierAndPostFix(queryParam.Key)
 		if !strings.HasPrefix(param, "_") || isGlobalSearchParam(param) {
 			continue
 		}
 
 		switch param {
 		case CountParam:
-			value := getSingletonParamValue(param, values)
-			count, err := strconv.Atoi(value)
+			count, err := strconv.Atoi(queryParam.Value)
 			if err != nil {
 				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_count\" content is invalid"))
 			}
@@ -112,8 +109,7 @@ func (q *Query) Options() *QueryOptions {
 				options.Count = count
 			}
 		case OffsetParam:
-			value := getSingletonParamValue(param, values)
-			offset, err := strconv.Atoi(value)
+			offset, err := strconv.Atoi(queryParam.Value)
 			if err != nil {
 				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_offset\" content is invalid"))
 			}
@@ -121,69 +117,59 @@ func (q *Query) Options() *QueryOptions {
 				options.Offset = offset
 			}
 		case SortParam:
-			for _, value := range values {
-				sortParam, ok := SearchParameterDictionary[q.Resource][value]
-				if !ok {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
-				}
-				descending := false
-				if modifier == "desc" {
-					descending = true
-				}
-				options.Sort = append(options.Sort, SortOption{Descending: descending, Parameter: sortParam})
+			sortParam, ok := SearchParameterDictionary[q.Resource][queryParam.Value]
+			if !ok {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
 			}
+			options.Sort = append(options.Sort, SortOption{Descending: modifier == "desc", Parameter: sortParam})
 		case IncludeParam:
-			for _, value := range values {
-				incls := strings.Split(value, ":")
-				if len(incls) < 2 || len(incls) > 3 {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
-				}
-				inclParam, ok := SearchParameterDictionary[incls[0]][incls[1]]
-				if !ok {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
-				}
-				// Only reference paramaters count, so verify it is a reference parameter
-				if inclParam.Type != "reference" {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
-				}
-				if len(incls) == 3 {
-					if isValidTarget(incls[2], inclParam) {
-						// Modify the targets to include only the one noted
-						inclParam.Targets = []string{incls[2]}
-					} else {
-						panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
-					}
-				}
-				options.Include = append(options.Include, IncludeOption{Resource: incls[0], Parameter: inclParam})
+			incls := strings.Split(queryParam.Value, ":")
+			if len(incls) < 2 || len(incls) > 3 {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
 			}
-		case RevIncludeParam:
-			for _, value := range values {
-				incls := strings.Split(value, ":")
-				if len(incls) < 2 || len(incls) > 3 {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
-				}
-				revInclParam, ok := SearchParameterDictionary[incls[0]][incls[1]]
-				if !ok {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
-				}
-				// Only reference paramaters count, so verify it is a reference parameter
-				if revInclParam.Type != "reference" {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
-				}
-				// Only the currently searched on resource is a valid target (or "Any")
-				target := q.Resource
-				if len(incls) == 3 && incls[2] != target && incls[2] != "Any" {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
-				}
-				// Make sure the selected param actually supports the intended target
-				if isValidTarget(target, revInclParam) {
-					// Modify the targets to include only the resource we're searching on
-					revInclParam.Targets = []string{target}
+			inclParam, ok := SearchParameterDictionary[incls[0]][incls[1]]
+			if !ok {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+			}
+			// Only reference paramaters count, so verify it is a reference parameter
+			if inclParam.Type != "reference" {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
+			}
+			if len(incls) == 3 {
+				if isValidTarget(incls[2], inclParam) {
+					// Modify the targets to include only the one noted
+					inclParam.Targets = []string{incls[2]}
 				} else {
-					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_include\" content is invalid"))
 				}
-				options.RevInclude = append(options.RevInclude, RevIncludeOption{Resource: incls[0], Parameter: revInclParam})
 			}
+			options.Include = append(options.Include, IncludeOption{Resource: incls[0], Parameter: inclParam})
+		case RevIncludeParam:
+			incls := strings.Split(queryParam.Value, ":")
+			if len(incls) < 2 || len(incls) > 3 {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+			}
+			revInclParam, ok := SearchParameterDictionary[incls[0]][incls[1]]
+			if !ok {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+			}
+			// Only reference paramaters count, so verify it is a reference parameter
+			if revInclParam.Type != "reference" {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+			}
+			// Only the currently searched on resource is a valid target (or "Any")
+			target := q.Resource
+			if len(incls) == 3 && incls[2] != target && incls[2] != "Any" {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+			}
+			// Make sure the selected param actually supports the intended target
+			if isValidTarget(target, revInclParam) {
+				// Modify the targets to include only the resource we're searching on
+				revInclParam.Targets = []string{target}
+			} else {
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
+			}
+			options.RevInclude = append(options.RevInclude, RevIncludeOption{Resource: incls[0], Parameter: revInclParam})
 		default:
 			panic(createUnsupportedSearchError("MSG_PARAM_UNKNOWN", fmt.Sprintf("Parameter \"%s\" not understood", param)))
 		}
@@ -207,28 +193,26 @@ func isValidTarget(target string, param SearchParamInfo) bool {
 	return false
 }
 
-// NormalizedQueryValues reconstructs the URL-encoded query based on parsed
+// URLQueryParameters reconstructs the URL-encoded query based on parsed
 // parameters.  This ensures better uniformity/consistency and also removes any
 // garbage parameters or bad formatting in the passed in parameters.  If
 // withOptions is specified, the query options will also be included in the
-// values.
-func (q *Query) NormalizedQueryValues(withOptions bool) url.Values {
-	values := url.Values{}
+// URLQueryParameters.
+func (q *Query) URLQueryParameters(withOptions bool) URLQueryParameters {
+	var queryParams URLQueryParameters
 	for _, param := range q.Params() {
 		k, v := param.getQueryParamAndValue()
-		values.Add(k, v)
+		queryParams.Add(k, v)
 	}
 
 	if withOptions {
-		oValues := q.Options().QueryValues()
-		for k, v := range oValues {
-			for _, v2 := range v {
-				values.Add(k, v2)
-			}
+		oQueryParams := q.Options().URLQueryParameters()
+		for _, oQueryParam := range oQueryParams.All() {
+			queryParams.Add(oQueryParam.Key, oQueryParam.Value)
 		}
 	}
 
-	return values
+	return queryParams
 }
 
 // QueryOptions contains option values such as count and offset.
@@ -245,25 +229,25 @@ func NewQueryOptions() *QueryOptions {
 	return &QueryOptions{Offset: 0, Count: 100}
 }
 
-// QueryValues returns values representing the query options.
-func (o *QueryOptions) QueryValues() url.Values {
-	values := url.Values{}
-	values.Set(CountParam, strconv.Itoa(o.Count))
-	values.Set(OffsetParam, strconv.Itoa(o.Offset))
+// URLQueryParameters returns URLQueryParameters representing the query options.
+func (o *QueryOptions) URLQueryParameters() URLQueryParameters {
+	var queryParams URLQueryParameters
 	for _, sort := range o.Sort {
 		sortParamKey := SortParam
 		if sort.Descending {
 			sortParamKey += ":desc"
 		}
-		values.Add(sortParamKey, sort.Parameter.Name)
+		queryParams.Add(sortParamKey, sort.Parameter.Name)
 	}
+	queryParams.Set(OffsetParam, strconv.Itoa(o.Offset))
+	queryParams.Set(CountParam, strconv.Itoa(o.Count))
 	for _, incl := range o.Include {
-		values.Add(IncludeParam, fmt.Sprintf("%s:%s", incl.Resource, incl.Parameter.Name))
+		queryParams.Add(IncludeParam, fmt.Sprintf("%s:%s", incl.Resource, incl.Parameter.Name))
 	}
 	for _, incl := range o.RevInclude {
-		values.Add(RevIncludeParam, fmt.Sprintf("%s:%s", incl.Resource, incl.Parameter.Name))
+		queryParams.Add(RevIncludeParam, fmt.Sprintf("%s:%s", incl.Resource, incl.Parameter.Name))
 	}
-	return values
+	return queryParams
 }
 
 // IncludeOption describes the data that should be included in query results

--- a/search/url_query_parser.go
+++ b/search/url_query_parser.go
@@ -1,0 +1,141 @@
+package search
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ParseQuery provides an alternative to url.ParseQuery when the order of parameters must be retained.  ParseQuery
+// parses the URL-encoded query string and returns a URLQueryParameters object that can be used to get the ordered list
+// of parameters, a map of the parameters, or parameters by name.  ParseQuery always returns a non-nil
+// URLQueryParameters object containing all the valid query parameters found; err describes the first decoding error
+// encountered, if any.
+func ParseQuery(query string) (u URLQueryParameters, err error) {
+	// Replace ";" with "&" so we can split on a single character
+	query = strings.Replace(query, ";", "&", -1)
+	// Split it into parts (e.g., "foo=bar" is a part)
+	parts := strings.Split(query, "&")
+	// iterate the parts and add them to the URLQueryParameters
+	for _, part := range parts {
+		if i := strings.Index(part, "="); i >= 0 {
+			key, value := part[:i], part[i+1:]
+			key, keyErr := url.QueryUnescape(key)
+			if keyErr != nil {
+				if err == nil {
+					err = keyErr
+				}
+				continue
+			}
+			value, valueErr := url.QueryUnescape(value)
+			if valueErr != nil {
+				if err == nil {
+					err = valueErr
+				}
+				continue
+			}
+			u.Add(key, value)
+		}
+	}
+	return
+}
+
+// URLQueryParameter represents a query parameter as a key/value pair.
+type URLQueryParameter struct {
+	Key   string
+	Value string
+}
+
+// URLQueryParameters represents an ordered list of query parameters that can be manipulated in several different ways.
+type URLQueryParameters struct {
+	params []URLQueryParameter
+}
+
+// Add adds a key/value pair to the end of the list of URLQueryParameters.  If the key already exists, the key/value is
+// still added to the end of the list, as URLQueryParameters permite duplicate keys.  To replace existing values, use
+// Set instead.
+func (u *URLQueryParameters) Add(Key string, value string) {
+	u.params = append(u.params, URLQueryParameter{Key: Key, Value: value})
+}
+
+// Set sets the value for the query parameter with the specified key.  If a query parameter with the specified key
+// already exists, it overwrites the existing value.  If multiple query parameters with the specified key exist, it
+// overwrites the value of the first matching query parameter and removes the remaining query parameters from the
+// list.  If no query parameters exist with the given key, the key/value pair are added as a new query parameter at
+// the end of the list.
+func (u *URLQueryParameters) Set(key string, value string) {
+	var dups []int
+	var found bool
+	for i := range u.params {
+		if u.params[i].Key == key {
+			if !found {
+				u.params[i].Value = value
+				found = true
+			} else {
+				dups = append(dups, i)
+			}
+		}
+	}
+	if !found {
+		u.Add(key, value)
+	} else {
+		for i := range dups {
+			j := dups[i] - i
+			u.params = append(u.params[:j], u.params[j+1:]...)
+		}
+	}
+}
+
+// Get returns the value of the first query parameter with the specified key.  If no query parameters have the specified
+// key, an empty string is returned.
+func (u *URLQueryParameters) Get(key string) string {
+	for i := range u.params {
+		if u.params[i].Key == key {
+			return u.params[i].Value
+		}
+	}
+	return ""
+}
+
+// GetMulti returns a slice containing the values of all the query parameters with the specified key, in the order in which
+// they were originally specified.  If no query parameters have the specified key, an empty slice is returned.
+func (u *URLQueryParameters) GetMulti(key string) []string {
+	var multi []string
+	for i := range u.params {
+		if u.params[i].Key == key {
+			multi = append(multi, u.params[i].Value)
+		}
+	}
+	return multi
+}
+
+// All returns a copy of the slice containing all of the URLQueryParameters in the original order.
+func (u *URLQueryParameters) All() []URLQueryParameter {
+	all := make([]URLQueryParameter, len(u.params))
+	copy(all, u.params)
+	return all
+}
+
+// Values returns a map similar to the map that would be returned by url.ParseQuery().  The url.Values object does not
+// guarantee that order is preserved.  If order must be preserved, use on of the other functions.
+func (u *URLQueryParameters) Values() url.Values {
+	values := url.Values{}
+	for _, param := range u.params {
+		values.Add(param.Key, param.Value)
+	}
+	return values
+}
+
+// Encode returns a URL-encoded string representing the query parameters in the original order.
+func (u *URLQueryParameters) Encode() string {
+	if len(u.params) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(u.params))
+	for i, param := range u.params {
+		parts[i] = fmt.Sprintf("%s=%s", url.QueryEscape(param.Key), url.QueryEscape(param.Value))
+	}
+
+	return strings.Join(parts, "&")
+}

--- a/search/url_query_parser_test.go
+++ b/search/url_query_parser_test.go
@@ -1,0 +1,223 @@
+package search
+
+import (
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+)
+
+type URLQueryParserSuite struct{}
+
+var _ = Suite(&URLQueryParserSuite{})
+
+func (s *URLQueryParserSuite) TestParseQuery(c *C) {
+	p, err := ParseQuery("abc=def&zyx=wvu&lmn=opq&ghi=jkl")
+	util.CheckErr(err)
+	all := p.All()
+	c.Assert(all, HasLen, 4)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "abc", Value: "def"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "zyx", Value: "wvu"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "lmn", Value: "opq"})
+	c.Assert(all[3], DeepEquals, URLQueryParameter{Key: "ghi", Value: "jkl"})
+}
+
+func (s *URLQueryParserSuite) TestParseQueryDuplicateKeys(c *C) {
+	p, err := ParseQuery("abc=def&zyx=wvu&abc=123&lmn=opq&ghi=jkl&abc=xyz")
+	util.CheckErr(err)
+	all := p.All()
+	c.Assert(all, HasLen, 6)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "abc", Value: "def"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "zyx", Value: "wvu"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "abc", Value: "123"})
+	c.Assert(all[3], DeepEquals, URLQueryParameter{Key: "lmn", Value: "opq"})
+	c.Assert(all[4], DeepEquals, URLQueryParameter{Key: "ghi", Value: "jkl"})
+	c.Assert(all[5], DeepEquals, URLQueryParameter{Key: "abc", Value: "xyz"})
+}
+
+func (s *URLQueryParserSuite) TestParseQueryWithEscapedChars(c *C) {
+	p, err := ParseQuery("foo%3Abar=foo%26baz")
+	util.CheckErr(err)
+	all := p.All()
+	c.Assert(all, HasLen, 1)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo:bar", Value: "foo&baz"})
+	c.Assert(p.Get("foo:bar"), Equals, "foo&baz")
+	c.Assert(p.GetMulti("foo:bar"), DeepEquals, []string{"foo&baz"})
+	values := p.Values()
+	c.Assert(values, HasLen, 1)
+	c.Assert(values.Get("foo:bar"), Equals, "foo&baz")
+}
+
+func (s *URLQueryParserSuite) TestAddSingleParam(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	all := p.All()
+	c.Assert(all, HasLen, 1)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar"})
+}
+
+func (s *URLQueryParserSuite) TestAddMultipleParams(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo3", "bar3")
+	all := p.All()
+	c.Assert(all, HasLen, 3)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "foo2", Value: "bar2"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "foo3", Value: "bar3"})
+}
+
+func (s *URLQueryParserSuite) TestAddDuplicateKeyParams(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo", "baz")
+	p.Add("foo", "barz")
+	all := p.All()
+	c.Assert(all, HasLen, 3)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "foo", Value: "baz"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "foo", Value: "barz"})
+}
+
+func (s *URLQueryParserSuite) TestSetNonExistingParam(c *C) {
+	p := URLQueryParameters{}
+	p.Set("foo", "bar")
+	all := p.All()
+	c.Assert(all, HasLen, 1)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar"})
+}
+
+func (s *URLQueryParserSuite) TestSetExistingParam(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Set("foo", "baz")
+	all := p.All()
+	c.Assert(all, HasLen, 1)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "baz"})
+}
+
+func (s *URLQueryParserSuite) TestSetExistingMultipleParams(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo", "baz")
+	p.Add("foo3", "bar3")
+	p.Set("foo", "barz")
+	all := p.All()
+	c.Assert(all, HasLen, 3)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "barz"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "foo2", Value: "bar2"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "foo3", Value: "bar3"})
+}
+
+func (s *URLQueryParserSuite) TestGet(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo3", "bar3")
+	c.Assert(p.Get("foo"), Equals, "bar")
+	c.Assert(p.Get("foo2"), Equals, "bar2")
+	c.Assert(p.Get("foo3"), Equals, "bar3")
+}
+
+func (s *URLQueryParserSuite) TestGetOnDuplicateKeyReturnsFirst(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo", "baz")
+	c.Assert(p.Get("foo"), Equals, "bar")
+}
+
+func (s *URLQueryParserSuite) TestGetNonExistingKey(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo3", "bar3")
+	c.Assert(p.Get("bar"), Equals, "")
+}
+
+func (s *URLQueryParserSuite) TestGetMulti(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo3", "bar3")
+	c.Assert(p.GetMulti("foo"), DeepEquals, []string{"bar"})
+	c.Assert(p.GetMulti("foo2"), DeepEquals, []string{"bar2"})
+	c.Assert(p.GetMulti("foo3"), DeepEquals, []string{"bar3"})
+}
+
+func (s *URLQueryParserSuite) TestGetMultiOnDuplicateKeys(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo", "baz")
+	p.Add("foo3", "bar3")
+	p.Add("foo", "barz")
+	c.Assert(p.GetMulti("foo"), DeepEquals, []string{"bar", "baz", "barz"})
+	c.Assert(p.GetMulti("foo2"), DeepEquals, []string{"bar2"})
+	c.Assert(p.GetMulti("foo3"), DeepEquals, []string{"bar3"})
+}
+
+func (s *URLQueryParserSuite) TestGetMultiNonExistingKey(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo2", "bar2")
+	p.Add("foo3", "bar3")
+	c.Assert(p.GetMulti("bar"), HasLen, 0)
+}
+
+func (s *URLQueryParserSuite) TestAll(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo3", "bar3")
+	p.Add("foo3", "bar3.1")
+	p.Add("foo2", "bar2")
+	p.Add("foo", "bar.1")
+	all := p.All()
+	c.Assert(all, HasLen, 5)
+	c.Assert(all[0], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar"})
+	c.Assert(all[1], DeepEquals, URLQueryParameter{Key: "foo3", Value: "bar3"})
+	c.Assert(all[2], DeepEquals, URLQueryParameter{Key: "foo3", Value: "bar3.1"})
+	c.Assert(all[3], DeepEquals, URLQueryParameter{Key: "foo2", Value: "bar2"})
+	c.Assert(all[4], DeepEquals, URLQueryParameter{Key: "foo", Value: "bar.1"})
+}
+
+func (s *URLQueryParserSuite) TestAllEmpty(c *C) {
+	p := URLQueryParameters{}
+	c.Assert(p.All(), HasLen, 0)
+}
+
+func (s *URLQueryParserSuite) TestValues(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo", "bar")
+	p.Add("foo3", "bar3")
+	p.Add("foo3", "bar3.1")
+	p.Add("foo2", "bar2")
+	p.Add("foo", "bar.1")
+	values := p.Values()
+	c.Assert(values, HasLen, 3)
+	c.Assert(values["foo"], DeepEquals, []string{"bar", "bar.1"})
+	c.Assert(values["foo2"], DeepEquals, []string{"bar2"})
+	c.Assert(values["foo3"], DeepEquals, []string{"bar3", "bar3.1"})
+}
+
+func (s *URLQueryParserSuite) TestValuesEmpty(c *C) {
+	p := URLQueryParameters{}
+	c.Assert(p.Values(), HasLen, 0)
+}
+
+func (s *URLQueryParserSuite) TestEncode(c *C) {
+	p := URLQueryParameters{}
+	p.Add("abc", "def")
+	p.Add("zyx", "wvu")
+	p.Add("abc", "123")
+	p.Add("lmn", "opq")
+	p.Add("ghi", "jkl")
+	p.Add("abc", "xyz")
+	c.Assert(p.Encode(), Equals, "abc=def&zyx=wvu&abc=123&lmn=opq&ghi=jkl&abc=xyz")
+}
+
+func (s *URLQueryParserSuite) TestEncodeEscapesSpecialChars(c *C) {
+	p := URLQueryParameters{}
+	p.Add("foo:bar", "foo&baz")
+	c.Assert(p.Encode(), Equals, "foo%3Abar=foo%26baz")
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -198,6 +198,7 @@ func (s *ServerSuite) TestGetPatientSearchPagingPreservesSearchParams(c *C) {
 	v.Add("name", "Donald")
 	v.Add("name", "Duck")
 	c.Assert(bundle.Link, HasLen, 3)
+	assertPagingLinkWithParams(c, bundle.Link[0], "self", v, 100, 0)
 	assertPagingLinkWithParams(c, bundle.Link[1], "first", v, 100, 0)
 	assertPagingLinkWithParams(c, bundle.Link[2], "last", v, 100, 0)
 


### PR DESCRIPTION
Implement sorting on search.  Note that there are a couple of limitations:
- If a sort parameter has multiple paths, we will only consider the 1st one for sorting
- If there are multiple sort params, and some have paths containing "parallel arrays", we drop all but the first param with the "parallel paths".  This is due to a limitation in MongoDB