### PR TITLE
Extension persistence

### DIFF
--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -93,14 +93,15 @@ func (x *AllergyIntolerance) checkResourceType() error {
 }
 
 type AllergyIntoleranceReactionComponent struct {
-	Substance     *CodeableConcept  `bson:"substance,omitempty" json:"substance,omitempty"`
-	Certainty     string            `bson:"certainty,omitempty" json:"certainty,omitempty"`
-	Manifestation []CodeableConcept `bson:"manifestation,omitempty" json:"manifestation,omitempty"`
-	Description   string            `bson:"description,omitempty" json:"description,omitempty"`
-	Onset         *FHIRDateTime     `bson:"onset,omitempty" json:"onset,omitempty"`
-	Severity      string            `bson:"severity,omitempty" json:"severity,omitempty"`
-	ExposureRoute *CodeableConcept  `bson:"exposureRoute,omitempty" json:"exposureRoute,omitempty"`
-	Note          *Annotation       `bson:"note,omitempty" json:"note,omitempty"`
+	BackboneElement `bson:",inline"`
+	Substance       *CodeableConcept  `bson:"substance,omitempty" json:"substance,omitempty"`
+	Certainty       string            `bson:"certainty,omitempty" json:"certainty,omitempty"`
+	Manifestation   []CodeableConcept `bson:"manifestation,omitempty" json:"manifestation,omitempty"`
+	Description     string            `bson:"description,omitempty" json:"description,omitempty"`
+	Onset           *FHIRDateTime     `bson:"onset,omitempty" json:"onset,omitempty"`
+	Severity        string            `bson:"severity,omitempty" json:"severity,omitempty"`
+	ExposureRoute   *CodeableConcept  `bson:"exposureRoute,omitempty" json:"exposureRoute,omitempty"`
+	Note            *Annotation       `bson:"note,omitempty" json:"note,omitempty"`
 }
 
 type AllergyIntolerancePlus struct {

--- a/models/appointment.go
+++ b/models/appointment.go
@@ -91,10 +91,11 @@ func (x *Appointment) checkResourceType() error {
 }
 
 type AppointmentParticipantComponent struct {
-	Type     []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Actor    *Reference        `bson:"actor,omitempty" json:"actor,omitempty"`
-	Required string            `bson:"required,omitempty" json:"required,omitempty"`
-	Status   string            `bson:"status,omitempty" json:"status,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Actor           *Reference        `bson:"actor,omitempty" json:"actor,omitempty"`
+	Required        string            `bson:"required,omitempty" json:"required,omitempty"`
+	Status          string            `bson:"status,omitempty" json:"status,omitempty"`
 }
 
 type AppointmentPlus struct {

--- a/models/auditevent.go
+++ b/models/auditevent.go
@@ -83,56 +83,62 @@ func (x *AuditEvent) checkResourceType() error {
 }
 
 type AuditEventEventComponent struct {
-	Type           *Coding       `bson:"type,omitempty" json:"type,omitempty"`
-	Subtype        []Coding      `bson:"subtype,omitempty" json:"subtype,omitempty"`
-	Action         string        `bson:"action,omitempty" json:"action,omitempty"`
-	DateTime       *FHIRDateTime `bson:"dateTime,omitempty" json:"dateTime,omitempty"`
-	Outcome        string        `bson:"outcome,omitempty" json:"outcome,omitempty"`
-	OutcomeDesc    string        `bson:"outcomeDesc,omitempty" json:"outcomeDesc,omitempty"`
-	PurposeOfEvent []Coding      `bson:"purposeOfEvent,omitempty" json:"purposeOfEvent,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding       `bson:"type,omitempty" json:"type,omitempty"`
+	Subtype         []Coding      `bson:"subtype,omitempty" json:"subtype,omitempty"`
+	Action          string        `bson:"action,omitempty" json:"action,omitempty"`
+	DateTime        *FHIRDateTime `bson:"dateTime,omitempty" json:"dateTime,omitempty"`
+	Outcome         string        `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	OutcomeDesc     string        `bson:"outcomeDesc,omitempty" json:"outcomeDesc,omitempty"`
+	PurposeOfEvent  []Coding      `bson:"purposeOfEvent,omitempty" json:"purposeOfEvent,omitempty"`
 }
 
 type AuditEventParticipantComponent struct {
-	Role         []CodeableConcept                      `bson:"role,omitempty" json:"role,omitempty"`
-	Reference    *Reference                             `bson:"reference,omitempty" json:"reference,omitempty"`
-	UserId       *Identifier                            `bson:"userId,omitempty" json:"userId,omitempty"`
-	AltId        string                                 `bson:"altId,omitempty" json:"altId,omitempty"`
-	Name         string                                 `bson:"name,omitempty" json:"name,omitempty"`
-	Requestor    *bool                                  `bson:"requestor,omitempty" json:"requestor,omitempty"`
-	Location     *Reference                             `bson:"location,omitempty" json:"location,omitempty"`
-	Policy       []string                               `bson:"policy,omitempty" json:"policy,omitempty"`
-	Media        *Coding                                `bson:"media,omitempty" json:"media,omitempty"`
-	Network      *AuditEventParticipantNetworkComponent `bson:"network,omitempty" json:"network,omitempty"`
-	PurposeOfUse []Coding                               `bson:"purposeOfUse,omitempty" json:"purposeOfUse,omitempty"`
+	BackboneElement `bson:",inline"`
+	Role            []CodeableConcept                      `bson:"role,omitempty" json:"role,omitempty"`
+	Reference       *Reference                             `bson:"reference,omitempty" json:"reference,omitempty"`
+	UserId          *Identifier                            `bson:"userId,omitempty" json:"userId,omitempty"`
+	AltId           string                                 `bson:"altId,omitempty" json:"altId,omitempty"`
+	Name            string                                 `bson:"name,omitempty" json:"name,omitempty"`
+	Requestor       *bool                                  `bson:"requestor,omitempty" json:"requestor,omitempty"`
+	Location        *Reference                             `bson:"location,omitempty" json:"location,omitempty"`
+	Policy          []string                               `bson:"policy,omitempty" json:"policy,omitempty"`
+	Media           *Coding                                `bson:"media,omitempty" json:"media,omitempty"`
+	Network         *AuditEventParticipantNetworkComponent `bson:"network,omitempty" json:"network,omitempty"`
+	PurposeOfUse    []Coding                               `bson:"purposeOfUse,omitempty" json:"purposeOfUse,omitempty"`
 }
 
 type AuditEventParticipantNetworkComponent struct {
-	Address string `bson:"address,omitempty" json:"address,omitempty"`
-	Type    string `bson:"type,omitempty" json:"type,omitempty"`
+	BackboneElement `bson:",inline"`
+	Address         string `bson:"address,omitempty" json:"address,omitempty"`
+	Type            string `bson:"type,omitempty" json:"type,omitempty"`
 }
 
 type AuditEventSourceComponent struct {
-	Site       string      `bson:"site,omitempty" json:"site,omitempty"`
-	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Type       []Coding    `bson:"type,omitempty" json:"type,omitempty"`
+	BackboneElement `bson:",inline"`
+	Site            string      `bson:"site,omitempty" json:"site,omitempty"`
+	Identifier      *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type            []Coding    `bson:"type,omitempty" json:"type,omitempty"`
 }
 
 type AuditEventObjectComponent struct {
-	Identifier    *Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Reference     *Reference                        `bson:"reference,omitempty" json:"reference,omitempty"`
-	Type          *Coding                           `bson:"type,omitempty" json:"type,omitempty"`
-	Role          *Coding                           `bson:"role,omitempty" json:"role,omitempty"`
-	Lifecycle     *Coding                           `bson:"lifecycle,omitempty" json:"lifecycle,omitempty"`
-	SecurityLabel []Coding                          `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
-	Name          string                            `bson:"name,omitempty" json:"name,omitempty"`
-	Description   string                            `bson:"description,omitempty" json:"description,omitempty"`
-	Query         string                            `bson:"query,omitempty" json:"query,omitempty"`
-	Detail        []AuditEventObjectDetailComponent `bson:"detail,omitempty" json:"detail,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      *Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Reference       *Reference                        `bson:"reference,omitempty" json:"reference,omitempty"`
+	Type            *Coding                           `bson:"type,omitempty" json:"type,omitempty"`
+	Role            *Coding                           `bson:"role,omitempty" json:"role,omitempty"`
+	Lifecycle       *Coding                           `bson:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+	SecurityLabel   []Coding                          `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
+	Name            string                            `bson:"name,omitempty" json:"name,omitempty"`
+	Description     string                            `bson:"description,omitempty" json:"description,omitempty"`
+	Query           string                            `bson:"query,omitempty" json:"query,omitempty"`
+	Detail          []AuditEventObjectDetailComponent `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 
 type AuditEventObjectDetailComponent struct {
-	Type  string `bson:"type,omitempty" json:"type,omitempty"`
-	Value string `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string `bson:"type,omitempty" json:"type,omitempty"`
+	Value           string `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type AuditEventPlus struct {

--- a/models/backboneelement.go
+++ b/models/backboneelement.go
@@ -27,5 +27,6 @@
 package models
 
 type BackboneElement struct {
+	Element           `bson:",inline"`
 	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }

--- a/models/bundle.go
+++ b/models/bundle.go
@@ -79,17 +79,19 @@ func (x *Bundle) checkResourceType() error {
 }
 
 type BundleLinkComponent struct {
-	Relation string `bson:"relation,omitempty" json:"relation,omitempty"`
-	Url      string `bson:"url,omitempty" json:"url,omitempty"`
+	BackboneElement `bson:",inline"`
+	Relation        string `bson:"relation,omitempty" json:"relation,omitempty"`
+	Url             string `bson:"url,omitempty" json:"url,omitempty"`
 }
 
 type BundleEntryComponent struct {
-	Link     []BundleLinkComponent         `bson:"link,omitempty" json:"link,omitempty"`
-	FullUrl  string                        `bson:"fullUrl,omitempty" json:"fullUrl,omitempty"`
-	Resource interface{}                   `bson:"resource,omitempty" json:"resource,omitempty"`
-	Search   *BundleEntrySearchComponent   `bson:"search,omitempty" json:"search,omitempty"`
-	Request  *BundleEntryRequestComponent  `bson:"request,omitempty" json:"request,omitempty"`
-	Response *BundleEntryResponseComponent `bson:"response,omitempty" json:"response,omitempty"`
+	BackboneElement `bson:",inline"`
+	Link            []BundleLinkComponent         `bson:"link,omitempty" json:"link,omitempty"`
+	FullUrl         string                        `bson:"fullUrl,omitempty" json:"fullUrl,omitempty"`
+	Resource        interface{}                   `bson:"resource,omitempty" json:"resource,omitempty"`
+	Search          *BundleEntrySearchComponent   `bson:"search,omitempty" json:"search,omitempty"`
+	Request         *BundleEntryRequestComponent  `bson:"request,omitempty" json:"request,omitempty"`
+	Response        *BundleEntryResponseComponent `bson:"response,omitempty" json:"response,omitempty"`
 }
 
 // The "bundleEntryComponent" sub-type is needed to avoid infinite recursion in UnmarshalJSON
@@ -108,11 +110,13 @@ func (x *BundleEntryComponent) UnmarshalJSON(data []byte) (err error) {
 }
 
 type BundleEntrySearchComponent struct {
-	Mode  string   `bson:"mode,omitempty" json:"mode,omitempty"`
-	Score *float64 `bson:"score,omitempty" json:"score,omitempty"`
+	BackboneElement `bson:",inline"`
+	Mode            string   `bson:"mode,omitempty" json:"mode,omitempty"`
+	Score           *float64 `bson:"score,omitempty" json:"score,omitempty"`
 }
 
 type BundleEntryRequestComponent struct {
+	BackboneElement `bson:",inline"`
 	Method          string        `bson:"method,omitempty" json:"method,omitempty"`
 	Url             string        `bson:"url,omitempty" json:"url,omitempty"`
 	IfNoneMatch     string        `bson:"ifNoneMatch,omitempty" json:"ifNoneMatch,omitempty"`
@@ -122,10 +126,11 @@ type BundleEntryRequestComponent struct {
 }
 
 type BundleEntryResponseComponent struct {
-	Status       string        `bson:"status,omitempty" json:"status,omitempty"`
-	Location     string        `bson:"location,omitempty" json:"location,omitempty"`
-	Etag         string        `bson:"etag,omitempty" json:"etag,omitempty"`
-	LastModified *FHIRDateTime `bson:"lastModified,omitempty" json:"lastModified,omitempty"`
+	BackboneElement `bson:",inline"`
+	Status          string        `bson:"status,omitempty" json:"status,omitempty"`
+	Location        string        `bson:"location,omitempty" json:"location,omitempty"`
+	Etag            string        `bson:"etag,omitempty" json:"etag,omitempty"`
+	LastModified    *FHIRDateTime `bson:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 type BundlePlus struct {

--- a/models/careplan.go
+++ b/models/careplan.go
@@ -95,16 +95,19 @@ func (x *CarePlan) checkResourceType() error {
 }
 
 type CarePlanRelatedPlanComponent struct {
-	Code string     `bson:"code,omitempty" json:"code,omitempty"`
-	Plan *Reference `bson:"plan,omitempty" json:"plan,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string     `bson:"code,omitempty" json:"code,omitempty"`
+	Plan            *Reference `bson:"plan,omitempty" json:"plan,omitempty"`
 }
 
 type CarePlanParticipantComponent struct {
-	Role   *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
-	Member *Reference       `bson:"member,omitempty" json:"member,omitempty"`
+	BackboneElement `bson:",inline"`
+	Role            *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Member          *Reference       `bson:"member,omitempty" json:"member,omitempty"`
 }
 
 type CarePlanActivityComponent struct {
+	BackboneElement `bson:",inline"`
 	ActionResulting []Reference                      `bson:"actionResulting,omitempty" json:"actionResulting,omitempty"`
 	Progress        []Annotation                     `bson:"progress,omitempty" json:"progress,omitempty"`
 	Reference       *Reference                       `bson:"reference,omitempty" json:"reference,omitempty"`
@@ -112,6 +115,7 @@ type CarePlanActivityComponent struct {
 }
 
 type CarePlanActivityDetailComponent struct {
+	BackboneElement        `bson:",inline"`
 	Category               *CodeableConcept  `bson:"category,omitempty" json:"category,omitempty"`
 	Code                   *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
 	ReasonCode             []CodeableConcept `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`

--- a/models/claim.go
+++ b/models/claim.go
@@ -108,18 +108,21 @@ func (x *Claim) checkResourceType() error {
 }
 
 type ClaimPayeeComponent struct {
-	Type         *Coding    `bson:"type,omitempty" json:"type,omitempty"`
-	Provider     *Reference `bson:"provider,omitempty" json:"provider,omitempty"`
-	Organization *Reference `bson:"organization,omitempty" json:"organization,omitempty"`
-	Person       *Reference `bson:"person,omitempty" json:"person,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding    `bson:"type,omitempty" json:"type,omitempty"`
+	Provider        *Reference `bson:"provider,omitempty" json:"provider,omitempty"`
+	Organization    *Reference `bson:"organization,omitempty" json:"organization,omitempty"`
+	Person          *Reference `bson:"person,omitempty" json:"person,omitempty"`
 }
 
 type ClaimDiagnosisComponent struct {
-	Sequence  *uint32 `bson:"sequence,omitempty" json:"sequence,omitempty"`
-	Diagnosis *Coding `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	BackboneElement `bson:",inline"`
+	Sequence        *uint32 `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Diagnosis       *Coding `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
 }
 
 type ClaimCoverageComponent struct {
+	BackboneElement     `bson:",inline"`
 	Sequence            *uint32    `bson:"sequence,omitempty" json:"sequence,omitempty"`
 	Focal               *bool      `bson:"focal,omitempty" json:"focal,omitempty"`
 	Coverage            *Reference `bson:"coverage,omitempty" json:"coverage,omitempty"`
@@ -131,6 +134,7 @@ type ClaimCoverageComponent struct {
 }
 
 type ClaimItemsComponent struct {
+	BackboneElement `bson:",inline"`
 	Sequence        *uint32                   `bson:"sequence,omitempty" json:"sequence,omitempty"`
 	Type            *Coding                   `bson:"type,omitempty" json:"type,omitempty"`
 	Provider        *Reference                `bson:"provider,omitempty" json:"provider,omitempty"`
@@ -151,40 +155,44 @@ type ClaimItemsComponent struct {
 }
 
 type ClaimDetailComponent struct {
-	Sequence  *uint32                   `bson:"sequence,omitempty" json:"sequence,omitempty"`
-	Type      *Coding                   `bson:"type,omitempty" json:"type,omitempty"`
-	Service   *Coding                   `bson:"service,omitempty" json:"service,omitempty"`
-	Quantity  *Quantity                 `bson:"quantity,omitempty" json:"quantity,omitempty"`
-	UnitPrice *Quantity                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor    *float64                  `bson:"factor,omitempty" json:"factor,omitempty"`
-	Points    *float64                  `bson:"points,omitempty" json:"points,omitempty"`
-	Net       *Quantity                 `bson:"net,omitempty" json:"net,omitempty"`
-	Udi       *Coding                   `bson:"udi,omitempty" json:"udi,omitempty"`
-	SubDetail []ClaimSubDetailComponent `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
+	BackboneElement `bson:",inline"`
+	Sequence        *uint32                   `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Type            *Coding                   `bson:"type,omitempty" json:"type,omitempty"`
+	Service         *Coding                   `bson:"service,omitempty" json:"service,omitempty"`
+	Quantity        *Quantity                 `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice       *Quantity                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor          *float64                  `bson:"factor,omitempty" json:"factor,omitempty"`
+	Points          *float64                  `bson:"points,omitempty" json:"points,omitempty"`
+	Net             *Quantity                 `bson:"net,omitempty" json:"net,omitempty"`
+	Udi             *Coding                   `bson:"udi,omitempty" json:"udi,omitempty"`
+	SubDetail       []ClaimSubDetailComponent `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 
 type ClaimSubDetailComponent struct {
-	Sequence  *uint32   `bson:"sequence,omitempty" json:"sequence,omitempty"`
-	Type      *Coding   `bson:"type,omitempty" json:"type,omitempty"`
-	Service   *Coding   `bson:"service,omitempty" json:"service,omitempty"`
-	Quantity  *Quantity `bson:"quantity,omitempty" json:"quantity,omitempty"`
-	UnitPrice *Quantity `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
-	Factor    *float64  `bson:"factor,omitempty" json:"factor,omitempty"`
-	Points    *float64  `bson:"points,omitempty" json:"points,omitempty"`
-	Net       *Quantity `bson:"net,omitempty" json:"net,omitempty"`
-	Udi       *Coding   `bson:"udi,omitempty" json:"udi,omitempty"`
+	BackboneElement `bson:",inline"`
+	Sequence        *uint32   `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Type            *Coding   `bson:"type,omitempty" json:"type,omitempty"`
+	Service         *Coding   `bson:"service,omitempty" json:"service,omitempty"`
+	Quantity        *Quantity `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice       *Quantity `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor          *float64  `bson:"factor,omitempty" json:"factor,omitempty"`
+	Points          *float64  `bson:"points,omitempty" json:"points,omitempty"`
+	Net             *Quantity `bson:"net,omitempty" json:"net,omitempty"`
+	Udi             *Coding   `bson:"udi,omitempty" json:"udi,omitempty"`
 }
 
 type ClaimProsthesisComponent struct {
-	Initial       *bool         `bson:"initial,omitempty" json:"initial,omitempty"`
-	PriorDate     *FHIRDateTime `bson:"priorDate,omitempty" json:"priorDate,omitempty"`
-	PriorMaterial *Coding       `bson:"priorMaterial,omitempty" json:"priorMaterial,omitempty"`
+	BackboneElement `bson:",inline"`
+	Initial         *bool         `bson:"initial,omitempty" json:"initial,omitempty"`
+	PriorDate       *FHIRDateTime `bson:"priorDate,omitempty" json:"priorDate,omitempty"`
+	PriorMaterial   *Coding       `bson:"priorMaterial,omitempty" json:"priorMaterial,omitempty"`
 }
 
 type ClaimMissingTeethComponent struct {
-	Tooth          *Coding       `bson:"tooth,omitempty" json:"tooth,omitempty"`
-	Reason         *Coding       `bson:"reason,omitempty" json:"reason,omitempty"`
-	ExtractionDate *FHIRDateTime `bson:"extractionDate,omitempty" json:"extractionDate,omitempty"`
+	BackboneElement `bson:",inline"`
+	Tooth           *Coding       `bson:"tooth,omitempty" json:"tooth,omitempty"`
+	Reason          *Coding       `bson:"reason,omitempty" json:"reason,omitempty"`
+	ExtractionDate  *FHIRDateTime `bson:"extractionDate,omitempty" json:"extractionDate,omitempty"`
 }
 
 type ClaimPlus struct {

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -105,42 +105,49 @@ func (x *ClaimResponse) checkResourceType() error {
 }
 
 type ClaimResponseItemsComponent struct {
-	SequenceLinkId *uint32                                  `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
-	NoteNumber     []uint32                                 `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
-	Adjudication   []ClaimResponseItemAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
-	Detail         []ClaimResponseItemDetailComponent       `bson:"detail,omitempty" json:"detail,omitempty"`
+	BackboneElement `bson:",inline"`
+	SequenceLinkId  *uint32                                  `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
+	NoteNumber      []uint32                                 `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication    []ClaimResponseItemAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Detail          []ClaimResponseItemDetailComponent       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 
 type ClaimResponseItemAdjudicationComponent struct {
-	Code   *Coding   `bson:"code,omitempty" json:"code,omitempty"`
-	Amount *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value  *float64  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding   `bson:"code,omitempty" json:"code,omitempty"`
+	Amount          *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value           *float64  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ClaimResponseItemDetailComponent struct {
-	SequenceLinkId *uint32                                    `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
-	Adjudication   []ClaimResponseDetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
-	SubDetail      []ClaimResponseSubDetailComponent          `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
+	BackboneElement `bson:",inline"`
+	SequenceLinkId  *uint32                                    `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
+	Adjudication    []ClaimResponseDetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	SubDetail       []ClaimResponseSubDetailComponent          `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 
 type ClaimResponseDetailAdjudicationComponent struct {
-	Code   *Coding   `bson:"code,omitempty" json:"code,omitempty"`
-	Amount *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value  *float64  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding   `bson:"code,omitempty" json:"code,omitempty"`
+	Amount          *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value           *float64  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ClaimResponseSubDetailComponent struct {
-	SequenceLinkId *uint32                                       `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
-	Adjudication   []ClaimResponseSubdetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	BackboneElement `bson:",inline"`
+	SequenceLinkId  *uint32                                       `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
+	Adjudication    []ClaimResponseSubdetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 
 type ClaimResponseSubdetailAdjudicationComponent struct {
-	Code   *Coding   `bson:"code,omitempty" json:"code,omitempty"`
-	Amount *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value  *float64  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding   `bson:"code,omitempty" json:"code,omitempty"`
+	Amount          *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value           *float64  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ClaimResponseAddedItemComponent struct {
+	BackboneElement  `bson:",inline"`
 	SequenceLinkId   []uint32                                      `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
 	Service          *Coding                                       `bson:"service,omitempty" json:"service,omitempty"`
 	Fee              *Quantity                                     `bson:"fee,omitempty" json:"fee,omitempty"`
@@ -150,24 +157,28 @@ type ClaimResponseAddedItemComponent struct {
 }
 
 type ClaimResponseAddedItemAdjudicationComponent struct {
-	Code   *Coding   `bson:"code,omitempty" json:"code,omitempty"`
-	Amount *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value  *float64  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding   `bson:"code,omitempty" json:"code,omitempty"`
+	Amount          *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value           *float64  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ClaimResponseAddedItemsDetailComponent struct {
-	Service      *Coding                                             `bson:"service,omitempty" json:"service,omitempty"`
-	Fee          *Quantity                                           `bson:"fee,omitempty" json:"fee,omitempty"`
-	Adjudication []ClaimResponseAddedItemDetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	BackboneElement `bson:",inline"`
+	Service         *Coding                                             `bson:"service,omitempty" json:"service,omitempty"`
+	Fee             *Quantity                                           `bson:"fee,omitempty" json:"fee,omitempty"`
+	Adjudication    []ClaimResponseAddedItemDetailAdjudicationComponent `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 
 type ClaimResponseAddedItemDetailAdjudicationComponent struct {
-	Code   *Coding   `bson:"code,omitempty" json:"code,omitempty"`
-	Amount *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
-	Value  *float64  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding   `bson:"code,omitempty" json:"code,omitempty"`
+	Amount          *Quantity `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value           *float64  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ClaimResponseErrorsComponent struct {
+	BackboneElement         `bson:",inline"`
 	SequenceLinkId          *uint32 `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
 	DetailSequenceLinkId    *uint32 `bson:"detailSequenceLinkId,omitempty" json:"detailSequenceLinkId,omitempty"`
 	SubdetailSequenceLinkId *uint32 `bson:"subdetailSequenceLinkId,omitempty" json:"subdetailSequenceLinkId,omitempty"`
@@ -175,12 +186,14 @@ type ClaimResponseErrorsComponent struct {
 }
 
 type ClaimResponseNotesComponent struct {
-	Number *uint32 `bson:"number,omitempty" json:"number,omitempty"`
-	Type   *Coding `bson:"type,omitempty" json:"type,omitempty"`
-	Text   string  `bson:"text,omitempty" json:"text,omitempty"`
+	BackboneElement `bson:",inline"`
+	Number          *uint32 `bson:"number,omitempty" json:"number,omitempty"`
+	Type            *Coding `bson:"type,omitempty" json:"type,omitempty"`
+	Text            string  `bson:"text,omitempty" json:"text,omitempty"`
 }
 
 type ClaimResponseCoverageComponent struct {
+	BackboneElement     `bson:",inline"`
 	Sequence            *uint32    `bson:"sequence,omitempty" json:"sequence,omitempty"`
 	Focal               *bool      `bson:"focal,omitempty" json:"focal,omitempty"`
 	Coverage            *Reference `bson:"coverage,omitempty" json:"coverage,omitempty"`

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -97,18 +97,21 @@ func (x *ClinicalImpression) checkResourceType() error {
 }
 
 type ClinicalImpressionInvestigationsComponent struct {
-	Code *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Item []Reference      `bson:"item,omitempty" json:"item,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Item            []Reference      `bson:"item,omitempty" json:"item,omitempty"`
 }
 
 type ClinicalImpressionFindingComponent struct {
-	Item  *CodeableConcept `bson:"item,omitempty" json:"item,omitempty"`
-	Cause string           `bson:"cause,omitempty" json:"cause,omitempty"`
+	BackboneElement `bson:",inline"`
+	Item            *CodeableConcept `bson:"item,omitempty" json:"item,omitempty"`
+	Cause           string           `bson:"cause,omitempty" json:"cause,omitempty"`
 }
 
 type ClinicalImpressionRuledOutComponent struct {
-	Item   *CodeableConcept `bson:"item,omitempty" json:"item,omitempty"`
-	Reason string           `bson:"reason,omitempty" json:"reason,omitempty"`
+	BackboneElement `bson:",inline"`
+	Item            *CodeableConcept `bson:"item,omitempty" json:"item,omitempty"`
+	Reason          string           `bson:"reason,omitempty" json:"reason,omitempty"`
 }
 
 type ClinicalImpressionPlus struct {

--- a/models/communication.go
+++ b/models/communication.go
@@ -92,6 +92,7 @@ func (x *Communication) checkResourceType() error {
 }
 
 type CommunicationPayloadComponent struct {
+	BackboneElement   `bson:",inline"`
 	ContentString     string      `bson:"contentString,omitempty" json:"contentString,omitempty"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`

--- a/models/communicationrequest.go
+++ b/models/communicationrequest.go
@@ -94,6 +94,7 @@ func (x *CommunicationRequest) checkResourceType() error {
 }
 
 type CommunicationRequestPayloadComponent struct {
+	BackboneElement   `bson:",inline"`
 	ContentString     string      `bson:"contentString,omitempty" json:"contentString,omitempty"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`

--- a/models/composition.go
+++ b/models/composition.go
@@ -93,26 +93,29 @@ func (x *Composition) checkResourceType() error {
 }
 
 type CompositionAttesterComponent struct {
-	Mode  []string      `bson:"mode,omitempty" json:"mode,omitempty"`
-	Time  *FHIRDateTime `bson:"time,omitempty" json:"time,omitempty"`
-	Party *Reference    `bson:"party,omitempty" json:"party,omitempty"`
+	BackboneElement `bson:",inline"`
+	Mode            []string      `bson:"mode,omitempty" json:"mode,omitempty"`
+	Time            *FHIRDateTime `bson:"time,omitempty" json:"time,omitempty"`
+	Party           *Reference    `bson:"party,omitempty" json:"party,omitempty"`
 }
 
 type CompositionEventComponent struct {
-	Code   []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Period *Period           `bson:"period,omitempty" json:"period,omitempty"`
-	Detail []Reference       `bson:"detail,omitempty" json:"detail,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Period          *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Detail          []Reference       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 
 type CompositionSectionComponent struct {
-	Title       string                        `bson:"title,omitempty" json:"title,omitempty"`
-	Code        *CodeableConcept              `bson:"code,omitempty" json:"code,omitempty"`
-	Text        *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
-	Mode        string                        `bson:"mode,omitempty" json:"mode,omitempty"`
-	OrderedBy   *CodeableConcept              `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
-	Entry       []Reference                   `bson:"entry,omitempty" json:"entry,omitempty"`
-	EmptyReason *CodeableConcept              `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
-	Section     []CompositionSectionComponent `bson:"section,omitempty" json:"section,omitempty"`
+	BackboneElement `bson:",inline"`
+	Title           string                        `bson:"title,omitempty" json:"title,omitempty"`
+	Code            *CodeableConcept              `bson:"code,omitempty" json:"code,omitempty"`
+	Text            *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Mode            string                        `bson:"mode,omitempty" json:"mode,omitempty"`
+	OrderedBy       *CodeableConcept              `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
+	Entry           []Reference                   `bson:"entry,omitempty" json:"entry,omitempty"`
+	EmptyReason     *CodeableConcept              `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
+	Section         []CompositionSectionComponent `bson:"section,omitempty" json:"section,omitempty"`
 }
 
 type CompositionPlus struct {

--- a/models/conceptmap.go
+++ b/models/conceptmap.go
@@ -97,29 +97,33 @@ func (x *ConceptMap) checkResourceType() error {
 }
 
 type ConceptMapContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type ConceptMapSourceElementComponent struct {
-	CodeSystem string                             `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
-	Code       string                             `bson:"code,omitempty" json:"code,omitempty"`
-	Target     []ConceptMapTargetElementComponent `bson:"target,omitempty" json:"target,omitempty"`
+	BackboneElement `bson:",inline"`
+	CodeSystem      string                             `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
+	Code            string                             `bson:"code,omitempty" json:"code,omitempty"`
+	Target          []ConceptMapTargetElementComponent `bson:"target,omitempty" json:"target,omitempty"`
 }
 
 type ConceptMapTargetElementComponent struct {
-	CodeSystem  string                            `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
-	Code        string                            `bson:"code,omitempty" json:"code,omitempty"`
-	Equivalence string                            `bson:"equivalence,omitempty" json:"equivalence,omitempty"`
-	Comments    string                            `bson:"comments,omitempty" json:"comments,omitempty"`
-	DependsOn   []ConceptMapOtherElementComponent `bson:"dependsOn,omitempty" json:"dependsOn,omitempty"`
-	Product     []ConceptMapOtherElementComponent `bson:"product,omitempty" json:"product,omitempty"`
+	BackboneElement `bson:",inline"`
+	CodeSystem      string                            `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
+	Code            string                            `bson:"code,omitempty" json:"code,omitempty"`
+	Equivalence     string                            `bson:"equivalence,omitempty" json:"equivalence,omitempty"`
+	Comments        string                            `bson:"comments,omitempty" json:"comments,omitempty"`
+	DependsOn       []ConceptMapOtherElementComponent `bson:"dependsOn,omitempty" json:"dependsOn,omitempty"`
+	Product         []ConceptMapOtherElementComponent `bson:"product,omitempty" json:"product,omitempty"`
 }
 
 type ConceptMapOtherElementComponent struct {
-	Element    string `bson:"element,omitempty" json:"element,omitempty"`
-	CodeSystem string `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
-	Code       string `bson:"code,omitempty" json:"code,omitempty"`
+	BackboneElement `bson:",inline"`
+	Element         string `bson:"element,omitempty" json:"element,omitempty"`
+	CodeSystem      string `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
+	Code            string `bson:"code,omitempty" json:"code,omitempty"`
 }
 
 type ConceptMapPlus struct {

--- a/models/condition.go
+++ b/models/condition.go
@@ -104,13 +104,15 @@ func (x *Condition) checkResourceType() error {
 }
 
 type ConditionStageComponent struct {
-	Summary    *CodeableConcept `bson:"summary,omitempty" json:"summary,omitempty"`
-	Assessment []Reference      `bson:"assessment,omitempty" json:"assessment,omitempty"`
+	BackboneElement `bson:",inline"`
+	Summary         *CodeableConcept `bson:"summary,omitempty" json:"summary,omitempty"`
+	Assessment      []Reference      `bson:"assessment,omitempty" json:"assessment,omitempty"`
 }
 
 type ConditionEvidenceComponent struct {
-	Code   *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Detail []Reference      `bson:"detail,omitempty" json:"detail,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Detail          []Reference      `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 
 type ConditionPlus struct {

--- a/models/conformance.go
+++ b/models/conformance.go
@@ -100,22 +100,26 @@ func (x *Conformance) checkResourceType() error {
 }
 
 type ConformanceContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type ConformanceSoftwareComponent struct {
-	Name        string        `bson:"name,omitempty" json:"name,omitempty"`
-	Version     string        `bson:"version,omitempty" json:"version,omitempty"`
-	ReleaseDate *FHIRDateTime `bson:"releaseDate,omitempty" json:"releaseDate,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string        `bson:"name,omitempty" json:"name,omitempty"`
+	Version         string        `bson:"version,omitempty" json:"version,omitempty"`
+	ReleaseDate     *FHIRDateTime `bson:"releaseDate,omitempty" json:"releaseDate,omitempty"`
 }
 
 type ConformanceImplementationComponent struct {
-	Description string `bson:"description,omitempty" json:"description,omitempty"`
-	Url         string `bson:"url,omitempty" json:"url,omitempty"`
+	BackboneElement `bson:",inline"`
+	Description     string `bson:"description,omitempty" json:"description,omitempty"`
+	Url             string `bson:"url,omitempty" json:"url,omitempty"`
 }
 
 type ConformanceRestComponent struct {
+	BackboneElement `bson:",inline"`
 	Mode            string                                        `bson:"mode,omitempty" json:"mode,omitempty"`
 	Documentation   string                                        `bson:"documentation,omitempty" json:"documentation,omitempty"`
 	Security        *ConformanceRestSecurityComponent             `bson:"security,omitempty" json:"security,omitempty"`
@@ -128,18 +132,21 @@ type ConformanceRestComponent struct {
 }
 
 type ConformanceRestSecurityComponent struct {
-	Cors        *bool                                         `bson:"cors,omitempty" json:"cors,omitempty"`
-	Service     []CodeableConcept                             `bson:"service,omitempty" json:"service,omitempty"`
-	Description string                                        `bson:"description,omitempty" json:"description,omitempty"`
-	Certificate []ConformanceRestSecurityCertificateComponent `bson:"certificate,omitempty" json:"certificate,omitempty"`
+	BackboneElement `bson:",inline"`
+	Cors            *bool                                         `bson:"cors,omitempty" json:"cors,omitempty"`
+	Service         []CodeableConcept                             `bson:"service,omitempty" json:"service,omitempty"`
+	Description     string                                        `bson:"description,omitempty" json:"description,omitempty"`
+	Certificate     []ConformanceRestSecurityCertificateComponent `bson:"certificate,omitempty" json:"certificate,omitempty"`
 }
 
 type ConformanceRestSecurityCertificateComponent struct {
-	Type string `bson:"type,omitempty" json:"type,omitempty"`
-	Blob string `bson:"blob,omitempty" json:"blob,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string `bson:"type,omitempty" json:"type,omitempty"`
+	Blob            string `bson:"blob,omitempty" json:"blob,omitempty"`
 }
 
 type ConformanceRestResourceComponent struct {
+	BackboneElement   `bson:",inline"`
 	Type              string                                        `bson:"type,omitempty" json:"type,omitempty"`
 	Profile           *Reference                                    `bson:"profile,omitempty" json:"profile,omitempty"`
 	Interaction       []ConformanceResourceInteractionComponent     `bson:"interaction,omitempty" json:"interaction,omitempty"`
@@ -155,56 +162,64 @@ type ConformanceRestResourceComponent struct {
 }
 
 type ConformanceResourceInteractionComponent struct {
-	Code          string `bson:"code,omitempty" json:"code,omitempty"`
-	Documentation string `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string `bson:"code,omitempty" json:"code,omitempty"`
+	Documentation   string `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 
 type ConformanceRestResourceSearchParamComponent struct {
-	Name          string   `bson:"name,omitempty" json:"name,omitempty"`
-	Definition    string   `bson:"definition,omitempty" json:"definition,omitempty"`
-	Type          string   `bson:"type,omitempty" json:"type,omitempty"`
-	Documentation string   `bson:"documentation,omitempty" json:"documentation,omitempty"`
-	Target        []string `bson:"target,omitempty" json:"target,omitempty"`
-	Modifier      []string `bson:"modifier,omitempty" json:"modifier,omitempty"`
-	Chain         []string `bson:"chain,omitempty" json:"chain,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string   `bson:"name,omitempty" json:"name,omitempty"`
+	Definition      string   `bson:"definition,omitempty" json:"definition,omitempty"`
+	Type            string   `bson:"type,omitempty" json:"type,omitempty"`
+	Documentation   string   `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Target          []string `bson:"target,omitempty" json:"target,omitempty"`
+	Modifier        []string `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Chain           []string `bson:"chain,omitempty" json:"chain,omitempty"`
 }
 
 type ConformanceSystemInteractionComponent struct {
-	Code          string `bson:"code,omitempty" json:"code,omitempty"`
-	Documentation string `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string `bson:"code,omitempty" json:"code,omitempty"`
+	Documentation   string `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 
 type ConformanceRestOperationComponent struct {
-	Name       string     `bson:"name,omitempty" json:"name,omitempty"`
-	Definition *Reference `bson:"definition,omitempty" json:"definition,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string     `bson:"name,omitempty" json:"name,omitempty"`
+	Definition      *Reference `bson:"definition,omitempty" json:"definition,omitempty"`
 }
 
 type ConformanceMessagingComponent struct {
-	Endpoint      []ConformanceMessagingEndpointComponent `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
-	ReliableCache *uint32                                 `bson:"reliableCache,omitempty" json:"reliableCache,omitempty"`
-	Documentation string                                  `bson:"documentation,omitempty" json:"documentation,omitempty"`
-	Event         []ConformanceMessagingEventComponent    `bson:"event,omitempty" json:"event,omitempty"`
+	BackboneElement `bson:",inline"`
+	Endpoint        []ConformanceMessagingEndpointComponent `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	ReliableCache   *uint32                                 `bson:"reliableCache,omitempty" json:"reliableCache,omitempty"`
+	Documentation   string                                  `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Event           []ConformanceMessagingEventComponent    `bson:"event,omitempty" json:"event,omitempty"`
 }
 
 type ConformanceMessagingEndpointComponent struct {
-	Protocol *Coding `bson:"protocol,omitempty" json:"protocol,omitempty"`
-	Address  string  `bson:"address,omitempty" json:"address,omitempty"`
+	BackboneElement `bson:",inline"`
+	Protocol        *Coding `bson:"protocol,omitempty" json:"protocol,omitempty"`
+	Address         string  `bson:"address,omitempty" json:"address,omitempty"`
 }
 
 type ConformanceMessagingEventComponent struct {
-	Code          *Coding    `bson:"code,omitempty" json:"code,omitempty"`
-	Category      string     `bson:"category,omitempty" json:"category,omitempty"`
-	Mode          string     `bson:"mode,omitempty" json:"mode,omitempty"`
-	Focus         string     `bson:"focus,omitempty" json:"focus,omitempty"`
-	Request       *Reference `bson:"request,omitempty" json:"request,omitempty"`
-	Response      *Reference `bson:"response,omitempty" json:"response,omitempty"`
-	Documentation string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *Coding    `bson:"code,omitempty" json:"code,omitempty"`
+	Category        string     `bson:"category,omitempty" json:"category,omitempty"`
+	Mode            string     `bson:"mode,omitempty" json:"mode,omitempty"`
+	Focus           string     `bson:"focus,omitempty" json:"focus,omitempty"`
+	Request         *Reference `bson:"request,omitempty" json:"request,omitempty"`
+	Response        *Reference `bson:"response,omitempty" json:"response,omitempty"`
+	Documentation   string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 
 type ConformanceDocumentComponent struct {
-	Mode          string     `bson:"mode,omitempty" json:"mode,omitempty"`
-	Documentation string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
-	Profile       *Reference `bson:"profile,omitempty" json:"profile,omitempty"`
+	BackboneElement `bson:",inline"`
+	Mode            string     `bson:"mode,omitempty" json:"mode,omitempty"`
+	Documentation   string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Profile         *Reference `bson:"profile,omitempty" json:"profile,omitempty"`
 }
 
 type ConformancePlus struct {

--- a/models/contract.go
+++ b/models/contract.go
@@ -98,11 +98,13 @@ func (x *Contract) checkResourceType() error {
 }
 
 type ContractActorComponent struct {
-	Entity *Reference        `bson:"entity,omitempty" json:"entity,omitempty"`
-	Role   []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	BackboneElement `bson:",inline"`
+	Entity          *Reference        `bson:"entity,omitempty" json:"entity,omitempty"`
+	Role            []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
 }
 
 type ContractValuedItemComponent struct {
+	BackboneElement       `bson:",inline"`
 	EntityCodeableConcept *CodeableConcept `bson:"entityCodeableConcept,omitempty" json:"entityCodeableConcept,omitempty"`
 	EntityReference       *Reference       `bson:"entityReference,omitempty" json:"entityReference,omitempty"`
 	Identifier            *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
@@ -115,32 +117,36 @@ type ContractValuedItemComponent struct {
 }
 
 type ContractSignatoryComponent struct {
-	Type      *Coding    `bson:"type,omitempty" json:"type,omitempty"`
-	Party     *Reference `bson:"party,omitempty" json:"party,omitempty"`
-	Signature string     `bson:"signature,omitempty" json:"signature,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding    `bson:"type,omitempty" json:"type,omitempty"`
+	Party           *Reference `bson:"party,omitempty" json:"party,omitempty"`
+	Signature       string     `bson:"signature,omitempty" json:"signature,omitempty"`
 }
 
 type ContractTermComponent struct {
-	Identifier   *Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Issued       *FHIRDateTime                     `bson:"issued,omitempty" json:"issued,omitempty"`
-	Applies      *Period                           `bson:"applies,omitempty" json:"applies,omitempty"`
-	Type         *CodeableConcept                  `bson:"type,omitempty" json:"type,omitempty"`
-	SubType      *CodeableConcept                  `bson:"subType,omitempty" json:"subType,omitempty"`
-	Subject      *Reference                        `bson:"subject,omitempty" json:"subject,omitempty"`
-	Action       []CodeableConcept                 `bson:"action,omitempty" json:"action,omitempty"`
-	ActionReason []CodeableConcept                 `bson:"actionReason,omitempty" json:"actionReason,omitempty"`
-	Actor        []ContractTermActorComponent      `bson:"actor,omitempty" json:"actor,omitempty"`
-	Text         string                            `bson:"text,omitempty" json:"text,omitempty"`
-	ValuedItem   []ContractTermValuedItemComponent `bson:"valuedItem,omitempty" json:"valuedItem,omitempty"`
-	Group        []ContractTermComponent           `bson:"group,omitempty" json:"group,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      *Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Issued          *FHIRDateTime                     `bson:"issued,omitempty" json:"issued,omitempty"`
+	Applies         *Period                           `bson:"applies,omitempty" json:"applies,omitempty"`
+	Type            *CodeableConcept                  `bson:"type,omitempty" json:"type,omitempty"`
+	SubType         *CodeableConcept                  `bson:"subType,omitempty" json:"subType,omitempty"`
+	Subject         *Reference                        `bson:"subject,omitempty" json:"subject,omitempty"`
+	Action          []CodeableConcept                 `bson:"action,omitempty" json:"action,omitempty"`
+	ActionReason    []CodeableConcept                 `bson:"actionReason,omitempty" json:"actionReason,omitempty"`
+	Actor           []ContractTermActorComponent      `bson:"actor,omitempty" json:"actor,omitempty"`
+	Text            string                            `bson:"text,omitempty" json:"text,omitempty"`
+	ValuedItem      []ContractTermValuedItemComponent `bson:"valuedItem,omitempty" json:"valuedItem,omitempty"`
+	Group           []ContractTermComponent           `bson:"group,omitempty" json:"group,omitempty"`
 }
 
 type ContractTermActorComponent struct {
-	Entity *Reference        `bson:"entity,omitempty" json:"entity,omitempty"`
-	Role   []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	BackboneElement `bson:",inline"`
+	Entity          *Reference        `bson:"entity,omitempty" json:"entity,omitempty"`
+	Role            []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
 }
 
 type ContractTermValuedItemComponent struct {
+	BackboneElement       `bson:",inline"`
 	EntityCodeableConcept *CodeableConcept `bson:"entityCodeableConcept,omitempty" json:"entityCodeableConcept,omitempty"`
 	EntityReference       *Reference       `bson:"entityReference,omitempty" json:"entityReference,omitempty"`
 	Identifier            *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
@@ -153,16 +159,19 @@ type ContractTermValuedItemComponent struct {
 }
 
 type ContractFriendlyLanguageComponent struct {
+	BackboneElement   `bson:",inline"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
 }
 
 type ContractLegalLanguageComponent struct {
+	BackboneElement   `bson:",inline"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
 }
 
 type ContractComputableLanguageComponent struct {
+	BackboneElement   `bson:",inline"`
 	ContentAttachment *Attachment `bson:"contentAttachment,omitempty" json:"contentAttachment,omitempty"`
 	ContentReference  *Reference  `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
 }

--- a/models/dataelement.go
+++ b/models/dataelement.go
@@ -93,15 +93,17 @@ func (x *DataElement) checkResourceType() error {
 }
 
 type DataElementContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type DataElementMappingComponent struct {
-	Identity string `bson:"identity,omitempty" json:"identity,omitempty"`
-	Uri      string `bson:"uri,omitempty" json:"uri,omitempty"`
-	Name     string `bson:"name,omitempty" json:"name,omitempty"`
-	Comments string `bson:"comments,omitempty" json:"comments,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identity        string `bson:"identity,omitempty" json:"identity,omitempty"`
+	Uri             string `bson:"uri,omitempty" json:"uri,omitempty"`
+	Name            string `bson:"name,omitempty" json:"name,omitempty"`
+	Comments        string `bson:"comments,omitempty" json:"comments,omitempty"`
 }
 
 type DataElementPlus struct {

--- a/models/detectedissue.go
+++ b/models/detectedissue.go
@@ -89,9 +89,10 @@ func (x *DetectedIssue) checkResourceType() error {
 }
 
 type DetectedIssueMitigationComponent struct {
-	Action *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
-	Date   *FHIRDateTime    `bson:"date,omitempty" json:"date,omitempty"`
-	Author *Reference       `bson:"author,omitempty" json:"author,omitempty"`
+	BackboneElement `bson:",inline"`
+	Action          *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
+	Date            *FHIRDateTime    `bson:"date,omitempty" json:"date,omitempty"`
+	Author          *Reference       `bson:"author,omitempty" json:"author,omitempty"`
 }
 
 type DetectedIssuePlus struct {

--- a/models/devicecomponent.go
+++ b/models/devicecomponent.go
@@ -89,9 +89,10 @@ func (x *DeviceComponent) checkResourceType() error {
 }
 
 type DeviceComponentProductionSpecificationComponent struct {
-	SpecType       *CodeableConcept `bson:"specType,omitempty" json:"specType,omitempty"`
-	ComponentId    *Identifier      `bson:"componentId,omitempty" json:"componentId,omitempty"`
-	ProductionSpec string           `bson:"productionSpec,omitempty" json:"productionSpec,omitempty"`
+	BackboneElement `bson:",inline"`
+	SpecType        *CodeableConcept `bson:"specType,omitempty" json:"specType,omitempty"`
+	ComponentId     *Identifier      `bson:"componentId,omitempty" json:"componentId,omitempty"`
+	ProductionSpec  string           `bson:"productionSpec,omitempty" json:"productionSpec,omitempty"`
 }
 
 type DeviceComponentPlus struct {

--- a/models/devicemetric.go
+++ b/models/devicemetric.go
@@ -89,9 +89,10 @@ func (x *DeviceMetric) checkResourceType() error {
 }
 
 type DeviceMetricCalibrationComponent struct {
-	Type  string        `bson:"type,omitempty" json:"type,omitempty"`
-	State string        `bson:"state,omitempty" json:"state,omitempty"`
-	Time  *FHIRDateTime `bson:"time,omitempty" json:"time,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string        `bson:"type,omitempty" json:"type,omitempty"`
+	State           string        `bson:"state,omitempty" json:"state,omitempty"`
+	Time            *FHIRDateTime `bson:"time,omitempty" json:"time,omitempty"`
 }
 
 type DeviceMetricPlus struct {

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -91,18 +91,20 @@ func (x *DiagnosticOrder) checkResourceType() error {
 }
 
 type DiagnosticOrderEventComponent struct {
-	Status      string           `bson:"status,omitempty" json:"status,omitempty"`
-	Description *CodeableConcept `bson:"description,omitempty" json:"description,omitempty"`
-	DateTime    *FHIRDateTime    `bson:"dateTime,omitempty" json:"dateTime,omitempty"`
-	Actor       *Reference       `bson:"actor,omitempty" json:"actor,omitempty"`
+	BackboneElement `bson:",inline"`
+	Status          string           `bson:"status,omitempty" json:"status,omitempty"`
+	Description     *CodeableConcept `bson:"description,omitempty" json:"description,omitempty"`
+	DateTime        *FHIRDateTime    `bson:"dateTime,omitempty" json:"dateTime,omitempty"`
+	Actor           *Reference       `bson:"actor,omitempty" json:"actor,omitempty"`
 }
 
 type DiagnosticOrderItemComponent struct {
-	Code     *CodeableConcept                `bson:"code,omitempty" json:"code,omitempty"`
-	Specimen []Reference                     `bson:"specimen,omitempty" json:"specimen,omitempty"`
-	BodySite *CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
-	Status   string                          `bson:"status,omitempty" json:"status,omitempty"`
-	Event    []DiagnosticOrderEventComponent `bson:"event,omitempty" json:"event,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept                `bson:"code,omitempty" json:"code,omitempty"`
+	Specimen        []Reference                     `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	BodySite        *CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Status          string                          `bson:"status,omitempty" json:"status,omitempty"`
+	Event           []DiagnosticOrderEventComponent `bson:"event,omitempty" json:"event,omitempty"`
 }
 
 type DiagnosticOrderPlus struct {

--- a/models/diagnosticreport.go
+++ b/models/diagnosticreport.go
@@ -97,8 +97,9 @@ func (x *DiagnosticReport) checkResourceType() error {
 }
 
 type DiagnosticReportImageComponent struct {
-	Comment string     `bson:"comment,omitempty" json:"comment,omitempty"`
-	Link    *Reference `bson:"link,omitempty" json:"link,omitempty"`
+	BackboneElement `bson:",inline"`
+	Comment         string     `bson:"comment,omitempty" json:"comment,omitempty"`
+	Link            *Reference `bson:"link,omitempty" json:"link,omitempty"`
 }
 
 type DiagnosticReportPlus struct {

--- a/models/documentmanifest.go
+++ b/models/documentmanifest.go
@@ -91,13 +91,15 @@ func (x *DocumentManifest) checkResourceType() error {
 }
 
 type DocumentManifestContentComponent struct {
-	PAttachment *Attachment `bson:"pAttachment,omitempty" json:"pAttachment,omitempty"`
-	PReference  *Reference  `bson:"pReference,omitempty" json:"pReference,omitempty"`
+	BackboneElement `bson:",inline"`
+	PAttachment     *Attachment `bson:"pAttachment,omitempty" json:"pAttachment,omitempty"`
+	PReference      *Reference  `bson:"pReference,omitempty" json:"pReference,omitempty"`
 }
 
 type DocumentManifestRelatedComponent struct {
-	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Ref        *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Ref             *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
 }
 
 type DocumentManifestPlus struct {

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -96,16 +96,19 @@ func (x *DocumentReference) checkResourceType() error {
 }
 
 type DocumentReferenceRelatesToComponent struct {
-	Code   string     `bson:"code,omitempty" json:"code,omitempty"`
-	Target *Reference `bson:"target,omitempty" json:"target,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string     `bson:"code,omitempty" json:"code,omitempty"`
+	Target          *Reference `bson:"target,omitempty" json:"target,omitempty"`
 }
 
 type DocumentReferenceContentComponent struct {
-	Attachment *Attachment `bson:"attachment,omitempty" json:"attachment,omitempty"`
-	Format     []Coding    `bson:"format,omitempty" json:"format,omitempty"`
+	BackboneElement `bson:",inline"`
+	Attachment      *Attachment `bson:"attachment,omitempty" json:"attachment,omitempty"`
+	Format          []Coding    `bson:"format,omitempty" json:"format,omitempty"`
 }
 
 type DocumentReferenceContextComponent struct {
+	BackboneElement   `bson:",inline"`
 	Encounter         *Reference                                 `bson:"encounter,omitempty" json:"encounter,omitempty"`
 	Event             []CodeableConcept                          `bson:"event,omitempty" json:"event,omitempty"`
 	Period            *Period                                    `bson:"period,omitempty" json:"period,omitempty"`
@@ -116,8 +119,9 @@ type DocumentReferenceContextComponent struct {
 }
 
 type DocumentReferenceContextRelatedComponent struct {
-	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Ref        *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Ref             *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
 }
 
 type DocumentReferencePlus struct {

--- a/models/elementdefinition.go
+++ b/models/elementdefinition.go
@@ -253,33 +253,38 @@ type ElementDefinition struct {
 }
 
 type ElementDefinitionSlicingComponent struct {
-	Discriminator []string `bson:"discriminator,omitempty" json:"discriminator,omitempty"`
-	Description   string   `bson:"description,omitempty" json:"description,omitempty"`
-	Ordered       *bool    `bson:"ordered,omitempty" json:"ordered,omitempty"`
-	Rules         string   `bson:"rules,omitempty" json:"rules,omitempty"`
+	BackboneElement `bson:",inline"`
+	Discriminator   []string `bson:"discriminator,omitempty" json:"discriminator,omitempty"`
+	Description     string   `bson:"description,omitempty" json:"description,omitempty"`
+	Ordered         *bool    `bson:"ordered,omitempty" json:"ordered,omitempty"`
+	Rules           string   `bson:"rules,omitempty" json:"rules,omitempty"`
 }
 
 type ElementDefinitionBaseComponent struct {
-	Path string `bson:"path,omitempty" json:"path,omitempty"`
-	Min  *int32 `bson:"min,omitempty" json:"min,omitempty"`
-	Max  string `bson:"max,omitempty" json:"max,omitempty"`
+	BackboneElement `bson:",inline"`
+	Path            string `bson:"path,omitempty" json:"path,omitempty"`
+	Min             *int32 `bson:"min,omitempty" json:"min,omitempty"`
+	Max             string `bson:"max,omitempty" json:"max,omitempty"`
 }
 
 type ElementDefinitionTypeRefComponent struct {
-	Code        string   `bson:"code,omitempty" json:"code,omitempty"`
-	Profile     []string `bson:"profile,omitempty" json:"profile,omitempty"`
-	Aggregation []string `bson:"aggregation,omitempty" json:"aggregation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string   `bson:"code,omitempty" json:"code,omitempty"`
+	Profile         []string `bson:"profile,omitempty" json:"profile,omitempty"`
+	Aggregation     []string `bson:"aggregation,omitempty" json:"aggregation,omitempty"`
 }
 
 type ElementDefinitionConstraintComponent struct {
-	Key          string `bson:"key,omitempty" json:"key,omitempty"`
-	Requirements string `bson:"requirements,omitempty" json:"requirements,omitempty"`
-	Severity     string `bson:"severity,omitempty" json:"severity,omitempty"`
-	Human        string `bson:"human,omitempty" json:"human,omitempty"`
-	Xpath        string `bson:"xpath,omitempty" json:"xpath,omitempty"`
+	BackboneElement `bson:",inline"`
+	Key             string `bson:"key,omitempty" json:"key,omitempty"`
+	Requirements    string `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Severity        string `bson:"severity,omitempty" json:"severity,omitempty"`
+	Human           string `bson:"human,omitempty" json:"human,omitempty"`
+	Xpath           string `bson:"xpath,omitempty" json:"xpath,omitempty"`
 }
 
 type ElementDefinitionBindingComponent struct {
+	BackboneElement   `bson:",inline"`
 	Strength          string     `bson:"strength,omitempty" json:"strength,omitempty"`
 	Description       string     `bson:"description,omitempty" json:"description,omitempty"`
 	ValueSetUri       string     `bson:"valueSetUri,omitempty" json:"valueSetUri,omitempty"`
@@ -287,7 +292,8 @@ type ElementDefinitionBindingComponent struct {
 }
 
 type ElementDefinitionMappingComponent struct {
-	Identity string `bson:"identity,omitempty" json:"identity,omitempty"`
-	Language string `bson:"language,omitempty" json:"language,omitempty"`
-	Map      string `bson:"map,omitempty" json:"map,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identity        string `bson:"identity,omitempty" json:"identity,omitempty"`
+	Language        string `bson:"language,omitempty" json:"language,omitempty"`
+	Map             string `bson:"map,omitempty" json:"map,omitempty"`
 }

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -98,17 +98,20 @@ func (x *Encounter) checkResourceType() error {
 }
 
 type EncounterStatusHistoryComponent struct {
-	Status string  `bson:"status,omitempty" json:"status,omitempty"`
-	Period *Period `bson:"period,omitempty" json:"period,omitempty"`
+	BackboneElement `bson:",inline"`
+	Status          string  `bson:"status,omitempty" json:"status,omitempty"`
+	Period          *Period `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 type EncounterParticipantComponent struct {
-	Type       []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Period     *Period           `bson:"period,omitempty" json:"period,omitempty"`
-	Individual *Reference        `bson:"individual,omitempty" json:"individual,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Period          *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Individual      *Reference        `bson:"individual,omitempty" json:"individual,omitempty"`
 }
 
 type EncounterHospitalizationComponent struct {
+	BackboneElement        `bson:",inline"`
 	PreAdmissionIdentifier *Identifier       `bson:"preAdmissionIdentifier,omitempty" json:"preAdmissionIdentifier,omitempty"`
 	Origin                 *Reference        `bson:"origin,omitempty" json:"origin,omitempty"`
 	AdmitSource            *CodeableConcept  `bson:"admitSource,omitempty" json:"admitSource,omitempty"`
@@ -123,9 +126,10 @@ type EncounterHospitalizationComponent struct {
 }
 
 type EncounterLocationComponent struct {
-	Location *Reference `bson:"location,omitempty" json:"location,omitempty"`
-	Status   string     `bson:"status,omitempty" json:"status,omitempty"`
-	Period   *Period    `bson:"period,omitempty" json:"period,omitempty"`
+	BackboneElement `bson:",inline"`
+	Location        *Reference `bson:"location,omitempty" json:"location,omitempty"`
+	Status          string     `bson:"status,omitempty" json:"status,omitempty"`
+	Period          *Period    `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 type EncounterPlus struct {

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -90,14 +90,16 @@ func (x *EpisodeOfCare) checkResourceType() error {
 }
 
 type EpisodeOfCareStatusHistoryComponent struct {
-	Status string  `bson:"status,omitempty" json:"status,omitempty"`
-	Period *Period `bson:"period,omitempty" json:"period,omitempty"`
+	BackboneElement `bson:",inline"`
+	Status          string  `bson:"status,omitempty" json:"status,omitempty"`
+	Period          *Period `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 type EpisodeOfCareCareTeamComponent struct {
-	Role   []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
-	Period *Period           `bson:"period,omitempty" json:"period,omitempty"`
-	Member *Reference        `bson:"member,omitempty" json:"member,omitempty"`
+	BackboneElement `bson:",inline"`
+	Role            []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Period          *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Member          *Reference        `bson:"member,omitempty" json:"member,omitempty"`
 }
 
 type EpisodeOfCarePlus struct {

--- a/models/extension_ext.go
+++ b/models/extension_ext.go
@@ -1,0 +1,153 @@
+package models
+
+import (
+	"errors"
+	"strings"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+// GetBSON translates the FHIR extension syntax to a syntax that is more suitable for storage and sorting in MongoDB.
+//
+// Extension {
+//   Url: "http://example.org/fhir/extensions/foo",
+//   ValueString: "bar",
+// }
+//
+// becomes
+//
+// bson.M {
+//   "@context": bson.M {
+//     "foo": contextDefinition {
+//       ID: "http://example.org/fhir/extensions/foo",
+//       Type: "string",
+//     },
+//   },
+//   "foo": "bar",
+// }
+func (e *Extension) GetBSON() (interface{}, error) {
+	result := bson.M{"@context": bson.M{}}
+
+	var i int
+	if i = strings.LastIndex(e.Url, "/"); i < 0 || i == (len(e.Url)-1) {
+		return nil, errors.New("Couldn't determine extension name for " + e.Url)
+	}
+	name := e.Url[i+1:]
+
+	var fhirType string
+	switch {
+	case e.ValueBoolean != nil:
+		fhirType = "boolean"
+		result[name] = *e.ValueBoolean
+	case e.ValueCodeableConcept != nil:
+		fhirType = "CodeableConcept"
+		result[name] = *e.ValueCodeableConcept
+	case e.ValueDateTime != nil:
+		fhirType = "dateTime"
+		result[name] = *e.ValueDateTime
+	case e.ValueInteger != nil:
+		fhirType = "integer"
+		result[name] = *e.ValueInteger
+	case e.ValueRange != nil:
+		fhirType = "Range"
+		result[name] = *e.ValueRange
+	default:
+		fhirType = "string"
+		result[name] = e.ValueString
+	}
+
+	result["@context"].(bson.M)[name] = contextDefinition{
+		ID:   e.Url,
+		Type: fhirType,
+	}
+
+	return result, nil
+}
+
+// SetBSON translates the stored extension syntax to the FHIR extension syntax.
+//
+// bson.M {
+//   "@context": bson.M {
+//     "foo": bson.M {
+//       "@id": "http://example.org/fhir/extensions/foo",
+//       "@type": "string",
+//     },
+//   },
+//   "foo": "bar",
+// }
+//
+// becomes
+//
+// Extension {
+//   Url: "http://example.org/fhir/extensions/foo",
+//   ValueString: "bar",
+// }
+func (e *Extension) SetBSON(raw bson.Raw) error {
+	// Since we don't know the exact structure (property names), use a streaming approach with bson.RawD
+	var rd bson.RawD
+	err := raw.Unmarshal(&rd)
+	if err != nil {
+		return err
+	}
+
+	// Ensure there are only two sub-documents, then identify them
+	if len(rd) != 2 {
+		return errors.New("Couldn't properly unmarshal extension; unrecognized format in BSON")
+	}
+	var context map[string]contextDefinition
+	var dataElement bson.RawDocElem
+	for i := range rd {
+		switch rd[i].Name {
+		case "@context":
+			rd[i].Value.Unmarshal(&context)
+		default:
+			dataElement = rd[i]
+		}
+	}
+	if _, ok := context[dataElement.Name]; !ok {
+		return errors.New("Couldn't properly unmarshal extension; key " + dataElement.Name + " not found in @context")
+	}
+
+	// Now set the URL and the right Value[x]
+	e.Url = context[dataElement.Name].ID
+	switch context[dataElement.Name].Type {
+	case "boolean":
+		e.ValueBoolean = new(bool)
+		if err := dataElement.Value.Unmarshal(e.ValueBoolean); err != nil {
+			return err
+		}
+	case "CodeableConcept":
+		e.ValueCodeableConcept = new(CodeableConcept)
+		if err := dataElement.Value.Unmarshal(e.ValueCodeableConcept); err != nil {
+			return err
+		}
+	case "dateTime":
+		e.ValueDateTime = new(FHIRDateTime)
+		if err := dataElement.Value.Unmarshal(e.ValueDateTime); err != nil {
+			return err
+		}
+	case "integer":
+		e.ValueInteger = new(int32)
+		if err := dataElement.Value.Unmarshal(e.ValueInteger); err != nil {
+			return err
+		}
+	case "Range":
+		e.ValueRange = new(Range)
+		if err := dataElement.Value.Unmarshal(e.ValueRange); err != nil {
+			return err
+		}
+	case "string":
+		if err := dataElement.Value.Unmarshal(&e.ValueString); err != nil {
+			return err
+		}
+	default:
+		return errors.New("Couldn't determine extension value type from stored data")
+	}
+
+	return nil
+}
+
+type contextDefinition struct {
+	ID   string `bson:"@id,omitempty"`
+	Type string `bson:"@type,omitempty"`
+}

--- a/models/extension_ext_test.go
+++ b/models/extension_ext_test.go
@@ -257,6 +257,82 @@ func (e *ExtensionSuite) TestUnmarshalCodeableConceptExtension(c *check.C) {
 	c.Assert(ext, check.DeepEquals, expected)
 }
 
+func (e *ExtensionSuite) TestMarshalReferenceExtension(c *check.C) {
+	t := true
+	ext := &Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueReference: &Reference{
+			Reference:    "Practitioner/123",
+			ReferencedID: "123",
+			Type:         "Practitioner",
+			External:     &t,
+		},
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "Reference",
+			},
+		},
+		"foo": bson.M{
+			"reference":   "Practitioner/123",
+			"referenceid": "123",
+			"type":        "Practitioner",
+			"external":    true,
+		},
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalReferenceExtension(c *check.C) {
+	t := true
+	expected := Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueReference: &Reference{
+			Reference:    "Practitioner/123",
+			ReferencedID: "123",
+			Type:         "Practitioner",
+			External:     &t,
+		},
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "Reference",
+			},
+		},
+		"foo": bson.M{
+			"reference":   "Practitioner/123",
+			"referenceid": "123",
+			"type":        "Practitioner",
+			"external":    true,
+		},
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}
+
 func (e *ExtensionSuite) TestMarshalDateTimeExtension(c *check.C) {
 	ext := &Extension{
 		Url: "http://example.org/fhir/extensions/foo",

--- a/models/extension_ext_test.go
+++ b/models/extension_ext_test.go
@@ -1,0 +1,400 @@
+package models
+
+import (
+	"time"
+
+	"github.com/pebbe/util"
+	check "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type ExtensionSuite struct {
+}
+
+var _ = check.Suite(&ExtensionSuite{})
+
+func (e *ExtensionSuite) TestMarshalStringExtension(c *check.C) {
+	ext := &Extension{
+		Url:         "http://example.org/fhir/extensions/foo",
+		ValueString: "bar",
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "string",
+			},
+		},
+		"foo": "bar",
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalStringExtension(c *check.C) {
+	expected := Extension{
+		Url:         "http://example.org/fhir/extensions/foo",
+		ValueString: "bar",
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "string",
+			},
+		},
+		"foo": "bar",
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestMarshalIntegerExtension(c *check.C) {
+	fifty := int32(50)
+	ext := &Extension{
+		Url:          "http://example.org/fhir/extensions/foo",
+		ValueInteger: &fifty,
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "integer",
+			},
+		},
+		"foo": 50,
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalIntegerExtension(c *check.C) {
+	fifty := int32(50)
+	expected := Extension{
+		Url:          "http://example.org/fhir/extensions/foo",
+		ValueInteger: &fifty,
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "integer",
+			},
+		},
+		"foo": 50,
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestMarshalBooleanExtension(c *check.C) {
+	t := true
+	ext := &Extension{
+		Url:          "http://example.org/fhir/extensions/foo",
+		ValueBoolean: &t,
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "boolean",
+			},
+		},
+		"foo": true,
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalBooleanExtension(c *check.C) {
+	t := true
+	expected := Extension{
+		Url:          "http://example.org/fhir/extensions/foo",
+		ValueBoolean: &t,
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "boolean",
+			},
+		},
+		"foo": true,
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestMarshalCodeableConceptExtension(c *check.C) {
+	ext := &Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueCodeableConcept: &CodeableConcept{
+			Coding: []Coding{
+				{System: "http://example.org/fhir/valuesets/foo", Code: "bar"},
+				{System: "http://example.org/fhir/valuesets/fooz", Code: "barz"},
+			},
+			Text: "bar",
+		},
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "CodeableConcept",
+			},
+		},
+		"foo": bson.M{
+			"coding": []interface{}{
+				bson.M{"system": "http://example.org/fhir/valuesets/foo", "code": "bar"},
+				bson.M{"system": "http://example.org/fhir/valuesets/fooz", "code": "barz"},
+			},
+			"text": "bar",
+		},
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalCodeableConceptExtension(c *check.C) {
+	expected := Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueCodeableConcept: &CodeableConcept{
+			Coding: []Coding{
+				{System: "http://example.org/fhir/valuesets/foo", Code: "bar"},
+				{System: "http://example.org/fhir/valuesets/fooz", Code: "barz"},
+			},
+			Text: "bar",
+		},
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "CodeableConcept",
+			},
+		},
+		"foo": bson.M{
+			"coding": []interface{}{
+				bson.M{"system": "http://example.org/fhir/valuesets/foo", "code": "bar"},
+				bson.M{"system": "http://example.org/fhir/valuesets/fooz", "code": "barz"},
+			},
+			"text": "bar",
+		},
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestMarshalDateTimeExtension(c *check.C) {
+	ext := &Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueDateTime: &FHIRDateTime{
+			Time:      time.Date(2012, time.March, 1, 12, 0, 0, 0, time.UTC),
+			Precision: Precision(Timestamp),
+		},
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "dateTime",
+			},
+		},
+		"foo": bson.M{
+			"time":      time.Date(2012, time.March, 1, 12, 0, 0, 0, time.UTC),
+			"precision": "timestamp",
+		},
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	// Can't do deep equals of whole object because the time location won't match (despite having the same offset)
+	c.Assert(m["@context"], check.DeepEquals, expected["@context"])
+	c.Assert(m["foo"].(bson.M)["precision"], check.Equals, expected["foo"].(bson.M)["precision"])
+	c.Assert(m["foo"].(bson.M)["time"].(time.Time).Unix(), check.Equals, expected["foo"].(bson.M)["time"].(time.Time).Unix())
+}
+
+func (e *ExtensionSuite) TestUnmarshalDateTimeExtension(c *check.C) {
+	expected := Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueDateTime: &FHIRDateTime{
+			Time:      time.Date(2012, time.March, 1, 12, 0, 0, 0, time.UTC),
+			Precision: Precision(Timestamp),
+		},
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "dateTime",
+			},
+		},
+		"foo": bson.M{
+			"time":      time.Date(2012, time.March, 1, 12, 0, 0, 0, time.UTC),
+			"precision": "timestamp",
+		},
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	// Can't do deep equals of whole object because the time location won't match (despite having the same offset)
+	c.Assert(ext.Url, check.Equals, expected.Url)
+	c.Assert(ext.ValueDateTime.Precision, check.Equals, expected.ValueDateTime.Precision)
+	c.Assert(ext.ValueDateTime.Time.Unix(), check.Equals, expected.ValueDateTime.Time.Unix())
+}
+
+func (e *ExtensionSuite) TestMarshalRangeExtension(c *check.C) {
+	l := float64(10)
+	h := float64(20)
+	ext := &Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueRange: &Range{
+			Low:  &Quantity{Value: &l, Unit: "mm"},
+			High: &Quantity{Value: &h, Unit: "mm"},
+		},
+	}
+
+	expected := bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "Range",
+			},
+		},
+		"foo": bson.M{
+			"low":  bson.M{"value": float64(10), "unit": "mm"},
+			"high": bson.M{"value": float64(20), "unit": "mm"},
+		},
+	}
+
+	// This is where SetBSON is called to marshal it into BSON bytes
+	data, err := bson.Marshal(ext)
+	util.CheckErr(err)
+
+	// Now unmarshal it back to a map so we can check it against the expected values
+	var m bson.M
+	err = bson.Unmarshal(data, &m)
+	util.CheckErr(err)
+
+	c.Assert(m, check.DeepEquals, expected)
+}
+
+func (e *ExtensionSuite) TestUnmarshalRangeExtension(c *check.C) {
+	l := float64(10)
+	h := float64(20)
+	expected := Extension{
+		Url: "http://example.org/fhir/extensions/foo",
+		ValueRange: &Range{
+			Low:  &Quantity{Value: &l, Unit: "mm"},
+			High: &Quantity{Value: &h, Unit: "mm"},
+		},
+	}
+
+	// First marshal the BSON representation into a BSON bytestream
+	data, err := bson.Marshal(bson.M{
+		"@context": bson.M{
+			"foo": bson.M{
+				"@id":   "http://example.org/fhir/extensions/foo",
+				"@type": "Range",
+			},
+		},
+		"foo": bson.M{
+			"low":  bson.M{"value": float64(10), "unit": "mm"},
+			"high": bson.M{"value": float64(20), "unit": "mm"},
+		},
+	})
+	util.CheckErr(err)
+
+	// Now unmarshal it into the extension and check it
+	var ext Extension
+	err = bson.Unmarshal(data, &ext)
+	util.CheckErr(err)
+
+	c.Assert(ext, check.DeepEquals, expected)
+}

--- a/models/familymemberhistory.go
+++ b/models/familymemberhistory.go
@@ -99,13 +99,14 @@ func (x *FamilyMemberHistory) checkResourceType() error {
 }
 
 type FamilyMemberHistoryConditionComponent struct {
-	Code        *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Outcome     *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
-	OnsetAge    *Quantity        `bson:"onsetAge,omitempty" json:"onsetAge,omitempty"`
-	OnsetRange  *Range           `bson:"onsetRange,omitempty" json:"onsetRange,omitempty"`
-	OnsetPeriod *Period          `bson:"onsetPeriod,omitempty" json:"onsetPeriod,omitempty"`
-	OnsetString string           `bson:"onsetString,omitempty" json:"onsetString,omitempty"`
-	Note        *Annotation      `bson:"note,omitempty" json:"note,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Outcome         *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	OnsetAge        *Quantity        `bson:"onsetAge,omitempty" json:"onsetAge,omitempty"`
+	OnsetRange      *Range           `bson:"onsetRange,omitempty" json:"onsetRange,omitempty"`
+	OnsetPeriod     *Period          `bson:"onsetPeriod,omitempty" json:"onsetPeriod,omitempty"`
+	OnsetString     string           `bson:"onsetString,omitempty" json:"onsetString,omitempty"`
+	Note            *Annotation      `bson:"note,omitempty" json:"note,omitempty"`
 }
 
 type FamilyMemberHistoryPlus struct {

--- a/models/goal.go
+++ b/models/goal.go
@@ -95,6 +95,7 @@ func (x *Goal) checkResourceType() error {
 }
 
 type GoalOutcomeComponent struct {
+	BackboneElement       `bson:",inline"`
 	ResultCodeableConcept *CodeableConcept `bson:"resultCodeableConcept,omitempty" json:"resultCodeableConcept,omitempty"`
 	ResultReference       *Reference       `bson:"resultReference,omitempty" json:"resultReference,omitempty"`
 }

--- a/models/group.go
+++ b/models/group.go
@@ -87,6 +87,7 @@ func (x *Group) checkResourceType() error {
 }
 
 type GroupCharacteristicComponent struct {
+	BackboneElement      `bson:",inline"`
 	Code                 *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 	ValueCodeableConcept *CodeableConcept `bson:"valueCodeableConcept,omitempty" json:"valueCodeableConcept,omitempty"`
 	ValueBoolean         *bool            `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
@@ -97,9 +98,10 @@ type GroupCharacteristicComponent struct {
 }
 
 type GroupMemberComponent struct {
-	Entity   *Reference `bson:"entity,omitempty" json:"entity,omitempty"`
-	Period   *Period    `bson:"period,omitempty" json:"period,omitempty"`
-	Inactive *bool      `bson:"inactive,omitempty" json:"inactive,omitempty"`
+	BackboneElement `bson:",inline"`
+	Entity          *Reference `bson:"entity,omitempty" json:"entity,omitempty"`
+	Period          *Period    `bson:"period,omitempty" json:"period,omitempty"`
+	Inactive        *bool      `bson:"inactive,omitempty" json:"inactive,omitempty"`
 }
 
 type GroupPlus struct {

--- a/models/healthcareservice.go
+++ b/models/healthcareservice.go
@@ -101,11 +101,13 @@ func (x *HealthcareService) checkResourceType() error {
 }
 
 type HealthcareServiceServiceTypeComponent struct {
-	Type      *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
-	Specialty []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Specialty       []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
 }
 
 type HealthcareServiceAvailableTimeComponent struct {
+	BackboneElement    `bson:",inline"`
 	DaysOfWeek         []string      `bson:"daysOfWeek,omitempty" json:"daysOfWeek,omitempty"`
 	AllDay             *bool         `bson:"allDay,omitempty" json:"allDay,omitempty"`
 	AvailableStartTime *FHIRDateTime `bson:"availableStartTime,omitempty" json:"availableStartTime,omitempty"`
@@ -113,8 +115,9 @@ type HealthcareServiceAvailableTimeComponent struct {
 }
 
 type HealthcareServiceNotAvailableComponent struct {
-	Description string  `bson:"description,omitempty" json:"description,omitempty"`
-	During      *Period `bson:"during,omitempty" json:"during,omitempty"`
+	BackboneElement `bson:",inline"`
+	Description     string  `bson:"description,omitempty" json:"description,omitempty"`
+	During          *Period `bson:"during,omitempty" json:"during,omitempty"`
 }
 
 type HealthcareServicePlus struct {

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -86,28 +86,32 @@ func (x *ImagingObjectSelection) checkResourceType() error {
 }
 
 type ImagingObjectSelectionStudyComponent struct {
-	Uid          string                                  `bson:"uid,omitempty" json:"uid,omitempty"`
-	Url          string                                  `bson:"url,omitempty" json:"url,omitempty"`
-	ImagingStudy *Reference                              `bson:"imagingStudy,omitempty" json:"imagingStudy,omitempty"`
-	Series       []ImagingObjectSelectionSeriesComponent `bson:"series,omitempty" json:"series,omitempty"`
+	BackboneElement `bson:",inline"`
+	Uid             string                                  `bson:"uid,omitempty" json:"uid,omitempty"`
+	Url             string                                  `bson:"url,omitempty" json:"url,omitempty"`
+	ImagingStudy    *Reference                              `bson:"imagingStudy,omitempty" json:"imagingStudy,omitempty"`
+	Series          []ImagingObjectSelectionSeriesComponent `bson:"series,omitempty" json:"series,omitempty"`
 }
 
 type ImagingObjectSelectionSeriesComponent struct {
-	Uid      string                                    `bson:"uid,omitempty" json:"uid,omitempty"`
-	Url      string                                    `bson:"url,omitempty" json:"url,omitempty"`
-	Instance []ImagingObjectSelectionInstanceComponent `bson:"instance,omitempty" json:"instance,omitempty"`
+	BackboneElement `bson:",inline"`
+	Uid             string                                    `bson:"uid,omitempty" json:"uid,omitempty"`
+	Url             string                                    `bson:"url,omitempty" json:"url,omitempty"`
+	Instance        []ImagingObjectSelectionInstanceComponent `bson:"instance,omitempty" json:"instance,omitempty"`
 }
 
 type ImagingObjectSelectionInstanceComponent struct {
-	SopClass string                                  `bson:"sopClass,omitempty" json:"sopClass,omitempty"`
-	Uid      string                                  `bson:"uid,omitempty" json:"uid,omitempty"`
-	Url      string                                  `bson:"url,omitempty" json:"url,omitempty"`
-	Frames   []ImagingObjectSelectionFramesComponent `bson:"frames,omitempty" json:"frames,omitempty"`
+	BackboneElement `bson:",inline"`
+	SopClass        string                                  `bson:"sopClass,omitempty" json:"sopClass,omitempty"`
+	Uid             string                                  `bson:"uid,omitempty" json:"uid,omitempty"`
+	Url             string                                  `bson:"url,omitempty" json:"url,omitempty"`
+	Frames          []ImagingObjectSelectionFramesComponent `bson:"frames,omitempty" json:"frames,omitempty"`
 }
 
 type ImagingObjectSelectionFramesComponent struct {
-	FrameNumbers []uint32 `bson:"frameNumbers,omitempty" json:"frameNumbers,omitempty"`
-	Url          string   `bson:"url,omitempty" json:"url,omitempty"`
+	BackboneElement `bson:",inline"`
+	FrameNumbers    []uint32 `bson:"frameNumbers,omitempty" json:"frameNumbers,omitempty"`
+	Url             string   `bson:"url,omitempty" json:"url,omitempty"`
 }
 
 type ImagingObjectSelectionPlus struct {

--- a/models/imagingstudy.go
+++ b/models/imagingstudy.go
@@ -95,6 +95,7 @@ func (x *ImagingStudy) checkResourceType() error {
 }
 
 type ImagingStudySeriesComponent struct {
+	BackboneElement   `bson:",inline"`
 	Number            *uint32                               `bson:"number,omitempty" json:"number,omitempty"`
 	Modality          *Coding                               `bson:"modality,omitempty" json:"modality,omitempty"`
 	Uid               string                                `bson:"uid,omitempty" json:"uid,omitempty"`
@@ -109,12 +110,13 @@ type ImagingStudySeriesComponent struct {
 }
 
 type ImagingStudySeriesInstanceComponent struct {
-	Number   *uint32      `bson:"number,omitempty" json:"number,omitempty"`
-	Uid      string       `bson:"uid,omitempty" json:"uid,omitempty"`
-	SopClass string       `bson:"sopClass,omitempty" json:"sopClass,omitempty"`
-	Type     string       `bson:"type,omitempty" json:"type,omitempty"`
-	Title    string       `bson:"title,omitempty" json:"title,omitempty"`
-	Content  []Attachment `bson:"content,omitempty" json:"content,omitempty"`
+	BackboneElement `bson:",inline"`
+	Number          *uint32      `bson:"number,omitempty" json:"number,omitempty"`
+	Uid             string       `bson:"uid,omitempty" json:"uid,omitempty"`
+	SopClass        string       `bson:"sopClass,omitempty" json:"sopClass,omitempty"`
+	Type            string       `bson:"type,omitempty" json:"type,omitempty"`
+	Title           string       `bson:"title,omitempty" json:"title,omitempty"`
+	Content         []Attachment `bson:"content,omitempty" json:"content,omitempty"`
 }
 
 type ImagingStudyPlus struct {

--- a/models/immunization.go
+++ b/models/immunization.go
@@ -100,17 +100,20 @@ func (x *Immunization) checkResourceType() error {
 }
 
 type ImmunizationExplanationComponent struct {
-	Reason         []CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
-	ReasonNotGiven []CodeableConcept `bson:"reasonNotGiven,omitempty" json:"reasonNotGiven,omitempty"`
+	BackboneElement `bson:",inline"`
+	Reason          []CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+	ReasonNotGiven  []CodeableConcept `bson:"reasonNotGiven,omitempty" json:"reasonNotGiven,omitempty"`
 }
 
 type ImmunizationReactionComponent struct {
-	Date     *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
-	Detail   *Reference    `bson:"detail,omitempty" json:"detail,omitempty"`
-	Reported *bool         `bson:"reported,omitempty" json:"reported,omitempty"`
+	BackboneElement `bson:",inline"`
+	Date            *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
+	Detail          *Reference    `bson:"detail,omitempty" json:"detail,omitempty"`
+	Reported        *bool         `bson:"reported,omitempty" json:"reported,omitempty"`
 }
 
 type ImmunizationVaccinationProtocolComponent struct {
+	BackboneElement  `bson:",inline"`
 	DoseSequence     *uint32           `bson:"doseSequence,omitempty" json:"doseSequence,omitempty"`
 	Description      string            `bson:"description,omitempty" json:"description,omitempty"`
 	Authority        *Reference        `bson:"authority,omitempty" json:"authority,omitempty"`

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -82,6 +82,7 @@ func (x *ImmunizationRecommendation) checkResourceType() error {
 }
 
 type ImmunizationRecommendationRecommendationComponent struct {
+	BackboneElement              `bson:",inline"`
 	Date                         *FHIRDateTime                                                    `bson:"date,omitempty" json:"date,omitempty"`
 	VaccineCode                  *CodeableConcept                                                 `bson:"vaccineCode,omitempty" json:"vaccineCode,omitempty"`
 	DoseNumber                   *uint32                                                          `bson:"doseNumber,omitempty" json:"doseNumber,omitempty"`
@@ -93,15 +94,17 @@ type ImmunizationRecommendationRecommendationComponent struct {
 }
 
 type ImmunizationRecommendationRecommendationDateCriterionComponent struct {
-	Code  *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Value *FHIRDateTime    `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Value           *FHIRDateTime    `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ImmunizationRecommendationRecommendationProtocolComponent struct {
-	DoseSequence *int32     `bson:"doseSequence,omitempty" json:"doseSequence,omitempty"`
-	Description  string     `bson:"description,omitempty" json:"description,omitempty"`
-	Authority    *Reference `bson:"authority,omitempty" json:"authority,omitempty"`
-	Series       string     `bson:"series,omitempty" json:"series,omitempty"`
+	BackboneElement `bson:",inline"`
+	DoseSequence    *int32     `bson:"doseSequence,omitempty" json:"doseSequence,omitempty"`
+	Description     string     `bson:"description,omitempty" json:"description,omitempty"`
+	Authority       *Reference `bson:"authority,omitempty" json:"authority,omitempty"`
+	Series          string     `bson:"series,omitempty" json:"series,omitempty"`
 }
 
 type ImmunizationRecommendationPlus struct {

--- a/models/implementationguide.go
+++ b/models/implementationguide.go
@@ -96,22 +96,26 @@ func (x *ImplementationGuide) checkResourceType() error {
 }
 
 type ImplementationGuideContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type ImplementationGuideDependencyComponent struct {
-	Type string `bson:"type,omitempty" json:"type,omitempty"`
-	Uri  string `bson:"uri,omitempty" json:"uri,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string `bson:"type,omitempty" json:"type,omitempty"`
+	Uri             string `bson:"uri,omitempty" json:"uri,omitempty"`
 }
 
 type ImplementationGuidePackageComponent struct {
-	Name        string                                        `bson:"name,omitempty" json:"name,omitempty"`
-	Description string                                        `bson:"description,omitempty" json:"description,omitempty"`
-	Resource    []ImplementationGuidePackageResourceComponent `bson:"resource,omitempty" json:"resource,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string                                        `bson:"name,omitempty" json:"name,omitempty"`
+	Description     string                                        `bson:"description,omitempty" json:"description,omitempty"`
+	Resource        []ImplementationGuidePackageResourceComponent `bson:"resource,omitempty" json:"resource,omitempty"`
 }
 
 type ImplementationGuidePackageResourceComponent struct {
+	BackboneElement `bson:",inline"`
 	Purpose         string     `bson:"purpose,omitempty" json:"purpose,omitempty"`
 	Name            string     `bson:"name,omitempty" json:"name,omitempty"`
 	Description     string     `bson:"description,omitempty" json:"description,omitempty"`
@@ -122,18 +126,20 @@ type ImplementationGuidePackageResourceComponent struct {
 }
 
 type ImplementationGuideGlobalComponent struct {
-	Type    string     `bson:"type,omitempty" json:"type,omitempty"`
-	Profile *Reference `bson:"profile,omitempty" json:"profile,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string     `bson:"type,omitempty" json:"type,omitempty"`
+	Profile         *Reference `bson:"profile,omitempty" json:"profile,omitempty"`
 }
 
 type ImplementationGuidePageComponent struct {
-	Source  string                             `bson:"source,omitempty" json:"source,omitempty"`
-	Name    string                             `bson:"name,omitempty" json:"name,omitempty"`
-	Kind    string                             `bson:"kind,omitempty" json:"kind,omitempty"`
-	Type    []string                           `bson:"type,omitempty" json:"type,omitempty"`
-	Package []string                           `bson:"package,omitempty" json:"package,omitempty"`
-	Format  string                             `bson:"format,omitempty" json:"format,omitempty"`
-	Page    []ImplementationGuidePageComponent `bson:"page,omitempty" json:"page,omitempty"`
+	BackboneElement `bson:",inline"`
+	Source          string                             `bson:"source,omitempty" json:"source,omitempty"`
+	Name            string                             `bson:"name,omitempty" json:"name,omitempty"`
+	Kind            string                             `bson:"kind,omitempty" json:"kind,omitempty"`
+	Type            []string                           `bson:"type,omitempty" json:"type,omitempty"`
+	Package         []string                           `bson:"package,omitempty" json:"package,omitempty"`
+	Format          string                             `bson:"format,omitempty" json:"format,omitempty"`
+	Page            []ImplementationGuidePageComponent `bson:"page,omitempty" json:"page,omitempty"`
 }
 
 type ImplementationGuidePlus struct {

--- a/models/list.go
+++ b/models/list.go
@@ -92,10 +92,11 @@ func (x *List) checkResourceType() error {
 }
 
 type ListEntryComponent struct {
-	Flag    *CodeableConcept `bson:"flag,omitempty" json:"flag,omitempty"`
-	Deleted *bool            `bson:"deleted,omitempty" json:"deleted,omitempty"`
-	Date    *FHIRDateTime    `bson:"date,omitempty" json:"date,omitempty"`
-	Item    *Reference       `bson:"item,omitempty" json:"item,omitempty"`
+	BackboneElement `bson:",inline"`
+	Flag            *CodeableConcept `bson:"flag,omitempty" json:"flag,omitempty"`
+	Deleted         *bool            `bson:"deleted,omitempty" json:"deleted,omitempty"`
+	Date            *FHIRDateTime    `bson:"date,omitempty" json:"date,omitempty"`
+	Item            *Reference       `bson:"item,omitempty" json:"item,omitempty"`
 }
 
 type ListPlus struct {

--- a/models/location.go
+++ b/models/location.go
@@ -91,9 +91,10 @@ func (x *Location) checkResourceType() error {
 }
 
 type LocationPositionComponent struct {
-	Longitude *float64 `bson:"longitude,omitempty" json:"longitude,omitempty"`
-	Latitude  *float64 `bson:"latitude,omitempty" json:"latitude,omitempty"`
-	Altitude  *float64 `bson:"altitude,omitempty" json:"altitude,omitempty"`
+	BackboneElement `bson:",inline"`
+	Longitude       *float64 `bson:"longitude,omitempty" json:"longitude,omitempty"`
+	Latitude        *float64 `bson:"latitude,omitempty" json:"latitude,omitempty"`
+	Altitude        *float64 `bson:"altitude,omitempty" json:"altitude,omitempty"`
 }
 
 type LocationPlus struct {

--- a/models/medication.go
+++ b/models/medication.go
@@ -84,29 +84,34 @@ func (x *Medication) checkResourceType() error {
 }
 
 type MedicationProductComponent struct {
-	Form       *CodeableConcept                       `bson:"form,omitempty" json:"form,omitempty"`
-	Ingredient []MedicationProductIngredientComponent `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
-	Batch      []MedicationProductBatchComponent      `bson:"batch,omitempty" json:"batch,omitempty"`
+	BackboneElement `bson:",inline"`
+	Form            *CodeableConcept                       `bson:"form,omitempty" json:"form,omitempty"`
+	Ingredient      []MedicationProductIngredientComponent `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
+	Batch           []MedicationProductBatchComponent      `bson:"batch,omitempty" json:"batch,omitempty"`
 }
 
 type MedicationProductIngredientComponent struct {
-	Item   *Reference `bson:"item,omitempty" json:"item,omitempty"`
-	Amount *Ratio     `bson:"amount,omitempty" json:"amount,omitempty"`
+	BackboneElement `bson:",inline"`
+	Item            *Reference `bson:"item,omitempty" json:"item,omitempty"`
+	Amount          *Ratio     `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 
 type MedicationProductBatchComponent struct {
-	LotNumber      string        `bson:"lotNumber,omitempty" json:"lotNumber,omitempty"`
-	ExpirationDate *FHIRDateTime `bson:"expirationDate,omitempty" json:"expirationDate,omitempty"`
+	BackboneElement `bson:",inline"`
+	LotNumber       string        `bson:"lotNumber,omitempty" json:"lotNumber,omitempty"`
+	ExpirationDate  *FHIRDateTime `bson:"expirationDate,omitempty" json:"expirationDate,omitempty"`
 }
 
 type MedicationPackageComponent struct {
-	Container *CodeableConcept                    `bson:"container,omitempty" json:"container,omitempty"`
-	Content   []MedicationPackageContentComponent `bson:"content,omitempty" json:"content,omitempty"`
+	BackboneElement `bson:",inline"`
+	Container       *CodeableConcept                    `bson:"container,omitempty" json:"container,omitempty"`
+	Content         []MedicationPackageContentComponent `bson:"content,omitempty" json:"content,omitempty"`
 }
 
 type MedicationPackageContentComponent struct {
-	Item   *Reference `bson:"item,omitempty" json:"item,omitempty"`
-	Amount *Quantity  `bson:"amount,omitempty" json:"amount,omitempty"`
+	BackboneElement `bson:",inline"`
+	Item            *Reference `bson:"item,omitempty" json:"item,omitempty"`
+	Amount          *Quantity  `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 
 type MedicationPlus struct {

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -95,6 +95,7 @@ func (x *MedicationAdministration) checkResourceType() error {
 }
 
 type MedicationAdministrationDosageComponent struct {
+	BackboneElement     `bson:",inline"`
 	Text                string           `bson:"text,omitempty" json:"text,omitempty"`
 	SiteCodeableConcept *CodeableConcept `bson:"siteCodeableConcept,omitempty" json:"siteCodeableConcept,omitempty"`
 	SiteReference       *Reference       `bson:"siteReference,omitempty" json:"siteReference,omitempty"`

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -96,6 +96,7 @@ func (x *MedicationDispense) checkResourceType() error {
 }
 
 type MedicationDispenseDosageInstructionComponent struct {
+	BackboneElement         `bson:",inline"`
 	Text                    string           `bson:"text,omitempty" json:"text,omitempty"`
 	AdditionalInstructions  *CodeableConcept `bson:"additionalInstructions,omitempty" json:"additionalInstructions,omitempty"`
 	Timing                  *Timing          `bson:"timing,omitempty" json:"timing,omitempty"`
@@ -113,6 +114,7 @@ type MedicationDispenseDosageInstructionComponent struct {
 }
 
 type MedicationDispenseSubstitutionComponent struct {
+	BackboneElement  `bson:",inline"`
 	Type             *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
 	Reason           []CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 	ResponsibleParty []Reference       `bson:"responsibleParty,omitempty" json:"responsibleParty,omitempty"`

--- a/models/medicationorder.go
+++ b/models/medicationorder.go
@@ -96,6 +96,7 @@ func (x *MedicationOrder) checkResourceType() error {
 }
 
 type MedicationOrderDosageInstructionComponent struct {
+	BackboneElement         `bson:",inline"`
 	Text                    string           `bson:"text,omitempty" json:"text,omitempty"`
 	AdditionalInstructions  *CodeableConcept `bson:"additionalInstructions,omitempty" json:"additionalInstructions,omitempty"`
 	Timing                  *Timing          `bson:"timing,omitempty" json:"timing,omitempty"`
@@ -113,6 +114,7 @@ type MedicationOrderDosageInstructionComponent struct {
 }
 
 type MedicationOrderDispenseRequestComponent struct {
+	BackboneElement           `bson:",inline"`
 	MedicationCodeableConcept *CodeableConcept `bson:"medicationCodeableConcept,omitempty" json:"medicationCodeableConcept,omitempty"`
 	MedicationReference       *Reference       `bson:"medicationReference,omitempty" json:"medicationReference,omitempty"`
 	ValidityPeriod            *Period          `bson:"validityPeriod,omitempty" json:"validityPeriod,omitempty"`
@@ -122,8 +124,9 @@ type MedicationOrderDispenseRequestComponent struct {
 }
 
 type MedicationOrderSubstitutionComponent struct {
-	Type   *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Reason *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Reason          *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 }
 
 type MedicationOrderPlus struct {

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -95,6 +95,7 @@ func (x *MedicationStatement) checkResourceType() error {
 }
 
 type MedicationStatementDosageComponent struct {
+	BackboneElement         `bson:",inline"`
 	Text                    string           `bson:"text,omitempty" json:"text,omitempty"`
 	Timing                  *Timing          `bson:"timing,omitempty" json:"timing,omitempty"`
 	AsNeededBoolean         *bool            `bson:"asNeededBoolean,omitempty" json:"asNeededBoolean,omitempty"`

--- a/models/messageheader.go
+++ b/models/messageheader.go
@@ -90,23 +90,26 @@ func (x *MessageHeader) checkResourceType() error {
 }
 
 type MessageHeaderResponseComponent struct {
-	Identifier string     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Code       string     `bson:"code,omitempty" json:"code,omitempty"`
-	Details    *Reference `bson:"details,omitempty" json:"details,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      string     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code            string     `bson:"code,omitempty" json:"code,omitempty"`
+	Details         *Reference `bson:"details,omitempty" json:"details,omitempty"`
 }
 
 type MessageHeaderMessageSourceComponent struct {
-	Name     string        `bson:"name,omitempty" json:"name,omitempty"`
-	Software string        `bson:"software,omitempty" json:"software,omitempty"`
-	Version  string        `bson:"version,omitempty" json:"version,omitempty"`
-	Contact  *ContactPoint `bson:"contact,omitempty" json:"contact,omitempty"`
-	Endpoint string        `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string        `bson:"name,omitempty" json:"name,omitempty"`
+	Software        string        `bson:"software,omitempty" json:"software,omitempty"`
+	Version         string        `bson:"version,omitempty" json:"version,omitempty"`
+	Contact         *ContactPoint `bson:"contact,omitempty" json:"contact,omitempty"`
+	Endpoint        string        `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 
 type MessageHeaderMessageDestinationComponent struct {
-	Name     string     `bson:"name,omitempty" json:"name,omitempty"`
-	Target   *Reference `bson:"target,omitempty" json:"target,omitempty"`
-	Endpoint string     `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string     `bson:"name,omitempty" json:"name,omitempty"`
+	Target          *Reference `bson:"target,omitempty" json:"target,omitempty"`
+	Endpoint        string     `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 
 type MessageHeaderPlus struct {

--- a/models/meta.go
+++ b/models/meta.go
@@ -27,6 +27,7 @@
 package models
 
 type Meta struct {
+	Element     `bson:",inline"`
 	VersionId   string        `bson:"versionId,omitempty" json:"versionId,omitempty"`
 	LastUpdated *FHIRDateTime `bson:"lastUpdated,omitempty" json:"lastUpdated,omitempty"`
 	Profile     []string      `bson:"profile,omitempty" json:"profile,omitempty"`

--- a/models/namingsystem.go
+++ b/models/namingsystem.go
@@ -92,15 +92,17 @@ func (x *NamingSystem) checkResourceType() error {
 }
 
 type NamingSystemContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type NamingSystemUniqueIdComponent struct {
-	Type      string  `bson:"type,omitempty" json:"type,omitempty"`
-	Value     string  `bson:"value,omitempty" json:"value,omitempty"`
-	Preferred *bool   `bson:"preferred,omitempty" json:"preferred,omitempty"`
-	Period    *Period `bson:"period,omitempty" json:"period,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string  `bson:"type,omitempty" json:"type,omitempty"`
+	Value           string  `bson:"value,omitempty" json:"value,omitempty"`
+	Preferred       *bool   `bson:"preferred,omitempty" json:"preferred,omitempty"`
+	Period          *Period `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 type NamingSystemPlus struct {

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -91,6 +91,7 @@ func (x *NutritionOrder) checkResourceType() error {
 }
 
 type NutritionOrderOralDietComponent struct {
+	BackboneElement      `bson:",inline"`
 	Type                 []CodeableConcept                         `bson:"type,omitempty" json:"type,omitempty"`
 	Schedule             []Timing                                  `bson:"schedule,omitempty" json:"schedule,omitempty"`
 	Nutrient             []NutritionOrderOralDietNutrientComponent `bson:"nutrient,omitempty" json:"nutrient,omitempty"`
@@ -100,24 +101,28 @@ type NutritionOrderOralDietComponent struct {
 }
 
 type NutritionOrderOralDietNutrientComponent struct {
-	Modifier *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
-	Amount   *Quantity        `bson:"amount,omitempty" json:"amount,omitempty"`
+	BackboneElement `bson:",inline"`
+	Modifier        *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Amount          *Quantity        `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 
 type NutritionOrderOralDietTextureComponent struct {
-	Modifier *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
-	FoodType *CodeableConcept `bson:"foodType,omitempty" json:"foodType,omitempty"`
+	BackboneElement `bson:",inline"`
+	Modifier        *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	FoodType        *CodeableConcept `bson:"foodType,omitempty" json:"foodType,omitempty"`
 }
 
 type NutritionOrderSupplementComponent struct {
-	Type        *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	ProductName string           `bson:"productName,omitempty" json:"productName,omitempty"`
-	Schedule    []Timing         `bson:"schedule,omitempty" json:"schedule,omitempty"`
-	Quantity    *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
-	Instruction string           `bson:"instruction,omitempty" json:"instruction,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	ProductName     string           `bson:"productName,omitempty" json:"productName,omitempty"`
+	Schedule        []Timing         `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	Quantity        *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Instruction     string           `bson:"instruction,omitempty" json:"instruction,omitempty"`
 }
 
 type NutritionOrderEnteralFormulaComponent struct {
+	BackboneElement           `bson:",inline"`
 	BaseFormulaType           *CodeableConcept                                      `bson:"baseFormulaType,omitempty" json:"baseFormulaType,omitempty"`
 	BaseFormulaProductName    string                                                `bson:"baseFormulaProductName,omitempty" json:"baseFormulaProductName,omitempty"`
 	AdditiveType              *CodeableConcept                                      `bson:"additiveType,omitempty" json:"additiveType,omitempty"`
@@ -130,6 +135,7 @@ type NutritionOrderEnteralFormulaComponent struct {
 }
 
 type NutritionOrderEnteralFormulaAdministrationComponent struct {
+	BackboneElement    `bson:",inline"`
 	Schedule           *Timing   `bson:"schedule,omitempty" json:"schedule,omitempty"`
 	Quantity           *Quantity `bson:"quantity,omitempty" json:"quantity,omitempty"`
 	RateSimpleQuantity *Quantity `bson:"rateSimpleQuantity,omitempty" json:"rateSimpleQuantity,omitempty"`

--- a/models/observation.go
+++ b/models/observation.go
@@ -109,19 +109,22 @@ func (x *Observation) checkResourceType() error {
 }
 
 type ObservationReferenceRangeComponent struct {
-	Low     *Quantity        `bson:"low,omitempty" json:"low,omitempty"`
-	High    *Quantity        `bson:"high,omitempty" json:"high,omitempty"`
-	Meaning *CodeableConcept `bson:"meaning,omitempty" json:"meaning,omitempty"`
-	Age     *Range           `bson:"age,omitempty" json:"age,omitempty"`
-	Text    string           `bson:"text,omitempty" json:"text,omitempty"`
+	BackboneElement `bson:",inline"`
+	Low             *Quantity        `bson:"low,omitempty" json:"low,omitempty"`
+	High            *Quantity        `bson:"high,omitempty" json:"high,omitempty"`
+	Meaning         *CodeableConcept `bson:"meaning,omitempty" json:"meaning,omitempty"`
+	Age             *Range           `bson:"age,omitempty" json:"age,omitempty"`
+	Text            string           `bson:"text,omitempty" json:"text,omitempty"`
 }
 
 type ObservationRelatedComponent struct {
-	Type   string     `bson:"type,omitempty" json:"type,omitempty"`
-	Target *Reference `bson:"target,omitempty" json:"target,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string     `bson:"type,omitempty" json:"type,omitempty"`
+	Target          *Reference `bson:"target,omitempty" json:"target,omitempty"`
 }
 
 type ObservationComponentComponent struct {
+	BackboneElement      `bson:",inline"`
 	Code                 *CodeableConcept                     `bson:"code,omitempty" json:"code,omitempty"`
 	ValueQuantity        *Quantity                            `bson:"valueQuantity,omitempty" json:"valueQuantity,omitempty"`
 	ValueCodeableConcept *CodeableConcept                     `bson:"valueCodeableConcept,omitempty" json:"valueCodeableConcept,omitempty"`

--- a/models/operationdefinition.go
+++ b/models/operationdefinition.go
@@ -98,23 +98,26 @@ func (x *OperationDefinition) checkResourceType() error {
 }
 
 type OperationDefinitionContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type OperationDefinitionParameterComponent struct {
-	Name          string                                        `bson:"name,omitempty" json:"name,omitempty"`
-	Use           string                                        `bson:"use,omitempty" json:"use,omitempty"`
-	Min           *int32                                        `bson:"min,omitempty" json:"min,omitempty"`
-	Max           string                                        `bson:"max,omitempty" json:"max,omitempty"`
-	Documentation string                                        `bson:"documentation,omitempty" json:"documentation,omitempty"`
-	Type          string                                        `bson:"type,omitempty" json:"type,omitempty"`
-	Profile       *Reference                                    `bson:"profile,omitempty" json:"profile,omitempty"`
-	Binding       *OperationDefinitionParameterBindingComponent `bson:"binding,omitempty" json:"binding,omitempty"`
-	Part          []OperationDefinitionParameterComponent       `bson:"part,omitempty" json:"part,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string                                        `bson:"name,omitempty" json:"name,omitempty"`
+	Use             string                                        `bson:"use,omitempty" json:"use,omitempty"`
+	Min             *int32                                        `bson:"min,omitempty" json:"min,omitempty"`
+	Max             string                                        `bson:"max,omitempty" json:"max,omitempty"`
+	Documentation   string                                        `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Type            string                                        `bson:"type,omitempty" json:"type,omitempty"`
+	Profile         *Reference                                    `bson:"profile,omitempty" json:"profile,omitempty"`
+	Binding         *OperationDefinitionParameterBindingComponent `bson:"binding,omitempty" json:"binding,omitempty"`
+	Part            []OperationDefinitionParameterComponent       `bson:"part,omitempty" json:"part,omitempty"`
 }
 
 type OperationDefinitionParameterBindingComponent struct {
+	BackboneElement   `bson:",inline"`
 	Strength          string     `bson:"strength,omitempty" json:"strength,omitempty"`
 	ValueSetUri       string     `bson:"valueSetUri,omitempty" json:"valueSetUri,omitempty"`
 	ValueSetReference *Reference `bson:"valueSetReference,omitempty" json:"valueSetReference,omitempty"`

--- a/models/operationoutcome.go
+++ b/models/operationoutcome.go
@@ -80,11 +80,12 @@ func (x *OperationOutcome) checkResourceType() error {
 }
 
 type OperationOutcomeIssueComponent struct {
-	Severity    string           `bson:"severity,omitempty" json:"severity,omitempty"`
-	Code        string           `bson:"code,omitempty" json:"code,omitempty"`
-	Details     *CodeableConcept `bson:"details,omitempty" json:"details,omitempty"`
-	Diagnostics string           `bson:"diagnostics,omitempty" json:"diagnostics,omitempty"`
-	Location    []string         `bson:"location,omitempty" json:"location,omitempty"`
+	BackboneElement `bson:",inline"`
+	Severity        string           `bson:"severity,omitempty" json:"severity,omitempty"`
+	Code            string           `bson:"code,omitempty" json:"code,omitempty"`
+	Details         *CodeableConcept `bson:"details,omitempty" json:"details,omitempty"`
+	Diagnostics     string           `bson:"diagnostics,omitempty" json:"diagnostics,omitempty"`
+	Location        []string         `bson:"location,omitempty" json:"location,omitempty"`
 }
 
 type OperationOutcomePlus struct {

--- a/models/order.go
+++ b/models/order.go
@@ -88,8 +88,9 @@ func (x *Order) checkResourceType() error {
 }
 
 type OrderWhenComponent struct {
-	Code     *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Schedule *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Schedule        *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
 }
 
 type OrderPlus struct {

--- a/models/organization.go
+++ b/models/organization.go
@@ -87,10 +87,11 @@ func (x *Organization) checkResourceType() error {
 }
 
 type OrganizationContactComponent struct {
-	Purpose *CodeableConcept `bson:"purpose,omitempty" json:"purpose,omitempty"`
-	Name    *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
-	Address *Address         `bson:"address,omitempty" json:"address,omitempty"`
+	BackboneElement `bson:",inline"`
+	Purpose         *CodeableConcept `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Name            *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address         *Address         `bson:"address,omitempty" json:"address,omitempty"`
 }
 
 type OrganizationPlus struct {

--- a/models/parameters.go
+++ b/models/parameters.go
@@ -75,6 +75,7 @@ func (x *Parameters) checkResourceType() error {
 }
 
 type ParametersParameterComponent struct {
+	BackboneElement      `bson:",inline"`
 	Name                 string                         `bson:"name,omitempty" json:"name,omitempty"`
 	ValueAddress         *Address                       `bson:"valueAddress,omitempty" json:"valueAddress,omitempty"`
 	ValueAnnotation      *Annotation                    `bson:"valueAnnotation,omitempty" json:"valueAnnotation,omitempty"`

--- a/models/patient.go
+++ b/models/patient.go
@@ -98,29 +98,33 @@ func (x *Patient) checkResourceType() error {
 }
 
 type PatientContactComponent struct {
-	Relationship []CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
-	Name         *HumanName        `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom      []ContactPoint    `bson:"telecom,omitempty" json:"telecom,omitempty"`
-	Address      *Address          `bson:"address,omitempty" json:"address,omitempty"`
-	Gender       string            `bson:"gender,omitempty" json:"gender,omitempty"`
-	Organization *Reference        `bson:"organization,omitempty" json:"organization,omitempty"`
-	Period       *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	BackboneElement `bson:",inline"`
+	Relationship    []CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Name            *HumanName        `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint    `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address         *Address          `bson:"address,omitempty" json:"address,omitempty"`
+	Gender          string            `bson:"gender,omitempty" json:"gender,omitempty"`
+	Organization    *Reference        `bson:"organization,omitempty" json:"organization,omitempty"`
+	Period          *Period           `bson:"period,omitempty" json:"period,omitempty"`
 }
 
 type PatientAnimalComponent struct {
-	Species      *CodeableConcept `bson:"species,omitempty" json:"species,omitempty"`
-	Breed        *CodeableConcept `bson:"breed,omitempty" json:"breed,omitempty"`
-	GenderStatus *CodeableConcept `bson:"genderStatus,omitempty" json:"genderStatus,omitempty"`
+	BackboneElement `bson:",inline"`
+	Species         *CodeableConcept `bson:"species,omitempty" json:"species,omitempty"`
+	Breed           *CodeableConcept `bson:"breed,omitempty" json:"breed,omitempty"`
+	GenderStatus    *CodeableConcept `bson:"genderStatus,omitempty" json:"genderStatus,omitempty"`
 }
 
 type PatientCommunicationComponent struct {
-	Language  *CodeableConcept `bson:"language,omitempty" json:"language,omitempty"`
-	Preferred *bool            `bson:"preferred,omitempty" json:"preferred,omitempty"`
+	BackboneElement `bson:",inline"`
+	Language        *CodeableConcept `bson:"language,omitempty" json:"language,omitempty"`
+	Preferred       *bool            `bson:"preferred,omitempty" json:"preferred,omitempty"`
 }
 
 type PatientLinkComponent struct {
-	Other *Reference `bson:"other,omitempty" json:"other,omitempty"`
-	Type  string     `bson:"type,omitempty" json:"type,omitempty"`
+	BackboneElement `bson:",inline"`
+	Other           *Reference `bson:"other,omitempty" json:"other,omitempty"`
+	Type            string     `bson:"type,omitempty" json:"type,omitempty"`
 }
 
 type PatientPlus struct {

--- a/models/paymentreconciliation.go
+++ b/models/paymentreconciliation.go
@@ -94,18 +94,20 @@ func (x *PaymentReconciliation) checkResourceType() error {
 }
 
 type PaymentReconciliationDetailsComponent struct {
-	Type      *Coding       `bson:"type,omitempty" json:"type,omitempty"`
-	Request   *Reference    `bson:"request,omitempty" json:"request,omitempty"`
-	Responce  *Reference    `bson:"responce,omitempty" json:"responce,omitempty"`
-	Submitter *Reference    `bson:"submitter,omitempty" json:"submitter,omitempty"`
-	Payee     *Reference    `bson:"payee,omitempty" json:"payee,omitempty"`
-	Date      *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
-	Amount    *Quantity     `bson:"amount,omitempty" json:"amount,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding       `bson:"type,omitempty" json:"type,omitempty"`
+	Request         *Reference    `bson:"request,omitempty" json:"request,omitempty"`
+	Responce        *Reference    `bson:"responce,omitempty" json:"responce,omitempty"`
+	Submitter       *Reference    `bson:"submitter,omitempty" json:"submitter,omitempty"`
+	Payee           *Reference    `bson:"payee,omitempty" json:"payee,omitempty"`
+	Date            *FHIRDateTime `bson:"date,omitempty" json:"date,omitempty"`
+	Amount          *Quantity     `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 
 type PaymentReconciliationNotesComponent struct {
-	Type *Coding `bson:"type,omitempty" json:"type,omitempty"`
-	Text string  `bson:"text,omitempty" json:"text,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding `bson:"type,omitempty" json:"type,omitempty"`
+	Text            string  `bson:"text,omitempty" json:"text,omitempty"`
 }
 
 type PaymentReconciliationPlus struct {

--- a/models/person.go
+++ b/models/person.go
@@ -89,8 +89,9 @@ func (x *Person) checkResourceType() error {
 }
 
 type PersonLinkComponent struct {
-	Target    *Reference `bson:"target,omitempty" json:"target,omitempty"`
-	Assurance string     `bson:"assurance,omitempty" json:"assurance,omitempty"`
+	BackboneElement `bson:",inline"`
+	Target          *Reference `bson:"target,omitempty" json:"target,omitempty"`
+	Assurance       string     `bson:"assurance,omitempty" json:"assurance,omitempty"`
 }
 
 type PersonPlus struct {

--- a/models/practitioner.go
+++ b/models/practitioner.go
@@ -90,6 +90,7 @@ func (x *Practitioner) checkResourceType() error {
 }
 
 type PractitionerPractitionerRoleComponent struct {
+	BackboneElement      `bson:",inline"`
 	ManagingOrganization *Reference        `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
 	Role                 *CodeableConcept  `bson:"role,omitempty" json:"role,omitempty"`
 	Specialty            []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
@@ -99,10 +100,11 @@ type PractitionerPractitionerRoleComponent struct {
 }
 
 type PractitionerQualificationComponent struct {
-	Identifier []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Code       *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Period     *Period          `bson:"period,omitempty" json:"period,omitempty"`
-	Issuer     *Reference       `bson:"issuer,omitempty" json:"issuer,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Period          *Period          `bson:"period,omitempty" json:"period,omitempty"`
+	Issuer          *Reference       `bson:"issuer,omitempty" json:"issuer,omitempty"`
 }
 
 type PractitionerPlus struct {

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -102,13 +102,15 @@ func (x *Procedure) checkResourceType() error {
 }
 
 type ProcedurePerformerComponent struct {
-	Actor *Reference       `bson:"actor,omitempty" json:"actor,omitempty"`
-	Role  *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	BackboneElement `bson:",inline"`
+	Actor           *Reference       `bson:"actor,omitempty" json:"actor,omitempty"`
+	Role            *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
 }
 
 type ProcedureFocalDeviceComponent struct {
-	Action      *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
-	Manipulated *Reference       `bson:"manipulated,omitempty" json:"manipulated,omitempty"`
+	BackboneElement `bson:",inline"`
+	Action          *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
+	Manipulated     *Reference       `bson:"manipulated,omitempty" json:"manipulated,omitempty"`
 }
 
 type ProcedurePlus struct {

--- a/models/processrequest.go
+++ b/models/processrequest.go
@@ -95,7 +95,8 @@ func (x *ProcessRequest) checkResourceType() error {
 }
 
 type ProcessRequestItemsComponent struct {
-	SequenceLinkId *int32 `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
+	BackboneElement `bson:",inline"`
+	SequenceLinkId  *int32 `bson:"sequenceLinkId,omitempty" json:"sequenceLinkId,omitempty"`
 }
 
 type ProcessRequestPlus struct {

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -92,8 +92,9 @@ func (x *ProcessResponse) checkResourceType() error {
 }
 
 type ProcessResponseNotesComponent struct {
-	Type *Coding `bson:"type,omitempty" json:"type,omitempty"`
-	Text string  `bson:"text,omitempty" json:"text,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *Coding `bson:"type,omitempty" json:"type,omitempty"`
+	Text            string  `bson:"text,omitempty" json:"text,omitempty"`
 }
 
 type ProcessResponsePlus struct {

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -89,23 +89,26 @@ func (x *Provenance) checkResourceType() error {
 }
 
 type ProvenanceAgentComponent struct {
-	Role         *Coding                                `bson:"role,omitempty" json:"role,omitempty"`
-	Actor        *Reference                             `bson:"actor,omitempty" json:"actor,omitempty"`
-	UserId       *Identifier                            `bson:"userId,omitempty" json:"userId,omitempty"`
-	RelatedAgent []ProvenanceAgentRelatedAgentComponent `bson:"relatedAgent,omitempty" json:"relatedAgent,omitempty"`
+	BackboneElement `bson:",inline"`
+	Role            *Coding                                `bson:"role,omitempty" json:"role,omitempty"`
+	Actor           *Reference                             `bson:"actor,omitempty" json:"actor,omitempty"`
+	UserId          *Identifier                            `bson:"userId,omitempty" json:"userId,omitempty"`
+	RelatedAgent    []ProvenanceAgentRelatedAgentComponent `bson:"relatedAgent,omitempty" json:"relatedAgent,omitempty"`
 }
 
 type ProvenanceAgentRelatedAgentComponent struct {
-	Type   *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
-	Target string           `bson:"target,omitempty" json:"target,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Target          string           `bson:"target,omitempty" json:"target,omitempty"`
 }
 
 type ProvenanceEntityComponent struct {
-	Role      string                    `bson:"role,omitempty" json:"role,omitempty"`
-	Type      *Coding                   `bson:"type,omitempty" json:"type,omitempty"`
-	Reference string                    `bson:"reference,omitempty" json:"reference,omitempty"`
-	Display   string                    `bson:"display,omitempty" json:"display,omitempty"`
-	Agent     *ProvenanceAgentComponent `bson:"agent,omitempty" json:"agent,omitempty"`
+	BackboneElement `bson:",inline"`
+	Role            string                    `bson:"role,omitempty" json:"role,omitempty"`
+	Type            *Coding                   `bson:"type,omitempty" json:"type,omitempty"`
+	Reference       string                    `bson:"reference,omitempty" json:"reference,omitempty"`
+	Display         string                    `bson:"display,omitempty" json:"display,omitempty"`
+	Agent           *ProvenanceAgentComponent `bson:"agent,omitempty" json:"agent,omitempty"`
 }
 
 type ProvenancePlus struct {

--- a/models/questionnaire.go
+++ b/models/questionnaire.go
@@ -87,26 +87,28 @@ func (x *Questionnaire) checkResourceType() error {
 }
 
 type QuestionnaireGroupComponent struct {
-	LinkId   string                           `bson:"linkId,omitempty" json:"linkId,omitempty"`
-	Title    string                           `bson:"title,omitempty" json:"title,omitempty"`
-	Concept  []Coding                         `bson:"concept,omitempty" json:"concept,omitempty"`
-	Text     string                           `bson:"text,omitempty" json:"text,omitempty"`
-	Required *bool                            `bson:"required,omitempty" json:"required,omitempty"`
-	Repeats  *bool                            `bson:"repeats,omitempty" json:"repeats,omitempty"`
-	Group    []QuestionnaireGroupComponent    `bson:"group,omitempty" json:"group,omitempty"`
-	Question []QuestionnaireQuestionComponent `bson:"question,omitempty" json:"question,omitempty"`
+	BackboneElement `bson:",inline"`
+	LinkId          string                           `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Title           string                           `bson:"title,omitempty" json:"title,omitempty"`
+	Concept         []Coding                         `bson:"concept,omitempty" json:"concept,omitempty"`
+	Text            string                           `bson:"text,omitempty" json:"text,omitempty"`
+	Required        *bool                            `bson:"required,omitempty" json:"required,omitempty"`
+	Repeats         *bool                            `bson:"repeats,omitempty" json:"repeats,omitempty"`
+	Group           []QuestionnaireGroupComponent    `bson:"group,omitempty" json:"group,omitempty"`
+	Question        []QuestionnaireQuestionComponent `bson:"question,omitempty" json:"question,omitempty"`
 }
 
 type QuestionnaireQuestionComponent struct {
-	LinkId   string                        `bson:"linkId,omitempty" json:"linkId,omitempty"`
-	Concept  []Coding                      `bson:"concept,omitempty" json:"concept,omitempty"`
-	Text     string                        `bson:"text,omitempty" json:"text,omitempty"`
-	Type     string                        `bson:"type,omitempty" json:"type,omitempty"`
-	Required *bool                         `bson:"required,omitempty" json:"required,omitempty"`
-	Repeats  *bool                         `bson:"repeats,omitempty" json:"repeats,omitempty"`
-	Options  *Reference                    `bson:"options,omitempty" json:"options,omitempty"`
-	Option   []Coding                      `bson:"option,omitempty" json:"option,omitempty"`
-	Group    []QuestionnaireGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
+	BackboneElement `bson:",inline"`
+	LinkId          string                        `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Concept         []Coding                      `bson:"concept,omitempty" json:"concept,omitempty"`
+	Text            string                        `bson:"text,omitempty" json:"text,omitempty"`
+	Type            string                        `bson:"type,omitempty" json:"type,omitempty"`
+	Required        *bool                         `bson:"required,omitempty" json:"required,omitempty"`
+	Repeats         *bool                         `bson:"repeats,omitempty" json:"repeats,omitempty"`
+	Options         *Reference                    `bson:"options,omitempty" json:"options,omitempty"`
+	Option          []Coding                      `bson:"option,omitempty" json:"option,omitempty"`
+	Group           []QuestionnaireGroupComponent `bson:"group,omitempty" json:"group,omitempty"`
 }
 
 type QuestionnairePlus struct {

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -88,21 +88,24 @@ func (x *QuestionnaireResponse) checkResourceType() error {
 }
 
 type QuestionnaireResponseGroupComponent struct {
-	LinkId   string                                   `bson:"linkId,omitempty" json:"linkId,omitempty"`
-	Title    string                                   `bson:"title,omitempty" json:"title,omitempty"`
-	Text     string                                   `bson:"text,omitempty" json:"text,omitempty"`
-	Subject  *Reference                               `bson:"subject,omitempty" json:"subject,omitempty"`
-	Group    []QuestionnaireResponseGroupComponent    `bson:"group,omitempty" json:"group,omitempty"`
-	Question []QuestionnaireResponseQuestionComponent `bson:"question,omitempty" json:"question,omitempty"`
+	BackboneElement `bson:",inline"`
+	LinkId          string                                   `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Title           string                                   `bson:"title,omitempty" json:"title,omitempty"`
+	Text            string                                   `bson:"text,omitempty" json:"text,omitempty"`
+	Subject         *Reference                               `bson:"subject,omitempty" json:"subject,omitempty"`
+	Group           []QuestionnaireResponseGroupComponent    `bson:"group,omitempty" json:"group,omitempty"`
+	Question        []QuestionnaireResponseQuestionComponent `bson:"question,omitempty" json:"question,omitempty"`
 }
 
 type QuestionnaireResponseQuestionComponent struct {
-	LinkId string                                         `bson:"linkId,omitempty" json:"linkId,omitempty"`
-	Text   string                                         `bson:"text,omitempty" json:"text,omitempty"`
-	Answer []QuestionnaireResponseQuestionAnswerComponent `bson:"answer,omitempty" json:"answer,omitempty"`
+	BackboneElement `bson:",inline"`
+	LinkId          string                                         `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Text            string                                         `bson:"text,omitempty" json:"text,omitempty"`
+	Answer          []QuestionnaireResponseQuestionAnswerComponent `bson:"answer,omitempty" json:"answer,omitempty"`
 }
 
 type QuestionnaireResponseQuestionAnswerComponent struct {
+	BackboneElement `bson:",inline"`
 	ValueBoolean    *bool                                 `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
 	ValueDecimal    *float64                              `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
 	ValueInteger    *int32                                `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`

--- a/models/reference_ext.go
+++ b/models/reference_ext.go
@@ -5,6 +5,16 @@ import (
 	"strings"
 )
 
+func (r *Reference) MarshalJSON() ([]byte, error) {
+	m := map[string]string{
+		"reference": r.Reference,
+	}
+	if r.Display != "" {
+		m["display"] = r.Display
+	}
+	return json.Marshal(m)
+}
+
 type reference Reference
 
 func (r *Reference) UnmarshalJSON(data []byte) (err error) {

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -89,6 +89,7 @@ func (x *RiskAssessment) checkResourceType() error {
 }
 
 type RiskAssessmentPredictionComponent struct {
+	BackboneElement            `bson:",inline"`
 	Outcome                    *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
 	ProbabilityDecimal         *float64         `bson:"probabilityDecimal,omitempty" json:"probabilityDecimal,omitempty"`
 	ProbabilityRange           *Range           `bson:"probabilityRange,omitempty" json:"probabilityRange,omitempty"`

--- a/models/searchparameter.go
+++ b/models/searchparameter.go
@@ -94,8 +94,9 @@ func (x *SearchParameter) checkResourceType() error {
 }
 
 type SearchParameterContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type SearchParameterPlus struct {

--- a/models/specimen.go
+++ b/models/specimen.go
@@ -89,6 +89,7 @@ func (x *Specimen) checkResourceType() error {
 }
 
 type SpecimenCollectionComponent struct {
+	BackboneElement   `bson:",inline"`
 	Collector         *Reference       `bson:"collector,omitempty" json:"collector,omitempty"`
 	Comment           []string         `bson:"comment,omitempty" json:"comment,omitempty"`
 	CollectedDateTime *FHIRDateTime    `bson:"collectedDateTime,omitempty" json:"collectedDateTime,omitempty"`
@@ -99,12 +100,14 @@ type SpecimenCollectionComponent struct {
 }
 
 type SpecimenTreatmentComponent struct {
-	Description string           `bson:"description,omitempty" json:"description,omitempty"`
-	Procedure   *CodeableConcept `bson:"procedure,omitempty" json:"procedure,omitempty"`
-	Additive    []Reference      `bson:"additive,omitempty" json:"additive,omitempty"`
+	BackboneElement `bson:",inline"`
+	Description     string           `bson:"description,omitempty" json:"description,omitempty"`
+	Procedure       *CodeableConcept `bson:"procedure,omitempty" json:"procedure,omitempty"`
+	Additive        []Reference      `bson:"additive,omitempty" json:"additive,omitempty"`
 }
 
 type SpecimenContainerComponent struct {
+	BackboneElement         `bson:",inline"`
 	Identifier              []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
 	Description             string           `bson:"description,omitempty" json:"description,omitempty"`
 	Type                    *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`

--- a/models/structuredefinition.go
+++ b/models/structuredefinition.go
@@ -104,23 +104,27 @@ func (x *StructureDefinition) checkResourceType() error {
 }
 
 type StructureDefinitionContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type StructureDefinitionMappingComponent struct {
-	Identity string `bson:"identity,omitempty" json:"identity,omitempty"`
-	Uri      string `bson:"uri,omitempty" json:"uri,omitempty"`
-	Name     string `bson:"name,omitempty" json:"name,omitempty"`
-	Comments string `bson:"comments,omitempty" json:"comments,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identity        string `bson:"identity,omitempty" json:"identity,omitempty"`
+	Uri             string `bson:"uri,omitempty" json:"uri,omitempty"`
+	Name            string `bson:"name,omitempty" json:"name,omitempty"`
+	Comments        string `bson:"comments,omitempty" json:"comments,omitempty"`
 }
 
 type StructureDefinitionSnapshotComponent struct {
-	Element []ElementDefinition `bson:"element,omitempty" json:"element,omitempty"`
+	BackboneElement `bson:",inline"`
+	Element         []ElementDefinition `bson:"element,omitempty" json:"element,omitempty"`
 }
 
 type StructureDefinitionDifferentialComponent struct {
-	Element []ElementDefinition `bson:"element,omitempty" json:"element,omitempty"`
+	BackboneElement `bson:",inline"`
+	Element         []ElementDefinition `bson:"element,omitempty" json:"element,omitempty"`
 }
 
 type StructureDefinitionPlus struct {

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -87,10 +87,11 @@ func (x *Subscription) checkResourceType() error {
 }
 
 type SubscriptionChannelComponent struct {
-	Type     string `bson:"type,omitempty" json:"type,omitempty"`
-	Endpoint string `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
-	Payload  string `bson:"payload,omitempty" json:"payload,omitempty"`
-	Header   string `bson:"header,omitempty" json:"header,omitempty"`
+	BackboneElement `bson:",inline"`
+	Type            string `bson:"type,omitempty" json:"type,omitempty"`
+	Endpoint        string `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	Payload         string `bson:"payload,omitempty" json:"payload,omitempty"`
+	Header          string `bson:"header,omitempty" json:"header,omitempty"`
 }
 
 type SubscriptionPlus struct {

--- a/models/substance.go
+++ b/models/substance.go
@@ -85,14 +85,16 @@ func (x *Substance) checkResourceType() error {
 }
 
 type SubstanceInstanceComponent struct {
-	Identifier *Identifier   `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Expiry     *FHIRDateTime `bson:"expiry,omitempty" json:"expiry,omitempty"`
-	Quantity   *Quantity     `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      *Identifier   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Expiry          *FHIRDateTime `bson:"expiry,omitempty" json:"expiry,omitempty"`
+	Quantity        *Quantity     `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 
 type SubstanceIngredientComponent struct {
-	Quantity  *Ratio     `bson:"quantity,omitempty" json:"quantity,omitempty"`
-	Substance *Reference `bson:"substance,omitempty" json:"substance,omitempty"`
+	BackboneElement `bson:",inline"`
+	Quantity        *Ratio     `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Substance       *Reference `bson:"substance,omitempty" json:"substance,omitempty"`
 }
 
 type SubstancePlus struct {

--- a/models/supplyrequest.go
+++ b/models/supplyrequest.go
@@ -90,8 +90,9 @@ func (x *SupplyRequest) checkResourceType() error {
 }
 
 type SupplyRequestWhenComponent struct {
-	Code     *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
-	Schedule *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Schedule        *Timing          `bson:"schedule,omitempty" json:"schedule,omitempty"`
 }
 
 type SupplyRequestPlus struct {

--- a/models/testscript.go
+++ b/models/testscript.go
@@ -100,53 +100,62 @@ func (x *TestScript) checkResourceType() error {
 }
 
 type TestScriptContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type TestScriptMetadataComponent struct {
-	Link       []TestScriptMetadataLinkComponent       `bson:"link,omitempty" json:"link,omitempty"`
-	Capability []TestScriptMetadataCapabilityComponent `bson:"capability,omitempty" json:"capability,omitempty"`
+	BackboneElement `bson:",inline"`
+	Link            []TestScriptMetadataLinkComponent       `bson:"link,omitempty" json:"link,omitempty"`
+	Capability      []TestScriptMetadataCapabilityComponent `bson:"capability,omitempty" json:"capability,omitempty"`
 }
 
 type TestScriptMetadataLinkComponent struct {
-	Url         string `bson:"url,omitempty" json:"url,omitempty"`
-	Description string `bson:"description,omitempty" json:"description,omitempty"`
+	BackboneElement `bson:",inline"`
+	Url             string `bson:"url,omitempty" json:"url,omitempty"`
+	Description     string `bson:"description,omitempty" json:"description,omitempty"`
 }
 
 type TestScriptMetadataCapabilityComponent struct {
-	Required    *bool      `bson:"required,omitempty" json:"required,omitempty"`
-	Validated   *bool      `bson:"validated,omitempty" json:"validated,omitempty"`
-	Description string     `bson:"description,omitempty" json:"description,omitempty"`
-	Destination *int32     `bson:"destination,omitempty" json:"destination,omitempty"`
-	Link        []string   `bson:"link,omitempty" json:"link,omitempty"`
-	Conformance *Reference `bson:"conformance,omitempty" json:"conformance,omitempty"`
+	BackboneElement `bson:",inline"`
+	Required        *bool      `bson:"required,omitempty" json:"required,omitempty"`
+	Validated       *bool      `bson:"validated,omitempty" json:"validated,omitempty"`
+	Description     string     `bson:"description,omitempty" json:"description,omitempty"`
+	Destination     *int32     `bson:"destination,omitempty" json:"destination,omitempty"`
+	Link            []string   `bson:"link,omitempty" json:"link,omitempty"`
+	Conformance     *Reference `bson:"conformance,omitempty" json:"conformance,omitempty"`
 }
 
 type TestScriptFixtureComponent struct {
-	Autocreate *bool      `bson:"autocreate,omitempty" json:"autocreate,omitempty"`
-	Autodelete *bool      `bson:"autodelete,omitempty" json:"autodelete,omitempty"`
-	Resource   *Reference `bson:"resource,omitempty" json:"resource,omitempty"`
+	BackboneElement `bson:",inline"`
+	Autocreate      *bool      `bson:"autocreate,omitempty" json:"autocreate,omitempty"`
+	Autodelete      *bool      `bson:"autodelete,omitempty" json:"autodelete,omitempty"`
+	Resource        *Reference `bson:"resource,omitempty" json:"resource,omitempty"`
 }
 
 type TestScriptVariableComponent struct {
-	Name        string `bson:"name,omitempty" json:"name,omitempty"`
-	HeaderField string `bson:"headerField,omitempty" json:"headerField,omitempty"`
-	Path        string `bson:"path,omitempty" json:"path,omitempty"`
-	SourceId    string `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string `bson:"name,omitempty" json:"name,omitempty"`
+	HeaderField     string `bson:"headerField,omitempty" json:"headerField,omitempty"`
+	Path            string `bson:"path,omitempty" json:"path,omitempty"`
+	SourceId        string `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
 }
 
 type TestScriptSetupComponent struct {
-	Metadata *TestScriptMetadataComponent     `bson:"metadata,omitempty" json:"metadata,omitempty"`
-	Action   []TestScriptSetupActionComponent `bson:"action,omitempty" json:"action,omitempty"`
+	BackboneElement `bson:",inline"`
+	Metadata        *TestScriptMetadataComponent     `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Action          []TestScriptSetupActionComponent `bson:"action,omitempty" json:"action,omitempty"`
 }
 
 type TestScriptSetupActionComponent struct {
-	Operation *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
-	Assert    *TestScriptSetupActionAssertComponent    `bson:"assert,omitempty" json:"assert,omitempty"`
+	BackboneElement `bson:",inline"`
+	Operation       *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert          *TestScriptSetupActionAssertComponent    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 
 type TestScriptSetupActionOperationComponent struct {
+	BackboneElement  `bson:",inline"`
 	Type             *Coding                                                `bson:"type,omitempty" json:"type,omitempty"`
 	Resource         string                                                 `bson:"resource,omitempty" json:"resource,omitempty"`
 	Label            string                                                 `bson:"label,omitempty" json:"label,omitempty"`
@@ -164,11 +173,13 @@ type TestScriptSetupActionOperationComponent struct {
 }
 
 type TestScriptSetupActionOperationRequestHeaderComponent struct {
-	Field string `bson:"field,omitempty" json:"field,omitempty"`
-	Value string `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Field           string `bson:"field,omitempty" json:"field,omitempty"`
+	Value           string `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type TestScriptSetupActionAssertComponent struct {
+	BackboneElement     `bson:",inline"`
 	Label               string `bson:"label,omitempty" json:"label,omitempty"`
 	Description         string `bson:"description,omitempty" json:"description,omitempty"`
 	Direction           string `bson:"direction,omitempty" json:"direction,omitempty"`
@@ -190,23 +201,27 @@ type TestScriptSetupActionAssertComponent struct {
 }
 
 type TestScriptTestComponent struct {
-	Name        string                          `bson:"name,omitempty" json:"name,omitempty"`
-	Description string                          `bson:"description,omitempty" json:"description,omitempty"`
-	Metadata    *TestScriptMetadataComponent    `bson:"metadata,omitempty" json:"metadata,omitempty"`
-	Action      []TestScriptTestActionComponent `bson:"action,omitempty" json:"action,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string                          `bson:"name,omitempty" json:"name,omitempty"`
+	Description     string                          `bson:"description,omitempty" json:"description,omitempty"`
+	Metadata        *TestScriptMetadataComponent    `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Action          []TestScriptTestActionComponent `bson:"action,omitempty" json:"action,omitempty"`
 }
 
 type TestScriptTestActionComponent struct {
-	Operation *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
-	Assert    *TestScriptSetupActionAssertComponent    `bson:"assert,omitempty" json:"assert,omitempty"`
+	BackboneElement `bson:",inline"`
+	Operation       *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert          *TestScriptSetupActionAssertComponent    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 
 type TestScriptTeardownComponent struct {
-	Action []TestScriptTeardownActionComponent `bson:"action,omitempty" json:"action,omitempty"`
+	BackboneElement `bson:",inline"`
+	Action          []TestScriptTeardownActionComponent `bson:"action,omitempty" json:"action,omitempty"`
 }
 
 type TestScriptTeardownActionComponent struct {
-	Operation *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Operation       *TestScriptSetupActionOperationComponent `bson:"operation,omitempty" json:"operation,omitempty"`
 }
 
 type TestScriptPlus struct {

--- a/models/timing.go
+++ b/models/timing.go
@@ -33,17 +33,18 @@ type Timing struct {
 }
 
 type TimingRepeatComponent struct {
-	BoundsDuration *Quantity `bson:"boundsDuration,omitempty" json:"boundsDuration,omitempty"`
-	BoundsRange    *Range    `bson:"boundsRange,omitempty" json:"boundsRange,omitempty"`
-	BoundsPeriod   *Period   `bson:"boundsPeriod,omitempty" json:"boundsPeriod,omitempty"`
-	Count          *int32    `bson:"count,omitempty" json:"count,omitempty"`
-	Duration       *float64  `bson:"duration,omitempty" json:"duration,omitempty"`
-	DurationMax    *float64  `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
-	DurationUnits  string    `bson:"durationUnits,omitempty" json:"durationUnits,omitempty"`
-	Frequency      *int32    `bson:"frequency,omitempty" json:"frequency,omitempty"`
-	FrequencyMax   *int32    `bson:"frequencyMax,omitempty" json:"frequencyMax,omitempty"`
-	Period         *float64  `bson:"period,omitempty" json:"period,omitempty"`
-	PeriodMax      *float64  `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
-	PeriodUnits    string    `bson:"periodUnits,omitempty" json:"periodUnits,omitempty"`
-	When           string    `bson:"when,omitempty" json:"when,omitempty"`
+	BackboneElement `bson:",inline"`
+	BoundsDuration  *Quantity `bson:"boundsDuration,omitempty" json:"boundsDuration,omitempty"`
+	BoundsRange     *Range    `bson:"boundsRange,omitempty" json:"boundsRange,omitempty"`
+	BoundsPeriod    *Period   `bson:"boundsPeriod,omitempty" json:"boundsPeriod,omitempty"`
+	Count           *int32    `bson:"count,omitempty" json:"count,omitempty"`
+	Duration        *float64  `bson:"duration,omitempty" json:"duration,omitempty"`
+	DurationMax     *float64  `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
+	DurationUnits   string    `bson:"durationUnits,omitempty" json:"durationUnits,omitempty"`
+	Frequency       *int32    `bson:"frequency,omitempty" json:"frequency,omitempty"`
+	FrequencyMax    *int32    `bson:"frequencyMax,omitempty" json:"frequencyMax,omitempty"`
+	Period          *float64  `bson:"period,omitempty" json:"period,omitempty"`
+	PeriodMax       *float64  `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
+	PeriodUnits     string    `bson:"periodUnits,omitempty" json:"periodUnits,omitempty"`
+	When            string    `bson:"when,omitempty" json:"when,omitempty"`
 }

--- a/models/valueset.go
+++ b/models/valueset.go
@@ -98,83 +98,94 @@ func (x *ValueSet) checkResourceType() error {
 }
 
 type ValueSetContactComponent struct {
-	Name    string         `bson:"name,omitempty" json:"name,omitempty"`
-	Telecom []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string         `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom         []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }
 
 type ValueSetCodeSystemComponent struct {
-	System        string                               `bson:"system,omitempty" json:"system,omitempty"`
-	Version       string                               `bson:"version,omitempty" json:"version,omitempty"`
-	CaseSensitive *bool                                `bson:"caseSensitive,omitempty" json:"caseSensitive,omitempty"`
-	Concept       []ValueSetConceptDefinitionComponent `bson:"concept,omitempty" json:"concept,omitempty"`
+	BackboneElement `bson:",inline"`
+	System          string                               `bson:"system,omitempty" json:"system,omitempty"`
+	Version         string                               `bson:"version,omitempty" json:"version,omitempty"`
+	CaseSensitive   *bool                                `bson:"caseSensitive,omitempty" json:"caseSensitive,omitempty"`
+	Concept         []ValueSetConceptDefinitionComponent `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 
 type ValueSetConceptDefinitionComponent struct {
-	Code        string                                          `bson:"code,omitempty" json:"code,omitempty"`
-	Abstract    *bool                                           `bson:"abstract,omitempty" json:"abstract,omitempty"`
-	Display     string                                          `bson:"display,omitempty" json:"display,omitempty"`
-	Definition  string                                          `bson:"definition,omitempty" json:"definition,omitempty"`
-	Designation []ValueSetConceptDefinitionDesignationComponent `bson:"designation,omitempty" json:"designation,omitempty"`
-	Concept     []ValueSetConceptDefinitionComponent            `bson:"concept,omitempty" json:"concept,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string                                          `bson:"code,omitempty" json:"code,omitempty"`
+	Abstract        *bool                                           `bson:"abstract,omitempty" json:"abstract,omitempty"`
+	Display         string                                          `bson:"display,omitempty" json:"display,omitempty"`
+	Definition      string                                          `bson:"definition,omitempty" json:"definition,omitempty"`
+	Designation     []ValueSetConceptDefinitionDesignationComponent `bson:"designation,omitempty" json:"designation,omitempty"`
+	Concept         []ValueSetConceptDefinitionComponent            `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 
 type ValueSetConceptDefinitionDesignationComponent struct {
-	Language string  `bson:"language,omitempty" json:"language,omitempty"`
-	Use      *Coding `bson:"use,omitempty" json:"use,omitempty"`
-	Value    string  `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Language        string  `bson:"language,omitempty" json:"language,omitempty"`
+	Use             *Coding `bson:"use,omitempty" json:"use,omitempty"`
+	Value           string  `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ValueSetComposeComponent struct {
-	Import  []string                      `bson:"import,omitempty" json:"import,omitempty"`
-	Include []ValueSetConceptSetComponent `bson:"include,omitempty" json:"include,omitempty"`
-	Exclude []ValueSetConceptSetComponent `bson:"exclude,omitempty" json:"exclude,omitempty"`
+	BackboneElement `bson:",inline"`
+	Import          []string                      `bson:"import,omitempty" json:"import,omitempty"`
+	Include         []ValueSetConceptSetComponent `bson:"include,omitempty" json:"include,omitempty"`
+	Exclude         []ValueSetConceptSetComponent `bson:"exclude,omitempty" json:"exclude,omitempty"`
 }
 
 type ValueSetConceptSetComponent struct {
-	System  string                              `bson:"system,omitempty" json:"system,omitempty"`
-	Version string                              `bson:"version,omitempty" json:"version,omitempty"`
-	Concept []ValueSetConceptReferenceComponent `bson:"concept,omitempty" json:"concept,omitempty"`
-	Filter  []ValueSetConceptSetFilterComponent `bson:"filter,omitempty" json:"filter,omitempty"`
+	BackboneElement `bson:",inline"`
+	System          string                              `bson:"system,omitempty" json:"system,omitempty"`
+	Version         string                              `bson:"version,omitempty" json:"version,omitempty"`
+	Concept         []ValueSetConceptReferenceComponent `bson:"concept,omitempty" json:"concept,omitempty"`
+	Filter          []ValueSetConceptSetFilterComponent `bson:"filter,omitempty" json:"filter,omitempty"`
 }
 
 type ValueSetConceptReferenceComponent struct {
-	Code        string                                          `bson:"code,omitempty" json:"code,omitempty"`
-	Display     string                                          `bson:"display,omitempty" json:"display,omitempty"`
-	Designation []ValueSetConceptDefinitionDesignationComponent `bson:"designation,omitempty" json:"designation,omitempty"`
+	BackboneElement `bson:",inline"`
+	Code            string                                          `bson:"code,omitempty" json:"code,omitempty"`
+	Display         string                                          `bson:"display,omitempty" json:"display,omitempty"`
+	Designation     []ValueSetConceptDefinitionDesignationComponent `bson:"designation,omitempty" json:"designation,omitempty"`
 }
 
 type ValueSetConceptSetFilterComponent struct {
-	Property string `bson:"property,omitempty" json:"property,omitempty"`
-	Op       string `bson:"op,omitempty" json:"op,omitempty"`
-	Value    string `bson:"value,omitempty" json:"value,omitempty"`
+	BackboneElement `bson:",inline"`
+	Property        string `bson:"property,omitempty" json:"property,omitempty"`
+	Op              string `bson:"op,omitempty" json:"op,omitempty"`
+	Value           string `bson:"value,omitempty" json:"value,omitempty"`
 }
 
 type ValueSetExpansionComponent struct {
-	Identifier string                                `bson:"identifier,omitempty" json:"identifier,omitempty"`
-	Timestamp  *FHIRDateTime                         `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
-	Total      *int32                                `bson:"total,omitempty" json:"total,omitempty"`
-	Offset     *int32                                `bson:"offset,omitempty" json:"offset,omitempty"`
-	Parameter  []ValueSetExpansionParameterComponent `bson:"parameter,omitempty" json:"parameter,omitempty"`
-	Contains   []ValueSetExpansionContainsComponent  `bson:"contains,omitempty" json:"contains,omitempty"`
+	BackboneElement `bson:",inline"`
+	Identifier      string                                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Timestamp       *FHIRDateTime                         `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
+	Total           *int32                                `bson:"total,omitempty" json:"total,omitempty"`
+	Offset          *int32                                `bson:"offset,omitempty" json:"offset,omitempty"`
+	Parameter       []ValueSetExpansionParameterComponent `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Contains        []ValueSetExpansionContainsComponent  `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 
 type ValueSetExpansionParameterComponent struct {
-	Name         string   `bson:"name,omitempty" json:"name,omitempty"`
-	ValueString  string   `bson:"valueString,omitempty" json:"valueString,omitempty"`
-	ValueBoolean *bool    `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
-	ValueInteger *int32   `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
-	ValueDecimal *float64 `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
-	ValueUri     string   `bson:"valueUri,omitempty" json:"valueUri,omitempty"`
-	ValueCode    string   `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
+	BackboneElement `bson:",inline"`
+	Name            string   `bson:"name,omitempty" json:"name,omitempty"`
+	ValueString     string   `bson:"valueString,omitempty" json:"valueString,omitempty"`
+	ValueBoolean    *bool    `bson:"valueBoolean,omitempty" json:"valueBoolean,omitempty"`
+	ValueInteger    *int32   `bson:"valueInteger,omitempty" json:"valueInteger,omitempty"`
+	ValueDecimal    *float64 `bson:"valueDecimal,omitempty" json:"valueDecimal,omitempty"`
+	ValueUri        string   `bson:"valueUri,omitempty" json:"valueUri,omitempty"`
+	ValueCode       string   `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 }
 
 type ValueSetExpansionContainsComponent struct {
-	System   string                               `bson:"system,omitempty" json:"system,omitempty"`
-	Abstract *bool                                `bson:"abstract,omitempty" json:"abstract,omitempty"`
-	Version  string                               `bson:"version,omitempty" json:"version,omitempty"`
-	Code     string                               `bson:"code,omitempty" json:"code,omitempty"`
-	Display  string                               `bson:"display,omitempty" json:"display,omitempty"`
-	Contains []ValueSetExpansionContainsComponent `bson:"contains,omitempty" json:"contains,omitempty"`
+	BackboneElement `bson:",inline"`
+	System          string                               `bson:"system,omitempty" json:"system,omitempty"`
+	Abstract        *bool                                `bson:"abstract,omitempty" json:"abstract,omitempty"`
+	Version         string                               `bson:"version,omitempty" json:"version,omitempty"`
+	Code            string                               `bson:"code,omitempty" json:"code,omitempty"`
+	Display         string                               `bson:"display,omitempty" json:"display,omitempty"`
+	Contains        []ValueSetExpansionContainsComponent `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 
 type ValueSetPlus struct {

--- a/models/visionprescription.go
+++ b/models/visionprescription.go
@@ -87,21 +87,22 @@ func (x *VisionPrescription) checkResourceType() error {
 }
 
 type VisionPrescriptionDispenseComponent struct {
-	Product   *Coding   `bson:"product,omitempty" json:"product,omitempty"`
-	Eye       string    `bson:"eye,omitempty" json:"eye,omitempty"`
-	Sphere    *float64  `bson:"sphere,omitempty" json:"sphere,omitempty"`
-	Cylinder  *float64  `bson:"cylinder,omitempty" json:"cylinder,omitempty"`
-	Axis      *int32    `bson:"axis,omitempty" json:"axis,omitempty"`
-	Prism     *float64  `bson:"prism,omitempty" json:"prism,omitempty"`
-	Base      string    `bson:"base,omitempty" json:"base,omitempty"`
-	Add       *float64  `bson:"add,omitempty" json:"add,omitempty"`
-	Power     *float64  `bson:"power,omitempty" json:"power,omitempty"`
-	BackCurve *float64  `bson:"backCurve,omitempty" json:"backCurve,omitempty"`
-	Diameter  *float64  `bson:"diameter,omitempty" json:"diameter,omitempty"`
-	Duration  *Quantity `bson:"duration,omitempty" json:"duration,omitempty"`
-	Color     string    `bson:"color,omitempty" json:"color,omitempty"`
-	Brand     string    `bson:"brand,omitempty" json:"brand,omitempty"`
-	Notes     string    `bson:"notes,omitempty" json:"notes,omitempty"`
+	BackboneElement `bson:",inline"`
+	Product         *Coding   `bson:"product,omitempty" json:"product,omitempty"`
+	Eye             string    `bson:"eye,omitempty" json:"eye,omitempty"`
+	Sphere          *float64  `bson:"sphere,omitempty" json:"sphere,omitempty"`
+	Cylinder        *float64  `bson:"cylinder,omitempty" json:"cylinder,omitempty"`
+	Axis            *int32    `bson:"axis,omitempty" json:"axis,omitempty"`
+	Prism           *float64  `bson:"prism,omitempty" json:"prism,omitempty"`
+	Base            string    `bson:"base,omitempty" json:"base,omitempty"`
+	Add             *float64  `bson:"add,omitempty" json:"add,omitempty"`
+	Power           *float64  `bson:"power,omitempty" json:"power,omitempty"`
+	BackCurve       *float64  `bson:"backCurve,omitempty" json:"backCurve,omitempty"`
+	Diameter        *float64  `bson:"diameter,omitempty" json:"diameter,omitempty"`
+	Duration        *Quantity `bson:"duration,omitempty" json:"duration,omitempty"`
+	Color           string    `bson:"color,omitempty" json:"color,omitempty"`
+	Brand           string    `bson:"brand,omitempty" json:"brand,omitempty"`
+	Notes           string    `bson:"notes,omitempty" json:"notes,omitempty"`
 }
 
 type VisionPrescriptionPlus struct {


### PR DESCRIPTION
This PR changes the persistence of extensions to better support searching and sorting on extensions.  The existing FHIR format for extensions does not work for sorting in Mongo since the key and value are parallel siblings.  This PR changes to serialization format to include the key in the path to the value.  The approach borrows from JSON-LD's format.

```json
{
  "url": "http://example.org/fhir/extensions/foo",
  "valueString": "bar",
}
```

becomes

```json
{
  "@context": {
    "foo": {
      "@id": "http://example.org/fhir/extensions/foo",
      "@type": "string",
    },
  },
  "foo": "bar",
}
```

In addition to this, all struct components are updated to embed `BackboneElement`, thereby allowing them to have extensions.

Lastly, `Reference` is updated to properly marshal to the FHIR-compliant format for the Reference resource.