### PR TITLE
Fix sorting of resources in upload

### DIFF
--- a/upload/upload_test.go
+++ b/upload/upload_test.go
@@ -95,6 +95,7 @@ func (s *UploadSuite) TestPostToFHIRServer(c *C) {
 
 	// Upload the resources and check the counts
 	refMap, err := UploadResources(fhirmodels, ts.URL)
+	util.CheckErr(err)
 
 	c.Assert(patientCount, Equals, 1)
 	c.Assert(encounterCount, Equals, 4)


### PR DESCRIPTION
 Sincle UploadResources posts one at a time, its important that we post resources that are referenced BEFORE the resources that reference them (so we can fix the references to use the right IDs).  The previous algorithm was faulty.  This one probably is too, but it seems to be better.  And it is a short-term fix, as other tools should be updated to post bundles instead.