### PR TITLE
Fix bug in resource helper methods

### DIFF
--- a/models/account.go
+++ b/models/account.go
@@ -356,43 +356,51 @@ func (a *AccountPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefere
 func (a *AccountPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedOrganizationResourcesReferencedByOwner != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedByOwner {
+			rsc := (*a.IncludedOrganizationResourcesReferencedByOwner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*a.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*a.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*a.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*a.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*a.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -401,83 +409,99 @@ func (a *AccountPlusRelatedResources) GetIncludedResources() map[string]interfac
 func (a *AccountPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -486,123 +510,147 @@ func (a *AccountPlusRelatedResources) GetRevIncludedResources() map[string]inter
 func (a *AccountPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedOrganizationResourcesReferencedByOwner != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedByOwner {
+			rsc := (*a.IncludedOrganizationResourcesReferencedByOwner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*a.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*a.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*a.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*a.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedBySubject {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*a.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/allergyintolerance.go
+++ b/models/allergyintolerance.go
@@ -367,33 +367,39 @@ func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedImmunizationRecom
 func (a *AllergyIntolerancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByRecorder != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByRecorder {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByRecorder != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByRecorder {
+			rsc := (*a.IncludedPatientResourcesReferencedByRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByReporter {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByReporter {
+			rsc := (*a.IncludedPatientResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -402,93 +408,111 @@ func (a *AllergyIntolerancePlusRelatedResources) GetIncludedResources() map[stri
 func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
-		for _, r := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			rsc := (*a.RevIncludedImmunizationRecommendationResourcesReferencingInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -497,123 +521,147 @@ func (a *AllergyIntolerancePlusRelatedResources) GetRevIncludedResources() map[s
 func (a *AllergyIntolerancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByRecorder != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByRecorder {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByRecorder != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByRecorder {
+			rsc := (*a.IncludedPatientResourcesReferencedByRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByReporter {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByReporter {
+			rsc := (*a.IncludedPatientResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByReporter != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByReporter {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
-		for _, r := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			rsc := (*a.RevIncludedImmunizationRecommendationResourcesReferencingInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/appointment.go
+++ b/models/appointment.go
@@ -427,48 +427,57 @@ func (a *AppointmentPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRe
 func (a *AppointmentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*a.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByActor {
+			rsc := (*a.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByActor {
+			rsc := (*a.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*a.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -477,108 +486,129 @@ func (a *AppointmentPlusRelatedResources) GetIncludedResources() map[string]inte
 func (a *AppointmentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*a.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAppointmentResponseResourcesReferencingAppointment != nil {
-		for _, r := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
+			rsc := (*a.RevIncludedAppointmentResponseResourcesReferencingAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedEncounterResourcesReferencingAppointment != nil {
-		for _, r := range *a.RevIncludedEncounterResourcesReferencingAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedEncounterResourcesReferencingAppointment {
+			rsc := (*a.RevIncludedEncounterResourcesReferencingAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -587,153 +617,183 @@ func (a *AppointmentPlusRelatedResources) GetRevIncludedResources() map[string]i
 func (a *AppointmentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*a.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByActor {
+			rsc := (*a.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByActor {
+			rsc := (*a.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*a.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*a.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAppointmentResponseResourcesReferencingAppointment != nil {
-		for _, r := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAppointmentResponseResourcesReferencingAppointment {
+			rsc := (*a.RevIncludedAppointmentResponseResourcesReferencingAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedEncounterResourcesReferencingAppointment != nil {
-		for _, r := range *a.RevIncludedEncounterResourcesReferencingAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedEncounterResourcesReferencingAppointment {
+			rsc := (*a.RevIncludedEncounterResourcesReferencingAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/appointmentresponse.go
+++ b/models/appointmentresponse.go
@@ -377,53 +377,63 @@ func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedMessageHeaderRes
 func (a *AppointmentResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*a.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByActor {
+			rsc := (*a.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByActor {
+			rsc := (*a.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedAppointmentResourcesReferencedByAppointment != nil {
-		for _, r := range *a.IncludedAppointmentResourcesReferencedByAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedAppointmentResourcesReferencedByAppointment {
+			rsc := (*a.IncludedAppointmentResourcesReferencedByAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*a.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -432,83 +442,99 @@ func (a *AppointmentResponsePlusRelatedResources) GetIncludedResources() map[str
 func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -517,133 +543,159 @@ func (a *AppointmentResponsePlusRelatedResources) GetRevIncludedResources() map[
 func (a *AppointmentResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*a.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByActor {
+			rsc := (*a.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*a.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByActor {
+			rsc := (*a.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedAppointmentResourcesReferencedByAppointment != nil {
-		for _, r := range *a.IncludedAppointmentResourcesReferencedByAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedAppointmentResourcesReferencedByAppointment {
+			rsc := (*a.IncludedAppointmentResourcesReferencedByAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *a.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*a.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/auditevent.go
+++ b/models/auditevent.go
@@ -396,38 +396,45 @@ func (a *AuditEventPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRef
 func (a *AuditEventPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedOrganizationResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedByParticipant {
+			rsc := (*a.IncludedOrganizationResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByParticipant {
+			rsc := (*a.IncludedDeviceResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByParticipant {
+			rsc := (*a.IncludedPatientResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatientPath1 != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatientPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatientPath2 != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatientPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -436,83 +443,99 @@ func (a *AuditEventPlusRelatedResources) GetIncludedResources() map[string]inter
 func (a *AuditEventPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -521,118 +544,141 @@ func (a *AuditEventPlusRelatedResources) GetRevIncludedResources() map[string]in
 func (a *AuditEventPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if a.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*a.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedOrganizationResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedOrganizationResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedOrganizationResourcesReferencedByParticipant {
+			rsc := (*a.IncludedOrganizationResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedDeviceResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedDeviceResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedDeviceResourcesReferencedByParticipant {
+			rsc := (*a.IncludedDeviceResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByParticipant {
+			rsc := (*a.IncludedPatientResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*a.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatientPath1 != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatientPath1 {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatientPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.IncludedPatientResourcesReferencedByPatientPath2 != nil {
-		for _, r := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *a.IncludedPatientResourcesReferencedByPatientPath2 {
+			rsc := (*a.IncludedPatientResourcesReferencedByPatientPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *a.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*a.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *a.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedListResourcesReferencingItem {
+			rsc := (*a.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*a.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *a.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*a.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*a.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *a.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*a.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *a.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*a.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*a.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*a.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*a.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*a.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*a.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if a.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *a.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *a.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*a.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/basic.go
+++ b/models/basic.go
@@ -302,23 +302,27 @@ func (b *BasicPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenc
 func (b *BasicPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*b.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*b.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*b.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*b.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -327,83 +331,99 @@ func (b *BasicPlusRelatedResources) GetIncludedResources() map[string]interface{
 func (b *BasicPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -412,103 +432,123 @@ func (b *BasicPlusRelatedResources) GetRevIncludedResources() map[string]interfa
 func (b *BasicPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*b.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*b.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*b.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*b.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/binary.go
+++ b/models/binary.go
@@ -251,83 +251,99 @@ func (b *BinaryPlusRelatedResources) GetIncludedResources() map[string]interface
 func (b *BinaryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -336,83 +352,99 @@ func (b *BinaryPlusRelatedResources) GetRevIncludedResources() map[string]interf
 func (b *BinaryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/bodysite.go
+++ b/models/bodysite.go
@@ -267,8 +267,9 @@ func (b *BodySitePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (b *BodySitePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*b.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -277,83 +278,99 @@ func (b *BodySitePlusRelatedResources) GetIncludedResources() map[string]interfa
 func (b *BodySitePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -362,88 +379,105 @@ func (b *BodySitePlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (b *BodySitePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *b.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*b.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/bundle.go
+++ b/models/bundle.go
@@ -328,13 +328,15 @@ func (b *BundlePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferen
 func (b *BundlePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedCompositionResourcesReferencedByComposition != nil {
-		for _, r := range *b.IncludedCompositionResourcesReferencedByComposition {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedCompositionResourcesReferencedByComposition {
+			rsc := (*b.IncludedCompositionResourcesReferencedByComposition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedMessageHeaderResourcesReferencedByMessage != nil {
-		for _, r := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
+			rsc := (*b.IncludedMessageHeaderResourcesReferencedByMessage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -343,83 +345,99 @@ func (b *BundlePlusRelatedResources) GetIncludedResources() map[string]interface
 func (b *BundlePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -428,93 +446,111 @@ func (b *BundlePlusRelatedResources) GetRevIncludedResources() map[string]interf
 func (b *BundlePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if b.IncludedCompositionResourcesReferencedByComposition != nil {
-		for _, r := range *b.IncludedCompositionResourcesReferencedByComposition {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedCompositionResourcesReferencedByComposition {
+			rsc := (*b.IncludedCompositionResourcesReferencedByComposition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.IncludedMessageHeaderResourcesReferencedByMessage != nil {
-		for _, r := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
-			resourceMap[r.Id] = &r
+		for idx := range *b.IncludedMessageHeaderResourcesReferencedByMessage {
+			rsc := (*b.IncludedMessageHeaderResourcesReferencedByMessage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *b.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*b.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *b.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedListResourcesReferencingItem {
+			rsc := (*b.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*b.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *b.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*b.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*b.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *b.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*b.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *b.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*b.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*b.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*b.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*b.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*b.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*b.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if b.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *b.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *b.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*b.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/careplan.go
+++ b/models/careplan.go
@@ -627,133 +627,159 @@ func (c *CarePlanPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (c *CarePlanPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedAppointmentResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcessRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedProcessRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedVisionPrescriptionResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceUseRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCommunicationRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*c.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGoalResourcesReferencedByGoal != nil {
-		for _, r := range *c.IncludedGoalResourcesReferencedByGoal {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGoalResourcesReferencedByGoal {
+			rsc := (*c.IncludedGoalResourcesReferencedByGoal)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*c.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByParticipant {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByParticipant {
+			rsc := (*c.IncludedPatientResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCarePlanResourcesReferencedByRelatedplan != nil {
-		for _, r := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
+			rsc := (*c.IncludedCarePlanResourcesReferencedByRelatedplan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *c.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*c.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -762,93 +788,111 @@ func (c *CarePlanPlusRelatedResources) GetIncludedResources() map[string]interfa
 func (c *CarePlanPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingRelatedplan != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingRelatedplan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -857,223 +901,267 @@ func (c *CarePlanPlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (c *CarePlanPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedAppointmentResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcessRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcessRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedProcessRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedVisionPrescriptionResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedVisionPrescriptionResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedVisionPrescriptionResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceUseRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceUseRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedDeviceUseRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCommunicationRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByActivityreference != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByActivityreference {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*c.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGoalResourcesReferencedByGoal != nil {
-		for _, r := range *c.IncludedGoalResourcesReferencedByGoal {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGoalResourcesReferencedByGoal {
+			rsc := (*c.IncludedGoalResourcesReferencedByGoal)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*c.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByParticipant {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByParticipant {
+			rsc := (*c.IncludedPatientResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCarePlanResourcesReferencedByRelatedplan != nil {
-		for _, r := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCarePlanResourcesReferencedByRelatedplan {
+			rsc := (*c.IncludedCarePlanResourcesReferencedByRelatedplan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *c.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*c.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingRelatedplan != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingRelatedplan {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingRelatedplan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/claim.go
+++ b/models/claim.go
@@ -390,13 +390,15 @@ func (c *ClaimPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenc
 func (c *ClaimPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -405,83 +407,99 @@ func (c *ClaimPlusRelatedResources) GetIncludedResources() map[string]interface{
 func (c *ClaimPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -490,93 +508,111 @@ func (c *ClaimPlusRelatedResources) GetRevIncludedResources() map[string]interfa
 func (c *ClaimPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/claimresponse.go
+++ b/models/claimresponse.go
@@ -380,83 +380,99 @@ func (c *ClaimResponsePlusRelatedResources) GetIncludedResources() map[string]in
 func (c *ClaimResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -465,83 +481,99 @@ func (c *ClaimResponsePlusRelatedResources) GetRevIncludedResources() map[string
 func (c *ClaimResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/clinicalimpression.go
+++ b/models/clinicalimpression.go
@@ -601,153 +601,183 @@ func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedMessageHeaderReso
 func (c *ClinicalImpressionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedClinicalImpressionResourcesReferencedByPrevious != nil {
-		for _, r := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
+			rsc := (*c.IncludedClinicalImpressionResourcesReferencedByPrevious)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAssessor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAssessor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAssessor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAssessor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedConditionResourcesReferencedByProblem != nil {
-		for _, r := range *c.IncludedConditionResourcesReferencedByProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedConditionResourcesReferencedByProblem {
+			rsc := (*c.IncludedConditionResourcesReferencedByProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAllergyIntoleranceResourcesReferencedByProblem != nil {
-		for _, r := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
+			rsc := (*c.IncludedAllergyIntoleranceResourcesReferencedByProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedObservationResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedObservationResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedObservationResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedObservationResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticReportResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedDiagnosticReportResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAppointmentResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByAction {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedProcedureResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureResourcesReferencedByAction {
+			rsc := (*c.IncludedProcedureResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAppointmentResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByPlan {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcessRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedProcessRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcessRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedProcessRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedVisionPrescriptionResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
+			rsc := (*c.IncludedVisionPrescriptionResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceUseRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedDeviceUseRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCarePlanResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedCarePlanResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCarePlanResourcesReferencedByPlan {
+			rsc := (*c.IncludedCarePlanResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCommunicationRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -756,88 +786,105 @@ func (c *ClinicalImpressionPlusRelatedResources) GetIncludedResources() map[stri
 func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPrevious != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPrevious)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -846,238 +893,285 @@ func (c *ClinicalImpressionPlusRelatedResources) GetRevIncludedResources() map[s
 func (c *ClinicalImpressionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedClinicalImpressionResourcesReferencedByPrevious != nil {
-		for _, r := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedClinicalImpressionResourcesReferencedByPrevious {
+			rsc := (*c.IncludedClinicalImpressionResourcesReferencedByPrevious)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAssessor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAssessor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAssessor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAssessor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedConditionResourcesReferencedByProblem != nil {
-		for _, r := range *c.IncludedConditionResourcesReferencedByProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedConditionResourcesReferencedByProblem {
+			rsc := (*c.IncludedConditionResourcesReferencedByProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAllergyIntoleranceResourcesReferencedByProblem != nil {
-		for _, r := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAllergyIntoleranceResourcesReferencedByProblem {
+			rsc := (*c.IncludedAllergyIntoleranceResourcesReferencedByProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedFamilyMemberHistoryResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedObservationResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedObservationResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedObservationResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedObservationResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticReportResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticReportResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedDiagnosticReportResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation != nil {
-		for _, r := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation {
+			rsc := (*c.IncludedQuestionnaireResponseResourcesReferencedByInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAppointmentResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByAction {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedProcedureResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureResourcesReferencedByAction {
+			rsc := (*c.IncludedProcedureResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByAction {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByAction != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByAction {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByAction {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedAppointmentResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedAppointmentResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedAppointmentResourcesReferencedByPlan {
+			rsc := (*c.IncludedAppointmentResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedReferralRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedReferralRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedReferralRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedReferralRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcessRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedProcessRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcessRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedProcessRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedVisionPrescriptionResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedVisionPrescriptionResourcesReferencedByPlan {
+			rsc := (*c.IncludedVisionPrescriptionResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDiagnosticOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDiagnosticOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedDiagnosticOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedProcedureRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedProcedureRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedProcedureRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceUseRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceUseRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedDeviceUseRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSupplyRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSupplyRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedSupplyRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCarePlanResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedCarePlanResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCarePlanResourcesReferencedByPlan {
+			rsc := (*c.IncludedCarePlanResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedNutritionOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedNutritionOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedNutritionOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedMedicationOrderResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedMedicationOrderResourcesReferencedByPlan {
+			rsc := (*c.IncludedMedicationOrderResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedCommunicationRequestResourcesReferencedByPlan != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByPlan {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPrevious != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPrevious {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPrevious)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/communication.go
+++ b/models/communication.go
@@ -437,78 +437,93 @@ func (c *CommunicationPlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (c *CommunicationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedCommunicationRequestResourcesReferencedByRequest != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySender {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySender {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedBySender {
+			rsc := (*c.IncludedDeviceResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySender {
+			rsc := (*c.IncludedPatientResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedByRecipient {
+			rsc := (*c.IncludedGroupResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			rsc := (*c.IncludedDeviceResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -517,83 +532,99 @@ func (c *CommunicationPlusRelatedResources) GetIncludedResources() map[string]in
 func (c *CommunicationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -602,158 +633,189 @@ func (c *CommunicationPlusRelatedResources) GetRevIncludedResources() map[string
 func (c *CommunicationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedCommunicationRequestResourcesReferencedByRequest != nil {
-		for _, r := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedCommunicationRequestResourcesReferencedByRequest {
+			rsc := (*c.IncludedCommunicationRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySender {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySender {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedBySender {
+			rsc := (*c.IncludedDeviceResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySender {
+			rsc := (*c.IncludedPatientResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedByRecipient {
+			rsc := (*c.IncludedGroupResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			rsc := (*c.IncludedDeviceResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/communicationrequest.go
+++ b/models/communicationrequest.go
@@ -483,83 +483,99 @@ func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedMessageHeaderRe
 func (c *CommunicationRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRequester {
+			rsc := (*c.IncludedPatientResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySender {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySender {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedBySender {
+			rsc := (*c.IncludedDeviceResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySender {
+			rsc := (*c.IncludedPatientResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			rsc := (*c.IncludedDeviceResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -568,98 +584,117 @@ func (c *CommunicationRequestPlusRelatedResources) GetIncludedResources() map[st
 func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCommunicationResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedCommunicationResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCommunicationResourcesReferencingRequest {
+			rsc := (*c.RevIncludedCommunicationResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -668,178 +703,213 @@ func (c *CommunicationRequestPlusRelatedResources) GetRevIncludedResources() map
 func (c *CommunicationRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRequester {
+			rsc := (*c.IncludedPatientResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRequester != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRequester {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySender {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySender {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedBySender {
+			rsc := (*c.IncludedDeviceResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySender {
+			rsc := (*c.IncludedPatientResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySender != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySender {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySender {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByRecipient {
+			rsc := (*c.IncludedDeviceResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*c.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCommunicationResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedCommunicationResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCommunicationResourcesReferencingRequest {
+			rsc := (*c.RevIncludedCommunicationResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/composition.go
+++ b/models/composition.go
@@ -399,48 +399,57 @@ func (c *CompositionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRe
 func (c *CompositionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*c.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*c.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAttester {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByAttester {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAttester {
+			rsc := (*c.IncludedPatientResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -449,88 +458,105 @@ func (c *CompositionPlusRelatedResources) GetIncludedResources() map[string]inte
 func (c *CompositionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBundleResourcesReferencingComposition != nil {
-		for _, r := range *c.RevIncludedBundleResourcesReferencingComposition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBundleResourcesReferencingComposition {
+			rsc := (*c.RevIncludedBundleResourcesReferencingComposition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -539,133 +565,159 @@ func (c *CompositionPlusRelatedResources) GetRevIncludedResources() map[string]i
 func (c *CompositionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*c.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*c.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAttester {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByAttester {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAttester != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAttester {
+			rsc := (*c.IncludedPatientResourcesReferencedByAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBundleResourcesReferencingComposition != nil {
-		for _, r := range *c.RevIncludedBundleResourcesReferencingComposition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBundleResourcesReferencingComposition {
+			rsc := (*c.RevIncludedBundleResourcesReferencingComposition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/conceptmap.go
+++ b/models/conceptmap.go
@@ -369,33 +369,39 @@ func (c *ConceptMapPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRef
 func (c *ConceptMapPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedStructureDefinitionResourcesReferencedBySource != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedBySource != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedBySource {
+			rsc := (*c.IncludedValueSetResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedByTarget != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedByTarget != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedByTarget {
+			rsc := (*c.IncludedValueSetResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedBySourceuri != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedBySourceuri != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedBySourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedBySourceuri {
+			rsc := (*c.IncludedValueSetResourcesReferencedBySourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -404,83 +410,99 @@ func (c *ConceptMapPlusRelatedResources) GetIncludedResources() map[string]inter
 func (c *ConceptMapPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -489,113 +511,135 @@ func (c *ConceptMapPlusRelatedResources) GetRevIncludedResources() map[string]in
 func (c *ConceptMapPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedStructureDefinitionResourcesReferencedBySource != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySource {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedBySource != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedBySource {
+			rsc := (*c.IncludedValueSetResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedByTarget != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedByTarget {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedByTarget != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedByTarget {
+			rsc := (*c.IncludedValueSetResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedBySourceuri != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySourceuri {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedValueSetResourcesReferencedBySourceuri != nil {
-		for _, r := range *c.IncludedValueSetResourcesReferencedBySourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedValueSetResourcesReferencedBySourceuri {
+			rsc := (*c.IncludedValueSetResourcesReferencedBySourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/condition.go
+++ b/models/condition.go
@@ -394,23 +394,27 @@ func (c *ConditionPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefe
 func (c *ConditionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAsserter != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAsserter {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAsserter != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAsserter {
+			rsc := (*c.IncludedPatientResourcesReferencedByAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -419,113 +423,135 @@ func (c *ConditionPlusRelatedResources) GetIncludedResources() map[string]interf
 func (c *ConditionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingCondition {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEpisodeOfCareResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
+			rsc := (*c.RevIncludedEpisodeOfCareResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedRiskAssessmentResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
+			rsc := (*c.RevIncludedRiskAssessmentResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEncounterResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedEncounterResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEncounterResourcesReferencingCondition {
+			rsc := (*c.RevIncludedEncounterResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEncounterResourcesReferencingIndication != nil {
-		for _, r := range *c.RevIncludedEncounterResourcesReferencingIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEncounterResourcesReferencingIndication {
+			rsc := (*c.RevIncludedEncounterResourcesReferencingIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -534,133 +560,159 @@ func (c *ConditionPlusRelatedResources) GetRevIncludedResources() map[string]int
 func (c *ConditionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *c.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*c.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedByAsserter != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByAsserter {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByAsserter != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByAsserter {
+			rsc := (*c.IncludedPatientResourcesReferencedByAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCarePlanResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedCarePlanResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCarePlanResourcesReferencingCondition {
+			rsc := (*c.RevIncludedCarePlanResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEpisodeOfCareResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEpisodeOfCareResourcesReferencingCondition {
+			rsc := (*c.RevIncludedEpisodeOfCareResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedRiskAssessmentResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedRiskAssessmentResourcesReferencingCondition {
+			rsc := (*c.RevIncludedRiskAssessmentResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEncounterResourcesReferencingCondition != nil {
-		for _, r := range *c.RevIncludedEncounterResourcesReferencingCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEncounterResourcesReferencingCondition {
+			rsc := (*c.RevIncludedEncounterResourcesReferencingCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedEncounterResourcesReferencingIndication != nil {
-		for _, r := range *c.RevIncludedEncounterResourcesReferencingIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedEncounterResourcesReferencingIndication {
+			rsc := (*c.RevIncludedEncounterResourcesReferencingIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingProblem != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingProblem {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingProblem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/conformance.go
+++ b/models/conformance.go
@@ -415,13 +415,15 @@ func (c *ConformancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRe
 func (c *ConformancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedByProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -430,83 +432,99 @@ func (c *ConformancePlusRelatedResources) GetIncludedResources() map[string]inte
 func (c *ConformancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -515,93 +533,111 @@ func (c *ConformancePlusRelatedResources) GetRevIncludedResources() map[string]i
 func (c *ConformancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedByProfile {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedByProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile != nil {
-		for _, r := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile {
+			rsc := (*c.IncludedStructureDefinitionResourcesReferencedBySupportedprofile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/contract.go
+++ b/models/contract.go
@@ -533,78 +533,93 @@ func (c *ContractPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (c *ContractPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedByActor {
+			rsc := (*c.IncludedGroupResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByActor {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*c.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByActor {
+			rsc := (*c.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSubstanceResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedSubstanceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSubstanceResourcesReferencedByActor {
+			rsc := (*c.IncludedSubstanceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedContractResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedContractResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedContractResourcesReferencedByActor {
+			rsc := (*c.IncludedContractResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedLocationResourcesReferencedByActor {
+			rsc := (*c.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySigner {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySigner {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySigner {
+			rsc := (*c.IncludedPatientResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -613,88 +628,105 @@ func (c *ContractPlusRelatedResources) GetIncludedResources() map[string]interfa
 func (c *ContractPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *c.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedContractResourcesReferencingActor {
+			rsc := (*c.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -703,163 +735,195 @@ func (c *ContractPlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (c *ContractPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*c.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedGroupResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedGroupResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedGroupResourcesReferencedByActor {
+			rsc := (*c.IncludedGroupResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByActor {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*c.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByActor {
+			rsc := (*c.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedSubstanceResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedSubstanceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedSubstanceResourcesReferencedByActor {
+			rsc := (*c.IncludedSubstanceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedContractResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedContractResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedContractResourcesReferencedByActor {
+			rsc := (*c.IncludedContractResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *c.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedLocationResourcesReferencedByActor {
+			rsc := (*c.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*c.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*c.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPractitionerResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedPractitionerResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPractitionerResourcesReferencedBySigner {
+			rsc := (*c.IncludedPractitionerResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedOrganizationResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedBySigner {
+			rsc := (*c.IncludedOrganizationResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedPatientResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedPatientResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedPatientResourcesReferencedBySigner {
+			rsc := (*c.IncludedPatientResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.IncludedRelatedPersonResourcesReferencedBySigner != nil {
-		for _, r := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedRelatedPersonResourcesReferencedBySigner {
+			rsc := (*c.IncludedRelatedPersonResourcesReferencedBySigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *c.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedContractResourcesReferencingActor {
+			rsc := (*c.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/coverage.go
+++ b/models/coverage.go
@@ -275,8 +275,9 @@ func (c *CoveragePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (c *CoveragePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedOrganizationResourcesReferencedByIssuer != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByIssuer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByIssuer {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByIssuer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -285,83 +286,99 @@ func (c *CoveragePlusRelatedResources) GetIncludedResources() map[string]interfa
 func (c *CoveragePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -370,88 +387,105 @@ func (c *CoveragePlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (c *CoveragePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if c.IncludedOrganizationResourcesReferencedByIssuer != nil {
-		for _, r := range *c.IncludedOrganizationResourcesReferencedByIssuer {
-			resourceMap[r.Id] = &r
+		for idx := range *c.IncludedOrganizationResourcesReferencedByIssuer {
+			rsc := (*c.IncludedOrganizationResourcesReferencedByIssuer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *c.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*c.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *c.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedListResourcesReferencingItem {
+			rsc := (*c.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*c.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *c.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*c.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*c.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *c.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*c.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *c.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*c.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*c.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*c.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*c.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*c.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*c.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if c.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *c.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *c.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*c.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/dataelement.go
+++ b/models/dataelement.go
@@ -282,83 +282,99 @@ func (d *DataElementPlusRelatedResources) GetIncludedResources() map[string]inte
 func (d *DataElementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -367,83 +383,99 @@ func (d *DataElementPlusRelatedResources) GetRevIncludedResources() map[string]i
 func (d *DataElementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/detectedissue.go
+++ b/models/detectedissue.go
@@ -302,18 +302,21 @@ func (d *DetectedIssuePlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (d *DetectedIssuePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -322,83 +325,99 @@ func (d *DetectedIssuePlusRelatedResources) GetIncludedResources() map[string]in
 func (d *DetectedIssuePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -407,98 +426,117 @@ func (d *DetectedIssuePlusRelatedResources) GetRevIncludedResources() map[string
 func (d *DetectedIssuePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/device.go
+++ b/models/device.go
@@ -721,18 +721,21 @@ func (d *DevicePlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferen
 func (d *DevicePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*d.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -741,293 +744,351 @@ func (d *DevicePlusRelatedResources) GetIncludedResources() map[string]interface
 func (d *DevicePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*d.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*d.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*d.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingSubject {
+			rsc := (*d.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingSource {
+			rsc := (*d.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*d.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*d.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*d.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*d.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceUseRequestResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
+			rsc := (*d.RevIncludedDeviceUseRequestResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceMetricResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
+			rsc := (*d.RevIncludedDeviceMetricResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*d.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*d.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedObservationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMedicationAdministrationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedMedicationAdministrationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedContractResourcesReferencingActor {
+			rsc := (*d.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*d.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*d.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
-		for _, r := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			rsc := (*d.RevIncludedRiskAssessmentResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *d.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*d.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceComponentResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
+			rsc := (*d.RevIncludedDeviceComponentResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *d.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*d.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*d.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceUseStatementResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
+			rsc := (*d.RevIncludedDeviceUseStatementResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*d.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -1036,308 +1097,369 @@ func (d *DevicePlusRelatedResources) GetRevIncludedResources() map[string]interf
 func (d *DevicePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*d.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*d.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*d.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*d.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingSubject {
+			rsc := (*d.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingSource {
+			rsc := (*d.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*d.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*d.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*d.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*d.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceUseRequestResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceUseRequestResourcesReferencingDevice {
+			rsc := (*d.RevIncludedDeviceUseRequestResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceMetricResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceMetricResourcesReferencingSource {
+			rsc := (*d.RevIncludedDeviceMetricResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*d.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*d.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedObservationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMedicationAdministrationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMedicationAdministrationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedMedicationAdministrationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedContractResourcesReferencingActor {
+			rsc := (*d.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*d.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*d.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
-		for _, r := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			rsc := (*d.RevIncludedRiskAssessmentResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *d.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*d.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceComponentResourcesReferencingSource != nil {
-		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceComponentResourcesReferencingSource {
+			rsc := (*d.RevIncludedDeviceComponentResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *d.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*d.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*d.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
-		for _, r := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			rsc := (*d.RevIncludedDiagnosticOrderResourcesReferencingActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceUseStatementResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceUseStatementResourcesReferencingDevice {
+			rsc := (*d.RevIncludedDeviceUseStatementResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *d.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*d.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingTarget {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/devicecomponent.go
+++ b/models/devicecomponent.go
@@ -310,13 +310,15 @@ func (d *DeviceComponentPlusRelatedResources) GetRevIncludedMessageHeaderResourc
 func (d *DeviceComponentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
-		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			rsc := (*d.IncludedDeviceComponentResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -325,93 +327,111 @@ func (d *DeviceComponentPlusRelatedResources) GetIncludedResources() map[string]
 func (d *DeviceComponentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceMetricResourcesReferencingParent != nil {
-		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
+			rsc := (*d.RevIncludedDeviceMetricResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceComponentResourcesReferencingParent != nil {
-		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
+			rsc := (*d.RevIncludedDeviceComponentResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -420,103 +440,123 @@ func (d *DeviceComponentPlusRelatedResources) GetRevIncludedResources() map[stri
 func (d *DeviceComponentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
-		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			rsc := (*d.IncludedDeviceComponentResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceMetricResourcesReferencingParent != nil {
-		for _, r := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceMetricResourcesReferencingParent {
+			rsc := (*d.RevIncludedDeviceMetricResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDeviceComponentResourcesReferencingParent != nil {
-		for _, r := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDeviceComponentResourcesReferencingParent {
+			rsc := (*d.RevIncludedDeviceComponentResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/devicemetric.go
+++ b/models/devicemetric.go
@@ -300,13 +300,15 @@ func (d *DeviceMetricPlusRelatedResources) GetRevIncludedMessageHeaderResourcesR
 func (d *DeviceMetricPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
-		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			rsc := (*d.IncludedDeviceComponentResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -315,88 +317,105 @@ func (d *DeviceMetricPlusRelatedResources) GetIncludedResources() map[string]int
 func (d *DeviceMetricPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedObservationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -405,98 +424,117 @@ func (d *DeviceMetricPlusRelatedResources) GetRevIncludedResources() map[string]
 func (d *DeviceMetricPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedDeviceComponentResourcesReferencedByParent != nil {
-		for _, r := range *d.IncludedDeviceComponentResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceComponentResourcesReferencedByParent {
+			rsc := (*d.IncludedDeviceComponentResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedObservationResourcesReferencingDevice != nil {
-		for _, r := range *d.RevIncludedObservationResourcesReferencingDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedObservationResourcesReferencingDevice {
+			rsc := (*d.RevIncludedObservationResourcesReferencingDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/deviceuserequest.go
+++ b/models/deviceuserequest.go
@@ -321,18 +321,21 @@ func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedMessageHeaderResour
 func (d *DeviceUseRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*d.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -341,93 +344,111 @@ func (d *DeviceUseRequestPlusRelatedResources) GetIncludedResources() map[string
 func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*d.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -436,108 +457,129 @@ func (d *DeviceUseRequestPlusRelatedResources) GetRevIncludedResources() map[str
 func (d *DeviceUseRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*d.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*d.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/deviceusestatement.go
+++ b/models/deviceusestatement.go
@@ -297,18 +297,21 @@ func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedMessageHeaderReso
 func (d *DeviceUseStatementPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*d.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -317,83 +320,99 @@ func (d *DeviceUseStatementPlusRelatedResources) GetIncludedResources() map[stri
 func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -402,98 +421,117 @@ func (d *DeviceUseStatementPlusRelatedResources) GetRevIncludedResources() map[s
 func (d *DeviceUseStatementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*d.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/diagnosticorder.go
+++ b/models/diagnosticorder.go
@@ -480,68 +480,81 @@ func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedMessageHeaderResourc
 func (d *DiagnosticOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*d.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByActorPath1 != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByActorPath2 != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByActorPath1 != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
+			rsc := (*d.IncludedDeviceResourcesReferencedByActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByActorPath2 != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
+			rsc := (*d.IncludedDeviceResourcesReferencedByActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByOrderer != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByOrderer {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimenPath1 != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimenPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimenPath2 != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimenPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -550,108 +563,129 @@ func (d *DiagnosticOrderPlusRelatedResources) GetIncludedResources() map[string]
 func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*d.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*d.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedImagingStudyResourcesReferencingOrder != nil {
-		for _, r := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
+			rsc := (*d.RevIncludedImagingStudyResourcesReferencingOrder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -660,173 +694,207 @@ func (d *DiagnosticOrderPlusRelatedResources) GetRevIncludedResources() map[stri
 func (d *DiagnosticOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*d.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByActorPath1 != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByActorPath1 {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByActorPath2 != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByActorPath2 {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByActorPath1 != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByActorPath1 {
+			rsc := (*d.IncludedDeviceResourcesReferencedByActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByActorPath2 != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByActorPath2 {
+			rsc := (*d.IncludedDeviceResourcesReferencedByActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByOrderer != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByOrderer {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimenPath1 != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath1 {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimenPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimenPath2 != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimenPath2 {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimenPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*d.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*d.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedImagingStudyResourcesReferencingOrder != nil {
-		for _, r := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedImagingStudyResourcesReferencingOrder {
+			rsc := (*d.RevIncludedImagingStudyResourcesReferencingOrder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/diagnosticreport.go
+++ b/models/diagnosticreport.go
@@ -441,73 +441,87 @@ func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedMessageHeaderResour
 func (d *DiagnosticReportPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedMediaResourcesReferencedByImage != nil {
-		for _, r := range *d.IncludedMediaResourcesReferencedByImage {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedMediaResourcesReferencedByImage {
+			rsc := (*d.IncludedMediaResourcesReferencedByImage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedReferralRequestResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedReferralRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedReferralRequestResourcesReferencedByRequest {
+			rsc := (*d.IncludedReferralRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDiagnosticOrderResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
+			rsc := (*d.IncludedDiagnosticOrderResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedProcedureRequestResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
+			rsc := (*d.IncludedProcedureRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*d.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedObservationResourcesReferencedByResult != nil {
-		for _, r := range *d.IncludedObservationResourcesReferencedByResult {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedObservationResourcesReferencedByResult {
+			rsc := (*d.IncludedObservationResourcesReferencedByResult)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimen != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -516,88 +530,105 @@ func (d *DiagnosticReportPlusRelatedResources) GetIncludedResources() map[string
 func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -606,158 +637,189 @@ func (d *DiagnosticReportPlusRelatedResources) GetRevIncludedResources() map[str
 func (d *DiagnosticReportPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedMediaResourcesReferencedByImage != nil {
-		for _, r := range *d.IncludedMediaResourcesReferencedByImage {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedMediaResourcesReferencedByImage {
+			rsc := (*d.IncludedMediaResourcesReferencedByImage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedReferralRequestResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedReferralRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedReferralRequestResourcesReferencedByRequest {
+			rsc := (*d.IncludedReferralRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDiagnosticOrderResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDiagnosticOrderResourcesReferencedByRequest {
+			rsc := (*d.IncludedDiagnosticOrderResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedProcedureRequestResourcesReferencedByRequest != nil {
-		for _, r := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedProcedureRequestResourcesReferencedByRequest {
+			rsc := (*d.IncludedProcedureRequestResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*d.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedObservationResourcesReferencedByResult != nil {
-		for _, r := range *d.IncludedObservationResourcesReferencedByResult {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedObservationResourcesReferencedByResult {
+			rsc := (*d.IncludedObservationResourcesReferencedByResult)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedSpecimenResourcesReferencedBySpecimen != nil {
-		for _, r := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedSpecimenResourcesReferencedBySpecimen {
+			rsc := (*d.IncludedSpecimenResourcesReferencedBySpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/documentmanifest.go
+++ b/models/documentmanifest.go
@@ -423,73 +423,87 @@ func (d *DocumentManifestPlusRelatedResources) GetRevIncludedMessageHeaderResour
 func (d *DocumentManifestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*d.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*d.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -498,83 +512,99 @@ func (d *DocumentManifestPlusRelatedResources) GetIncludedResources() map[string
 func (d *DocumentManifestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -583,153 +613,183 @@ func (d *DocumentManifestPlusRelatedResources) GetRevIncludedResources() map[str
 func (d *DocumentManifestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*d.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByRecipient {
+			rsc := (*d.IncludedPatientResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByRecipient != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByRecipient {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/documentreference.go
+++ b/models/documentreference.go
@@ -475,78 +475,93 @@ func (d *DocumentReferencePlusRelatedResources) GetRevIncludedMessageHeaderResou
 func (d *DocumentReferencePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*d.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthenticator != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthenticator != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByCustodian != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByCustodian {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByCustodian {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByCustodian)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDocumentReferenceResourcesReferencedByRelatesto != nil {
-		for _, r := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
+			rsc := (*d.IncludedDocumentReferenceResourcesReferencedByRelatesto)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -555,88 +570,105 @@ func (d *DocumentReferencePlusRelatedResources) GetIncludedResources() map[strin
 func (d *DocumentReferencePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatesto != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatesto)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -645,163 +677,195 @@ func (d *DocumentReferencePlusRelatedResources) GetRevIncludedResources() map[st
 func (d *DocumentReferencePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if d.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*d.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*d.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*d.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*d.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*d.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthenticator != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthenticator {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthenticator != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthenticator {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByCustodian != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByCustodian {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByCustodian {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByCustodian)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*d.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*d.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*d.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*d.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *d.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*d.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.IncludedDocumentReferenceResourcesReferencedByRelatesto != nil {
-		for _, r := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
-			resourceMap[r.Id] = &r
+		for idx := range *d.IncludedDocumentReferenceResourcesReferencedByRelatesto {
+			rsc := (*d.IncludedDocumentReferenceResourcesReferencedByRelatesto)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *d.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*d.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *d.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedListResourcesReferencingItem {
+			rsc := (*d.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDocumentReferenceResourcesReferencingRelatesto != nil {
-		for _, r := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDocumentReferenceResourcesReferencingRelatesto {
+			rsc := (*d.RevIncludedDocumentReferenceResourcesReferencingRelatesto)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *d.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*d.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*d.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *d.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*d.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *d.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*d.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*d.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*d.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*d.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*d.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*d.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if d.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *d.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *d.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*d.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/eligibilityrequest.go
+++ b/models/eligibilityrequest.go
@@ -261,83 +261,99 @@ func (e *EligibilityRequestPlusRelatedResources) GetIncludedResources() map[stri
 func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -346,83 +362,99 @@ func (e *EligibilityRequestPlusRelatedResources) GetRevIncludedResources() map[s
 func (e *EligibilityRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/eligibilityresponse.go
+++ b/models/eligibilityresponse.go
@@ -264,83 +264,99 @@ func (e *EligibilityResponsePlusRelatedResources) GetIncludedResources() map[str
 func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -349,83 +365,99 @@ func (e *EligibilityResponsePlusRelatedResources) GetRevIncludedResources() map[
 func (e *EligibilityResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -637,68 +637,81 @@ func (e *EncounterPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefe
 func (e *EncounterPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare != nil {
-		for _, r := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
+			rsc := (*e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
-		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			rsc := (*e.IncludedReferralRequestResourcesReferencedByIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedAppointmentResourcesReferencedByAppointment != nil {
-		for _, r := range *e.IncludedAppointmentResourcesReferencedByAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedAppointmentResourcesReferencedByAppointment {
+			rsc := (*e.IncludedAppointmentResourcesReferencedByAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedEncounterResourcesReferencedByPartof != nil {
-		for _, r := range *e.IncludedEncounterResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedEncounterResourcesReferencedByPartof {
+			rsc := (*e.IncludedEncounterResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedProcedureResourcesReferencedByProcedure != nil {
-		for _, r := range *e.IncludedProcedureResourcesReferencedByProcedure {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedProcedureResourcesReferencedByProcedure {
+			rsc := (*e.IncludedProcedureResourcesReferencedByProcedure)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*e.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*e.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *e.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*e.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedConditionResourcesReferencedByIndication != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByIndication {
+			rsc := (*e.IncludedConditionResourcesReferencedByIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedProcedureResourcesReferencedByIndication != nil {
-		for _, r := range *e.IncludedProcedureResourcesReferencedByIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedProcedureResourcesReferencedByIndication {
+			rsc := (*e.IncludedProcedureResourcesReferencedByIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -707,178 +720,213 @@ func (e *EncounterPlusRelatedResources) GetIncludedResources() map[string]interf
 func (e *EncounterPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcedureResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedProcedureResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcedureResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedProcedureResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedListResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedVisionPrescriptionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedVisionPrescriptionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcedureRequestResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedProcedureRequestResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedFlagResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedFlagResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedFlagResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedFlagResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedObservationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedObservationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedObservationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedObservationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMedicationAdministrationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedMedicationAdministrationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCommunicationRequestResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCommunicationRequestResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedRiskAssessmentResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedRiskAssessmentResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDiagnosticReportResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDiagnosticReportResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedNutritionOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedNutritionOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedEncounterResourcesReferencingPartof != nil {
-		for _, r := range *e.RevIncludedEncounterResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedEncounterResourcesReferencingPartof {
+			rsc := (*e.RevIncludedEncounterResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMedicationOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedMedicationOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCommunicationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCommunicationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedConditionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedConditionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedConditionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedConditionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDiagnosticOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDiagnosticOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -887,243 +935,291 @@ func (e *EncounterPlusRelatedResources) GetRevIncludedResources() map[string]int
 func (e *EncounterPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare != nil {
-		for _, r := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare {
+			rsc := (*e.IncludedEpisodeOfCareResourcesReferencedByEpisodeofcare)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
-		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			rsc := (*e.IncludedReferralRequestResourcesReferencedByIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedAppointmentResourcesReferencedByAppointment != nil {
-		for _, r := range *e.IncludedAppointmentResourcesReferencedByAppointment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedAppointmentResourcesReferencedByAppointment {
+			rsc := (*e.IncludedAppointmentResourcesReferencedByAppointment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedEncounterResourcesReferencedByPartof != nil {
-		for _, r := range *e.IncludedEncounterResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedEncounterResourcesReferencedByPartof {
+			rsc := (*e.IncludedEncounterResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedProcedureResourcesReferencedByProcedure != nil {
-		for _, r := range *e.IncludedProcedureResourcesReferencedByProcedure {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedProcedureResourcesReferencedByProcedure {
+			rsc := (*e.IncludedProcedureResourcesReferencedByProcedure)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByParticipant != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByParticipant {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedRelatedPersonResourcesReferencedByParticipant != nil {
-		for _, r := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedRelatedPersonResourcesReferencedByParticipant {
+			rsc := (*e.IncludedRelatedPersonResourcesReferencedByParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*e.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *e.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*e.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedConditionResourcesReferencedByIndication != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByIndication {
+			rsc := (*e.IncludedConditionResourcesReferencedByIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedProcedureResourcesReferencedByIndication != nil {
-		for _, r := range *e.IncludedProcedureResourcesReferencedByIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedProcedureResourcesReferencedByIndication {
+			rsc := (*e.IncludedProcedureResourcesReferencedByIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcedureResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedProcedureResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcedureResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedProcedureResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedListResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedVisionPrescriptionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedVisionPrescriptionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedVisionPrescriptionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcedureRequestResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcedureRequestResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedProcedureRequestResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedFlagResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedFlagResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedFlagResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedFlagResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedObservationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedObservationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedObservationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedObservationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMedicationAdministrationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMedicationAdministrationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedMedicationAdministrationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCommunicationRequestResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCommunicationRequestResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCommunicationRequestResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedRiskAssessmentResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedRiskAssessmentResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedRiskAssessmentResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDiagnosticReportResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDiagnosticReportResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDiagnosticReportResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedNutritionOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedNutritionOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedNutritionOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedEncounterResourcesReferencingPartof != nil {
-		for _, r := range *e.RevIncludedEncounterResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedEncounterResourcesReferencingPartof {
+			rsc := (*e.RevIncludedEncounterResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMedicationOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMedicationOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedMedicationOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCommunicationResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCommunicationResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCommunicationResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedConditionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedConditionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedConditionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedConditionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDiagnosticOrderResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDiagnosticOrderResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedDiagnosticOrderResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/enrollmentrequest.go
+++ b/models/enrollmentrequest.go
@@ -283,13 +283,15 @@ func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedMessageHeaderResou
 func (e *EnrollmentRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*e.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -298,83 +300,99 @@ func (e *EnrollmentRequestPlusRelatedResources) GetIncludedResources() map[strin
 func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -383,93 +401,111 @@ func (e *EnrollmentRequestPlusRelatedResources) GetRevIncludedResources() map[st
 func (e *EnrollmentRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*e.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/enrollmentresponse.go
+++ b/models/enrollmentresponse.go
@@ -264,83 +264,99 @@ func (e *EnrollmentResponsePlusRelatedResources) GetIncludedResources() map[stri
 func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -349,83 +365,99 @@ func (e *EnrollmentResponsePlusRelatedResources) GetRevIncludedResources() map[s
 func (e *EnrollmentResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/episodeofcare.go
+++ b/models/episodeofcare.go
@@ -363,38 +363,45 @@ func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (e *EpisodeOfCarePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*e.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
-		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			rsc := (*e.IncludedReferralRequestResourcesReferencedByIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *e.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*e.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByTeammember != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByTeammember {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedOrganizationResourcesReferencedByTeammember != nil {
-		for _, r := range *e.IncludedOrganizationResourcesReferencedByTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedOrganizationResourcesReferencedByTeammember {
+			rsc := (*e.IncludedOrganizationResourcesReferencedByTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByCaremanager != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByCaremanager)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -403,88 +410,105 @@ func (e *EpisodeOfCarePlusRelatedResources) GetIncludedResources() map[string]in
 func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedEncounterResourcesReferencingEpisodeofcare != nil {
-		for _, r := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
+			rsc := (*e.RevIncludedEncounterResourcesReferencingEpisodeofcare)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -493,123 +517,147 @@ func (e *EpisodeOfCarePlusRelatedResources) GetRevIncludedResources() map[string
 func (e *EpisodeOfCarePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *e.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*e.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedReferralRequestResourcesReferencedByIncomingreferral != nil {
-		for _, r := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedReferralRequestResourcesReferencedByIncomingreferral {
+			rsc := (*e.IncludedReferralRequestResourcesReferencedByIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *e.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*e.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *e.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*e.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByTeammember != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByTeammember {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedOrganizationResourcesReferencedByTeammember != nil {
-		for _, r := range *e.IncludedOrganizationResourcesReferencedByTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedOrganizationResourcesReferencedByTeammember {
+			rsc := (*e.IncludedOrganizationResourcesReferencedByTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.IncludedPractitionerResourcesReferencedByCaremanager != nil {
-		for _, r := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
-			resourceMap[r.Id] = &r
+		for idx := range *e.IncludedPractitionerResourcesReferencedByCaremanager {
+			rsc := (*e.IncludedPractitionerResourcesReferencedByCaremanager)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedEncounterResourcesReferencingEpisodeofcare != nil {
-		for _, r := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedEncounterResourcesReferencingEpisodeofcare {
+			rsc := (*e.RevIncludedEncounterResourcesReferencingEpisodeofcare)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/explanationofbenefit.go
+++ b/models/explanationofbenefit.go
@@ -264,83 +264,99 @@ func (e *ExplanationOfBenefitPlusRelatedResources) GetIncludedResources() map[st
 func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -349,83 +365,99 @@ func (e *ExplanationOfBenefitPlusRelatedResources) GetRevIncludedResources() map
 func (e *ExplanationOfBenefitPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if e.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *e.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*e.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *e.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedListResourcesReferencingItem {
+			rsc := (*e.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*e.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *e.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*e.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*e.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *e.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*e.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *e.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*e.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*e.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*e.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*e.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*e.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*e.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if e.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *e.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *e.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*e.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/familymemberhistory.go
+++ b/models/familymemberhistory.go
@@ -302,8 +302,9 @@ func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedMessageHeaderRes
 func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*f.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -312,88 +313,105 @@ func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedResources() map[str
 func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*f.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *f.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedListResourcesReferencingItem {
+			rsc := (*f.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*f.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*f.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*f.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*f.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*f.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*f.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*f.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*f.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -402,93 +420,111 @@ func (f *FamilyMemberHistoryPlusRelatedResources) GetRevIncludedResources() map[
 func (f *FamilyMemberHistoryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*f.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*f.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *f.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedListResourcesReferencingItem {
+			rsc := (*f.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*f.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*f.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*f.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*f.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*f.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*f.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*f.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*f.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/flag.go
+++ b/models/flag.go
@@ -389,58 +389,69 @@ func (f *FlagPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenci
 func (f *FlagPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*f.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*f.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*f.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*f.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*f.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*f.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*f.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*f.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*f.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*f.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *f.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*f.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -449,83 +460,99 @@ func (f *FlagPlusRelatedResources) GetIncludedResources() map[string]interface{}
 func (f *FlagPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*f.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *f.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedListResourcesReferencingItem {
+			rsc := (*f.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*f.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*f.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*f.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*f.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*f.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*f.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*f.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*f.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -534,138 +561,165 @@ func (f *FlagPlusRelatedResources) GetRevIncludedResources() map[string]interfac
 func (f *FlagPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if f.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*f.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*f.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*f.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*f.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *f.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*f.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*f.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*f.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*f.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*f.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *f.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*f.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *f.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *f.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*f.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *f.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*f.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *f.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedListResourcesReferencingItem {
+			rsc := (*f.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*f.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *f.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*f.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*f.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *f.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*f.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *f.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*f.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*f.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*f.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*f.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*f.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*f.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if f.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *f.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *f.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*f.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/goal.go
+++ b/models/goal.go
@@ -329,23 +329,27 @@ func (g *GoalPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenci
 func (g *GoalPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*g.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*g.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*g.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*g.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -354,88 +358,105 @@ func (g *GoalPlusRelatedResources) GetIncludedResources() map[string]interface{}
 func (g *GoalPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*g.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCarePlanResourcesReferencingGoal != nil {
-		for _, r := range *g.RevIncludedCarePlanResourcesReferencingGoal {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCarePlanResourcesReferencingGoal {
+			rsc := (*g.RevIncludedCarePlanResourcesReferencingGoal)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingItem {
+			rsc := (*g.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*g.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*g.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*g.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*g.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*g.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*g.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*g.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*g.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*g.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -444,108 +465,129 @@ func (g *GoalPlusRelatedResources) GetRevIncludedResources() map[string]interfac
 func (g *GoalPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*g.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*g.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedOrganizationResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedOrganizationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedOrganizationResourcesReferencedBySubject {
+			rsc := (*g.IncludedOrganizationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*g.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*g.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCarePlanResourcesReferencingGoal != nil {
-		for _, r := range *g.RevIncludedCarePlanResourcesReferencingGoal {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCarePlanResourcesReferencingGoal {
+			rsc := (*g.RevIncludedCarePlanResourcesReferencingGoal)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingItem {
+			rsc := (*g.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*g.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*g.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*g.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*g.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*g.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*g.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*g.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*g.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*g.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/group.go
+++ b/models/group.go
@@ -505,28 +505,33 @@ func (g *GroupPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenc
 func (g *GroupPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.IncludedPractitionerResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedPractitionerResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPractitionerResourcesReferencedByMember {
+			rsc := (*g.IncludedPractitionerResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedDeviceResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedDeviceResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedDeviceResourcesReferencedByMember {
+			rsc := (*g.IncludedDeviceResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedMedicationResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedMedicationResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedMedicationResourcesReferencedByMember {
+			rsc := (*g.IncludedMedicationResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedPatientResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedByMember {
+			rsc := (*g.IncludedPatientResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedSubstanceResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedSubstanceResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedSubstanceResourcesReferencedByMember {
+			rsc := (*g.IncludedSubstanceResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -535,168 +540,201 @@ func (g *GroupPlusRelatedResources) GetIncludedResources() map[string]interface{
 func (g *GroupPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*g.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*g.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCarePlanResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCarePlanResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCarePlanResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCarePlanResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*g.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcedureResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedProcedureResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcedureResourcesReferencingSubject {
+			rsc := (*g.RevIncludedProcedureResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingItem {
+			rsc := (*g.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingSubject {
+			rsc := (*g.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*g.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*g.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*g.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
+			rsc := (*g.RevIncludedProcedureRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*g.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*g.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *g.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedContractResourcesReferencingActor {
+			rsc := (*g.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			rsc := (*g.RevIncludedRiskAssessmentResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*g.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*g.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*g.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*g.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*g.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*g.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*g.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*g.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*g.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -705,193 +743,231 @@ func (g *GroupPlusRelatedResources) GetRevIncludedResources() map[string]interfa
 func (g *GroupPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if g.IncludedPractitionerResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedPractitionerResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPractitionerResourcesReferencedByMember {
+			rsc := (*g.IncludedPractitionerResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedDeviceResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedDeviceResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedDeviceResourcesReferencedByMember {
+			rsc := (*g.IncludedDeviceResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedMedicationResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedMedicationResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedMedicationResourcesReferencedByMember {
+			rsc := (*g.IncludedMedicationResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedPatientResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedPatientResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedPatientResourcesReferencedByMember {
+			rsc := (*g.IncludedPatientResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.IncludedSubstanceResourcesReferencedByMember != nil {
-		for _, r := range *g.IncludedSubstanceResourcesReferencedByMember {
-			resourceMap[r.Id] = &r
+		for idx := range *g.IncludedSubstanceResourcesReferencedByMember {
+			rsc := (*g.IncludedSubstanceResourcesReferencedByMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *g.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*g.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*g.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCarePlanResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCarePlanResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCarePlanResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCarePlanResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*g.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcedureResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedProcedureResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcedureResourcesReferencingSubject {
+			rsc := (*g.RevIncludedProcedureResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingItem {
+			rsc := (*g.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedListResourcesReferencingSubject {
+			rsc := (*g.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*g.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*g.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *g.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*g.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*g.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcedureRequestResourcesReferencingSubject {
+			rsc := (*g.RevIncludedProcedureRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*g.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*g.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *g.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedContractResourcesReferencingActor {
+			rsc := (*g.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			rsc := (*g.RevIncludedRiskAssessmentResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*g.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *g.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*g.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*g.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *g.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*g.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*g.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*g.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*g.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*g.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*g.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*g.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if g.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *g.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *g.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*g.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/healthcareservice.go
+++ b/models/healthcareservice.go
@@ -355,13 +355,15 @@ func (h *HealthcareServicePlusRelatedResources) GetRevIncludedMessageHeaderResou
 func (h *HealthcareServicePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if h.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *h.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *h.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*h.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *h.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *h.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*h.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -370,103 +372,123 @@ func (h *HealthcareServicePlusRelatedResources) GetIncludedResources() map[strin
 func (h *HealthcareServicePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if h.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*h.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*h.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *h.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*h.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*h.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*h.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *h.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedListResourcesReferencingItem {
+			rsc := (*h.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*h.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *h.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*h.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*h.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*h.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *h.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*h.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*h.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *h.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*h.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*h.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*h.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*h.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*h.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*h.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*h.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *h.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*h.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -475,113 +497,135 @@ func (h *HealthcareServicePlusRelatedResources) GetRevIncludedResources() map[st
 func (h *HealthcareServicePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if h.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *h.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *h.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*h.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *h.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *h.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*h.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*h.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*h.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *h.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*h.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*h.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*h.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *h.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedListResourcesReferencingItem {
+			rsc := (*h.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*h.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *h.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*h.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*h.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*h.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *h.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*h.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*h.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *h.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*h.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*h.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*h.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*h.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*h.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *h.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*h.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*h.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if h.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *h.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *h.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*h.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/imagingobjectselection.go
+++ b/models/imagingobjectselection.go
@@ -357,33 +357,39 @@ func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedMessageHeader
 func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*i.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*i.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*i.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*i.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -392,83 +398,99 @@ func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedResources() map[
 func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -477,113 +499,135 @@ func (i *ImagingObjectSelectionPlusRelatedResources) GetRevIncludedResources() m
 func (i *ImagingObjectSelectionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedOrganizationResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedOrganizationResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedOrganizationResourcesReferencedByAuthor {
+			rsc := (*i.IncludedOrganizationResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*i.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*i.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*i.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/imagingstudy.go
+++ b/models/imagingstudy.go
@@ -312,13 +312,15 @@ func (i *ImagingStudyPlusRelatedResources) GetRevIncludedMessageHeaderResourcesR
 func (i *ImagingStudyPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedDiagnosticOrderResourcesReferencedByOrder != nil {
-		for _, r := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
+			rsc := (*i.IncludedDiagnosticOrderResourcesReferencedByOrder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -327,83 +329,99 @@ func (i *ImagingStudyPlusRelatedResources) GetIncludedResources() map[string]int
 func (i *ImagingStudyPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -412,93 +430,111 @@ func (i *ImagingStudyPlusRelatedResources) GetRevIncludedResources() map[string]
 func (i *ImagingStudyPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedDiagnosticOrderResourcesReferencedByOrder != nil {
-		for _, r := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedDiagnosticOrderResourcesReferencedByOrder {
+			rsc := (*i.IncludedDiagnosticOrderResourcesReferencedByOrder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/immunization.go
+++ b/models/immunization.go
@@ -377,33 +377,39 @@ func (i *ImmunizationPlusRelatedResources) GetRevIncludedImmunizationRecommendat
 func (i *ImmunizationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedObservationResourcesReferencedByReaction != nil {
-		for _, r := range *i.IncludedObservationResourcesReferencedByReaction {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedObservationResourcesReferencedByReaction {
+			rsc := (*i.IncludedObservationResourcesReferencedByReaction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedOrganizationResourcesReferencedByManufacturer != nil {
-		for _, r := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
+			rsc := (*i.IncludedOrganizationResourcesReferencedByManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *i.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*i.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -412,88 +418,105 @@ func (i *ImmunizationPlusRelatedResources) GetIncludedResources() map[string]int
 func (i *ImmunizationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedImmunizationRecommendationResourcesReferencingSupport != nil {
-		for _, r := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
+			rsc := (*i.RevIncludedImmunizationRecommendationResourcesReferencingSupport)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -502,118 +525,141 @@ func (i *ImmunizationPlusRelatedResources) GetRevIncludedResources() map[string]
 func (i *ImmunizationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *i.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*i.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedObservationResourcesReferencedByReaction != nil {
-		for _, r := range *i.IncludedObservationResourcesReferencedByReaction {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedObservationResourcesReferencedByReaction {
+			rsc := (*i.IncludedObservationResourcesReferencedByReaction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedOrganizationResourcesReferencedByManufacturer != nil {
-		for _, r := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedOrganizationResourcesReferencedByManufacturer {
+			rsc := (*i.IncludedOrganizationResourcesReferencedByManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *i.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*i.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedImmunizationRecommendationResourcesReferencingSupport != nil {
-		for _, r := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedImmunizationRecommendationResourcesReferencingSupport {
+			rsc := (*i.RevIncludedImmunizationRecommendationResourcesReferencingSupport)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/immunizationrecommendation.go
+++ b/models/immunizationrecommendation.go
@@ -320,23 +320,27 @@ func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedMessageHe
 func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedAllergyIntoleranceResourcesReferencedByInformation != nil {
-		for _, r := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
+			rsc := (*i.IncludedAllergyIntoleranceResourcesReferencedByInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedObservationResourcesReferencedByInformation != nil {
-		for _, r := range *i.IncludedObservationResourcesReferencedByInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedObservationResourcesReferencedByInformation {
+			rsc := (*i.IncludedObservationResourcesReferencedByInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedImmunizationResourcesReferencedBySupport != nil {
-		for _, r := range *i.IncludedImmunizationResourcesReferencedBySupport {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedImmunizationResourcesReferencedBySupport {
+			rsc := (*i.IncludedImmunizationResourcesReferencedBySupport)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -345,83 +349,99 @@ func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedResources() 
 func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -430,103 +450,123 @@ func (i *ImmunizationRecommendationPlusRelatedResources) GetRevIncludedResources
 func (i *ImmunizationRecommendationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *i.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*i.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedAllergyIntoleranceResourcesReferencedByInformation != nil {
-		for _, r := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedAllergyIntoleranceResourcesReferencedByInformation {
+			rsc := (*i.IncludedAllergyIntoleranceResourcesReferencedByInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedObservationResourcesReferencedByInformation != nil {
-		for _, r := range *i.IncludedObservationResourcesReferencedByInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedObservationResourcesReferencedByInformation {
+			rsc := (*i.IncludedObservationResourcesReferencedByInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.IncludedImmunizationResourcesReferencedBySupport != nil {
-		for _, r := range *i.IncludedImmunizationResourcesReferencedBySupport {
-			resourceMap[r.Id] = &r
+		for idx := range *i.IncludedImmunizationResourcesReferencedBySupport {
+			rsc := (*i.IncludedImmunizationResourcesReferencedBySupport)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/implementationguide.go
+++ b/models/implementationguide.go
@@ -318,83 +318,99 @@ func (i *ImplementationGuidePlusRelatedResources) GetIncludedResources() map[str
 func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -403,83 +419,99 @@ func (i *ImplementationGuidePlusRelatedResources) GetRevIncludedResources() map[
 func (i *ImplementationGuidePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if i.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *i.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*i.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *i.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedListResourcesReferencingItem {
+			rsc := (*i.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*i.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *i.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*i.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*i.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *i.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*i.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *i.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*i.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*i.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*i.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*i.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*i.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*i.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if i.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *i.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *i.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*i.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/list.go
+++ b/models/list.go
@@ -378,48 +378,57 @@ func (l *ListPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenci
 func (l *ListPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*l.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*l.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*l.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*l.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*l.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*l.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*l.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedBySource {
+			rsc := (*l.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *l.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*l.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -428,83 +437,99 @@ func (l *ListPlusRelatedResources) GetIncludedResources() map[string]interface{}
 func (l *ListPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingItem {
+			rsc := (*l.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*l.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*l.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*l.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*l.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*l.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*l.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*l.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*l.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*l.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -513,128 +538,153 @@ func (l *ListPlusRelatedResources) GetRevIncludedResources() map[string]interfac
 func (l *ListPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*l.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*l.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*l.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *l.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*l.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*l.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*l.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedDeviceResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedDeviceResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedDeviceResourcesReferencedBySource {
+			rsc := (*l.IncludedDeviceResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *l.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedPatientResourcesReferencedBySource {
+			rsc := (*l.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *l.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*l.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingItem {
+			rsc := (*l.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*l.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*l.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*l.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*l.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*l.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*l.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*l.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*l.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*l.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/location.go
+++ b/models/location.go
@@ -502,13 +502,15 @@ func (l *LocationPlusRelatedResources) GetRevIncludedLocationResourcesReferencin
 func (l *LocationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.IncludedLocationResourcesReferencedByPartof != nil {
-		for _, r := range *l.IncludedLocationResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedLocationResourcesReferencedByPartof {
+			rsc := (*l.IncludedLocationResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *l.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*l.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -517,188 +519,225 @@ func (l *LocationPlusRelatedResources) GetIncludedResources() map[string]interfa
 func (l *LocationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*l.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedAppointmentResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResourcesReferencingLocation {
+			rsc := (*l.RevIncludedAppointmentResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*l.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProvenanceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcedureResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedProcedureResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcedureResourcesReferencingLocation {
+			rsc := (*l.RevIncludedProcedureResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingItem {
+			rsc := (*l.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingSubject {
+			rsc := (*l.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*l.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedImmunizationResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedImmunizationResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedImmunizationResourcesReferencingLocation {
+			rsc := (*l.RevIncludedImmunizationResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDeviceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedDeviceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDeviceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedDeviceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*l.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedPractitionerResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedPractitionerResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedPractitionerResourcesReferencingLocation {
+			rsc := (*l.RevIncludedPractitionerResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*l.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResponseResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
+			rsc := (*l.RevIncludedAppointmentResponseResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*l.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedContractResourcesReferencingActor {
+			rsc := (*l.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*l.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMedicationDispenseResourcesReferencingDestination != nil {
-		for _, r := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
+			rsc := (*l.RevIncludedMedicationDispenseResourcesReferencingDestination)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*l.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedHealthcareServiceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedHealthcareServiceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedEncounterResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedEncounterResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedEncounterResourcesReferencingLocation {
+			rsc := (*l.RevIncludedEncounterResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*l.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*l.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*l.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*l.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*l.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*l.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*l.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*l.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*l.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedLocationResourcesReferencingPartof != nil {
-		for _, r := range *l.RevIncludedLocationResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedLocationResourcesReferencingPartof {
+			rsc := (*l.RevIncludedLocationResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -707,198 +746,237 @@ func (l *LocationPlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (l *LocationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if l.IncludedLocationResourcesReferencedByPartof != nil {
-		for _, r := range *l.IncludedLocationResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedLocationResourcesReferencedByPartof {
+			rsc := (*l.IncludedLocationResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *l.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *l.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*l.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*l.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedAppointmentResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResourcesReferencingLocation {
+			rsc := (*l.RevIncludedAppointmentResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*l.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProvenanceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *l.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*l.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcedureResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedProcedureResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcedureResourcesReferencingLocation {
+			rsc := (*l.RevIncludedProcedureResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingItem {
+			rsc := (*l.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedListResourcesReferencingSubject {
+			rsc := (*l.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*l.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *l.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*l.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedImmunizationResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedImmunizationResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedImmunizationResourcesReferencingLocation {
+			rsc := (*l.RevIncludedImmunizationResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDeviceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedDeviceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDeviceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedDeviceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*l.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedPractitionerResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedPractitionerResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedPractitionerResourcesReferencingLocation {
+			rsc := (*l.RevIncludedPractitionerResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*l.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAppointmentResponseResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAppointmentResponseResourcesReferencingLocation {
+			rsc := (*l.RevIncludedAppointmentResponseResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*l.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedContractResourcesReferencingActor {
+			rsc := (*l.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*l.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMedicationDispenseResourcesReferencingDestination != nil {
-		for _, r := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMedicationDispenseResourcesReferencingDestination {
+			rsc := (*l.RevIncludedMedicationDispenseResourcesReferencingDestination)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*l.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedHealthcareServiceResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedHealthcareServiceResourcesReferencingLocation {
+			rsc := (*l.RevIncludedHealthcareServiceResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedEncounterResourcesReferencingLocation != nil {
-		for _, r := range *l.RevIncludedEncounterResourcesReferencingLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedEncounterResourcesReferencingLocation {
+			rsc := (*l.RevIncludedEncounterResourcesReferencingLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *l.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*l.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *l.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*l.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*l.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*l.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*l.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*l.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*l.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *l.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*l.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*l.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *l.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*l.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if l.RevIncludedLocationResourcesReferencingPartof != nil {
-		for _, r := range *l.RevIncludedLocationResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *l.RevIncludedLocationResourcesReferencingPartof {
+			rsc := (*l.RevIncludedLocationResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/media.go
+++ b/models/media.go
@@ -355,38 +355,45 @@ func (m *MediaPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenc
 func (m *MediaPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*m.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*m.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedSpecimenResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedSpecimenResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedSpecimenResourcesReferencedBySubject {
+			rsc := (*m.IncludedSpecimenResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*m.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*m.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByOperator != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByOperator {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByOperator {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByOperator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -395,88 +402,105 @@ func (m *MediaPlusRelatedResources) GetIncludedResources() map[string]interface{
 func (m *MediaPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDiagnosticReportResourcesReferencingImage != nil {
-		for _, r := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
+			rsc := (*m.RevIncludedDiagnosticReportResourcesReferencingImage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -485,123 +509,147 @@ func (m *MediaPlusRelatedResources) GetRevIncludedResources() map[string]interfa
 func (m *MediaPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedBySubject {
+			rsc := (*m.IncludedPractitionerResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*m.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedSpecimenResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedSpecimenResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedSpecimenResourcesReferencedBySubject {
+			rsc := (*m.IncludedSpecimenResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*m.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*m.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByOperator != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByOperator {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByOperator {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByOperator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDiagnosticReportResourcesReferencingImage != nil {
-		for _, r := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDiagnosticReportResourcesReferencingImage {
+			rsc := (*m.RevIncludedDiagnosticReportResourcesReferencingImage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/medication.go
+++ b/models/medication.go
@@ -403,23 +403,27 @@ func (m *MedicationPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRef
 func (m *MedicationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedMedicationResourcesReferencedByIngredient != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByIngredient {
+			rsc := (*m.IncludedMedicationResourcesReferencedByIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedSubstanceResourcesReferencedByIngredient != nil {
-		for _, r := range *m.IncludedSubstanceResourcesReferencedByIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedSubstanceResourcesReferencedByIngredient {
+			rsc := (*m.IncludedSubstanceResourcesReferencedByIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByContent != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByContent {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByContent {
+			rsc := (*m.IncludedMedicationResourcesReferencedByContent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByManufacturer != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -428,118 +432,141 @@ func (m *MedicationPlusRelatedResources) GetIncludedResources() map[string]inter
 func (m *MedicationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationResourcesReferencingIngredient != nil {
-		for _, r := range *m.RevIncludedMedicationResourcesReferencingIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationResourcesReferencingIngredient {
+			rsc := (*m.RevIncludedMedicationResourcesReferencingIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationResourcesReferencingContent != nil {
-		for _, r := range *m.RevIncludedMedicationResourcesReferencingContent {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationResourcesReferencingContent {
+			rsc := (*m.RevIncludedMedicationResourcesReferencingContent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationAdministrationResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationAdministrationResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationStatementResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationStatementResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *m.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*m.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationDispenseResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationDispenseResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationOrderResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationOrderResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -548,138 +575,165 @@ func (m *MedicationPlusRelatedResources) GetRevIncludedResources() map[string]in
 func (m *MedicationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedMedicationResourcesReferencedByIngredient != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByIngredient {
+			rsc := (*m.IncludedMedicationResourcesReferencedByIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedSubstanceResourcesReferencedByIngredient != nil {
-		for _, r := range *m.IncludedSubstanceResourcesReferencedByIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedSubstanceResourcesReferencedByIngredient {
+			rsc := (*m.IncludedSubstanceResourcesReferencedByIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByContent != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByContent {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByContent {
+			rsc := (*m.IncludedMedicationResourcesReferencedByContent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByManufacturer != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByManufacturer {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationResourcesReferencingIngredient != nil {
-		for _, r := range *m.RevIncludedMedicationResourcesReferencingIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationResourcesReferencingIngredient {
+			rsc := (*m.RevIncludedMedicationResourcesReferencingIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationResourcesReferencingContent != nil {
-		for _, r := range *m.RevIncludedMedicationResourcesReferencingContent {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationResourcesReferencingContent {
+			rsc := (*m.RevIncludedMedicationResourcesReferencingContent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationAdministrationResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationAdministrationResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationAdministrationResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationStatementResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationStatementResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationStatementResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *m.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*m.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationDispenseResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationDispenseResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationDispenseResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationOrderResourcesReferencingMedication != nil {
-		for _, r := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationOrderResourcesReferencingMedication {
+			rsc := (*m.RevIncludedMedicationOrderResourcesReferencingMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/medicationadministration.go
+++ b/models/medicationadministration.go
@@ -371,43 +371,51 @@ func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedMessageHead
 func (m *MedicationAdministrationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
-		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			rsc := (*m.IncludedMedicationOrderResourcesReferencedByPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedPatientResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedRelatedPersonResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedRelatedPersonResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*m.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*m.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -416,83 +424,99 @@ func (m *MedicationAdministrationPlusRelatedResources) GetIncludedResources() ma
 func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -501,123 +525,147 @@ func (m *MedicationAdministrationPlusRelatedResources) GetRevIncludedResources()
 func (m *MedicationAdministrationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
-		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			rsc := (*m.IncludedMedicationOrderResourcesReferencedByPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedPatientResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedRelatedPersonResourcesReferencedByPractitioner != nil {
-		for _, r := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedRelatedPersonResourcesReferencedByPractitioner {
+			rsc := (*m.IncludedRelatedPersonResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*m.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*m.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/medicationdispense.go
+++ b/models/medicationdispense.go
@@ -379,43 +379,51 @@ func (m *MedicationDispensePlusRelatedResources) GetRevIncludedMessageHeaderReso
 func (m *MedicationDispensePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPatientResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedLocationResourcesReferencedByDestination != nil {
-		for _, r := range *m.IncludedLocationResourcesReferencedByDestination {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedLocationResourcesReferencedByDestination {
+			rsc := (*m.IncludedLocationResourcesReferencedByDestination)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByResponsibleparty != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByResponsibleparty)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByDispenser != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByDispenser {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByDispenser {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByDispenser)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
-		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			rsc := (*m.IncludedMedicationOrderResourcesReferencedByPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -424,83 +432,99 @@ func (m *MedicationDispensePlusRelatedResources) GetIncludedResources() map[stri
 func (m *MedicationDispensePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -509,123 +533,147 @@ func (m *MedicationDispensePlusRelatedResources) GetRevIncludedResources() map[s
 func (m *MedicationDispensePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPatientResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedLocationResourcesReferencedByDestination != nil {
-		for _, r := range *m.IncludedLocationResourcesReferencedByDestination {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedLocationResourcesReferencedByDestination {
+			rsc := (*m.IncludedLocationResourcesReferencedByDestination)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByResponsibleparty != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByResponsibleparty {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByResponsibleparty)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByDispenser != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByDispenser {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByDispenser {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByDispenser)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationOrderResourcesReferencedByPrescription != nil {
-		for _, r := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationOrderResourcesReferencedByPrescription {
+			rsc := (*m.IncludedMedicationOrderResourcesReferencedByPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/medicationorder.go
+++ b/models/medicationorder.go
@@ -398,23 +398,27 @@ func (m *MedicationOrderPlusRelatedResources) GetRevIncludedMessageHeaderResourc
 func (m *MedicationOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByPrescriber != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*m.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -423,108 +427,129 @@ func (m *MedicationOrderPlusRelatedResources) GetIncludedResources() map[string]
 func (m *MedicationOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*m.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationAdministrationResourcesReferencingPrescription != nil {
-		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
+			rsc := (*m.RevIncludedMedicationAdministrationResourcesReferencingPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationDispenseResourcesReferencingPrescription != nil {
-		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
+			rsc := (*m.RevIncludedMedicationDispenseResourcesReferencingPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -533,128 +558,153 @@ func (m *MedicationOrderPlusRelatedResources) GetRevIncludedResources() map[stri
 func (m *MedicationOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByPrescriber != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByPrescriber {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *m.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*m.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*m.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationAdministrationResourcesReferencingPrescription != nil {
-		for _, r := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationAdministrationResourcesReferencingPrescription {
+			rsc := (*m.RevIncludedMedicationAdministrationResourcesReferencingPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMedicationDispenseResourcesReferencingPrescription != nil {
-		for _, r := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMedicationDispenseResourcesReferencingPrescription {
+			rsc := (*m.RevIncludedMedicationDispenseResourcesReferencingPrescription)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/medicationstatement.go
+++ b/models/medicationstatement.go
@@ -342,28 +342,33 @@ func (m *MedicationStatementPlusRelatedResources) GetRevIncludedMessageHeaderRes
 func (m *MedicationStatementPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*m.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedBySource {
+			rsc := (*m.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedRelatedPersonResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedRelatedPersonResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedRelatedPersonResourcesReferencedBySource {
+			rsc := (*m.IncludedRelatedPersonResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -372,83 +377,99 @@ func (m *MedicationStatementPlusRelatedResources) GetIncludedResources() map[str
 func (m *MedicationStatementPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -457,108 +478,129 @@ func (m *MedicationStatementPlusRelatedResources) GetRevIncludedResources() map[
 func (m *MedicationStatementPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*m.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedMedicationResourcesReferencedByMedication != nil {
-		for _, r := range *m.IncludedMedicationResourcesReferencedByMedication {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedMedicationResourcesReferencedByMedication {
+			rsc := (*m.IncludedMedicationResourcesReferencedByMedication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*m.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPatientResourcesReferencedBySource {
+			rsc := (*m.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedRelatedPersonResourcesReferencedBySource != nil {
-		for _, r := range *m.IncludedRelatedPersonResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedRelatedPersonResourcesReferencedBySource {
+			rsc := (*m.IncludedRelatedPersonResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/messageheader.go
+++ b/models/messageheader.go
@@ -377,38 +377,45 @@ func (m *MessageHeaderPlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (m *MessageHeaderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByReceiver {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedByTarget != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedByTarget {
+			rsc := (*m.IncludedDeviceResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByResponsible != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByResponsible {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByResponsible != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByResponsible {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByEnterer != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByEnterer {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByEnterer {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByEnterer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -417,88 +424,105 @@ func (m *MessageHeaderPlusRelatedResources) GetIncludedResources() map[string]in
 func (m *MessageHeaderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBundleResourcesReferencingMessage != nil {
-		for _, r := range *m.RevIncludedBundleResourcesReferencingMessage {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBundleResourcesReferencingMessage {
+			rsc := (*m.RevIncludedBundleResourcesReferencingMessage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -507,123 +531,147 @@ func (m *MessageHeaderPlusRelatedResources) GetRevIncludedResources() map[string
 func (m *MessageHeaderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if m.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByReceiver != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByReceiver {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedDeviceResourcesReferencedByTarget != nil {
-		for _, r := range *m.IncludedDeviceResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedDeviceResourcesReferencedByTarget {
+			rsc := (*m.IncludedDeviceResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByResponsible != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByResponsible {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedOrganizationResourcesReferencedByResponsible != nil {
-		for _, r := range *m.IncludedOrganizationResourcesReferencedByResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedOrganizationResourcesReferencedByResponsible {
+			rsc := (*m.IncludedOrganizationResourcesReferencedByResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.IncludedPractitionerResourcesReferencedByEnterer != nil {
-		for _, r := range *m.IncludedPractitionerResourcesReferencedByEnterer {
-			resourceMap[r.Id] = &r
+		for idx := range *m.IncludedPractitionerResourcesReferencedByEnterer {
+			rsc := (*m.IncludedPractitionerResourcesReferencedByEnterer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *m.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*m.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *m.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedListResourcesReferencingItem {
+			rsc := (*m.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*m.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *m.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*m.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*m.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *m.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*m.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *m.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*m.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*m.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedBundleResourcesReferencingMessage != nil {
-		for _, r := range *m.RevIncludedBundleResourcesReferencingMessage {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedBundleResourcesReferencingMessage {
+			rsc := (*m.RevIncludedBundleResourcesReferencingMessage)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*m.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*m.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*m.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*m.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if m.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *m.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *m.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*m.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/namingsystem.go
+++ b/models/namingsystem.go
@@ -298,8 +298,9 @@ func (n *NamingSystemPlusRelatedResources) GetRevIncludedMessageHeaderResourcesR
 func (n *NamingSystemPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.IncludedNamingSystemResourcesReferencedByReplacedby != nil {
-		for _, r := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
+			rsc := (*n.IncludedNamingSystemResourcesReferencedByReplacedby)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -308,88 +309,105 @@ func (n *NamingSystemPlusRelatedResources) GetIncludedResources() map[string]int
 func (n *NamingSystemPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*n.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *n.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedListResourcesReferencingItem {
+			rsc := (*n.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*n.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*n.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*n.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*n.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*n.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*n.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*n.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedNamingSystemResourcesReferencingReplacedby != nil {
-		for _, r := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
+			rsc := (*n.RevIncludedNamingSystemResourcesReferencingReplacedby)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*n.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -398,93 +416,111 @@ func (n *NamingSystemPlusRelatedResources) GetRevIncludedResources() map[string]
 func (n *NamingSystemPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.IncludedNamingSystemResourcesReferencedByReplacedby != nil {
-		for _, r := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedNamingSystemResourcesReferencedByReplacedby {
+			rsc := (*n.IncludedNamingSystemResourcesReferencedByReplacedby)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*n.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *n.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedListResourcesReferencingItem {
+			rsc := (*n.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*n.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*n.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*n.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*n.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*n.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*n.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*n.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedNamingSystemResourcesReferencingReplacedby != nil {
-		for _, r := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedNamingSystemResourcesReferencingReplacedby {
+			rsc := (*n.RevIncludedNamingSystemResourcesReferencingReplacedby)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*n.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/nutritionorder.go
+++ b/models/nutritionorder.go
@@ -379,18 +379,21 @@ func (n *NutritionOrderPlusRelatedResources) GetRevIncludedMessageHeaderResource
 func (n *NutritionOrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *n.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*n.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *n.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*n.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *n.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*n.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -399,98 +402,117 @@ func (n *NutritionOrderPlusRelatedResources) GetIncludedResources() map[string]i
 func (n *NutritionOrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*n.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*n.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *n.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedListResourcesReferencingItem {
+			rsc := (*n.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*n.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*n.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*n.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*n.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*n.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*n.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*n.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*n.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -499,113 +521,135 @@ func (n *NutritionOrderPlusRelatedResources) GetRevIncludedResources() map[strin
 func (n *NutritionOrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if n.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *n.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*n.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *n.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*n.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *n.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *n.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*n.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *n.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*n.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*n.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *n.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedListResourcesReferencingItem {
+			rsc := (*n.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*n.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *n.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*n.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*n.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *n.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*n.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *n.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*n.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*n.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*n.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*n.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*n.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*n.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if n.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *n.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *n.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*n.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/observation.go
+++ b/models/observation.go
@@ -533,78 +533,93 @@ func (o *ObservationPlusRelatedResources) GetRevIncludedImmunizationRecommendati
 func (o *ObservationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*o.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*o.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*o.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*o.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*o.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedSpecimenResourcesReferencedBySpecimen != nil {
-		for _, r := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
+			rsc := (*o.IncludedSpecimenResourcesReferencedBySpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*o.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*o.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *o.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*o.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedObservationResourcesReferencedByRelatedtarget != nil {
-		for _, r := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
+			rsc := (*o.IncludedObservationResourcesReferencedByRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget != nil {
-		for _, r := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
+			rsc := (*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*o.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceMetricResourcesReferencedByDevice != nil {
-		for _, r := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
+			rsc := (*o.IncludedDeviceMetricResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -613,108 +628,129 @@ func (o *ObservationPlusRelatedResources) GetIncludedResources() map[string]inte
 func (o *ObservationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationResourcesReferencingReaction != nil {
-		for _, r := range *o.RevIncludedImmunizationResourcesReferencingReaction {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationResourcesReferencingReaction {
+			rsc := (*o.RevIncludedImmunizationResourcesReferencingReaction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
-		for _, r := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
+			rsc := (*o.RevIncludedObservationResourcesReferencingRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDiagnosticReportResourcesReferencingResult != nil {
-		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
+			rsc := (*o.RevIncludedDiagnosticReportResourcesReferencingResult)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
-		for _, r := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			rsc := (*o.RevIncludedImmunizationRecommendationResourcesReferencingInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -723,183 +759,219 @@ func (o *ObservationPlusRelatedResources) GetRevIncludedResources() map[string]i
 func (o *ObservationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*o.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*o.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*o.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedLocationResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedLocationResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedLocationResourcesReferencedBySubject {
+			rsc := (*o.IncludedLocationResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*o.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedSpecimenResourcesReferencedBySpecimen != nil {
-		for _, r := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedSpecimenResourcesReferencedBySpecimen {
+			rsc := (*o.IncludedSpecimenResourcesReferencedBySpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*o.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*o.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *o.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*o.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedObservationResourcesReferencedByRelatedtarget != nil {
-		for _, r := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedObservationResourcesReferencedByRelatedtarget {
+			rsc := (*o.IncludedObservationResourcesReferencedByRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget != nil {
-		for _, r := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget {
+			rsc := (*o.IncludedQuestionnaireResponseResourcesReferencedByRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByDevice != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByDevice {
+			rsc := (*o.IncludedDeviceResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceMetricResourcesReferencedByDevice != nil {
-		for _, r := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceMetricResourcesReferencedByDevice {
+			rsc := (*o.IncludedDeviceMetricResourcesReferencedByDevice)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationResourcesReferencingReaction != nil {
-		for _, r := range *o.RevIncludedImmunizationResourcesReferencingReaction {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationResourcesReferencingReaction {
+			rsc := (*o.RevIncludedImmunizationResourcesReferencingReaction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
-		for _, r := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedObservationResourcesReferencingRelatedtarget {
+			rsc := (*o.RevIncludedObservationResourcesReferencingRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDiagnosticReportResourcesReferencingResult != nil {
-		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDiagnosticReportResourcesReferencingResult {
+			rsc := (*o.RevIncludedDiagnosticReportResourcesReferencingResult)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationRecommendationResourcesReferencingInformation != nil {
-		for _, r := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationRecommendationResourcesReferencingInformation {
+			rsc := (*o.RevIncludedImmunizationRecommendationResourcesReferencingInformation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/operationdefinition.go
+++ b/models/operationdefinition.go
@@ -328,13 +328,15 @@ func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedMessageHeaderRes
 func (o *OperationDefinitionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
-		for _, r := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
+			rsc := (*o.IncludedStructureDefinitionResourcesReferencedByProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOperationDefinitionResourcesReferencedByBase != nil {
-		for _, r := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
+			rsc := (*o.IncludedOperationDefinitionResourcesReferencedByBase)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -343,88 +345,105 @@ func (o *OperationDefinitionPlusRelatedResources) GetIncludedResources() map[str
 func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOperationDefinitionResourcesReferencingBase != nil {
-		for _, r := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
+			rsc := (*o.RevIncludedOperationDefinitionResourcesReferencingBase)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -433,98 +452,117 @@ func (o *OperationDefinitionPlusRelatedResources) GetRevIncludedResources() map[
 func (o *OperationDefinitionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedStructureDefinitionResourcesReferencedByProfile != nil {
-		for _, r := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedStructureDefinitionResourcesReferencedByProfile {
+			rsc := (*o.IncludedStructureDefinitionResourcesReferencedByProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOperationDefinitionResourcesReferencedByBase != nil {
-		for _, r := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOperationDefinitionResourcesReferencedByBase {
+			rsc := (*o.IncludedOperationDefinitionResourcesReferencedByBase)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOperationDefinitionResourcesReferencingBase != nil {
-		for _, r := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOperationDefinitionResourcesReferencingBase {
+			rsc := (*o.RevIncludedOperationDefinitionResourcesReferencingBase)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/operationoutcome.go
+++ b/models/operationoutcome.go
@@ -264,83 +264,99 @@ func (o *OperationOutcomePlusRelatedResources) GetIncludedResources() map[string
 func (o *OperationOutcomePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -349,83 +365,99 @@ func (o *OperationOutcomePlusRelatedResources) GetRevIncludedResources() map[str
 func (o *OperationOutcomePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/order.go
+++ b/models/order.go
@@ -414,53 +414,63 @@ func (o *OrderPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenc
 func (o *OrderPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*o.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*o.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*o.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedSubstanceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedSubstanceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedSubstanceResourcesReferencedBySubject {
+			rsc := (*o.IncludedSubstanceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*o.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*o.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedBySource != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedBySource {
+			rsc := (*o.IncludedOrganizationResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByTarget {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByTarget {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByTarget {
+			rsc := (*o.IncludedDeviceResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -469,98 +479,117 @@ func (o *OrderPlusRelatedResources) GetIncludedResources() map[string]interface{
 func (o *OrderPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -569,148 +598,177 @@ func (o *OrderPlusRelatedResources) GetRevIncludedResources() map[string]interfa
 func (o *OrderPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*o.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*o.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*o.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedSubstanceResourcesReferencedBySubject != nil {
-		for _, r := range *o.IncludedSubstanceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedSubstanceResourcesReferencedBySubject {
+			rsc := (*o.IncludedSubstanceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *o.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*o.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*o.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedBySource != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedBySource {
+			rsc := (*o.IncludedOrganizationResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByTarget {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByTarget {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByTarget != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByTarget {
+			rsc := (*o.IncludedDeviceResourcesReferencedByTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/orderresponse.go
+++ b/models/orderresponse.go
@@ -304,23 +304,27 @@ func (o *OrderResponsePlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (o *OrderResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedOrderResourcesReferencedByRequest != nil {
-		for _, r := range *o.IncludedOrderResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrderResourcesReferencedByRequest {
+			rsc := (*o.IncludedOrderResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByWho {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByWho {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByWho {
+			rsc := (*o.IncludedDeviceResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -329,83 +333,99 @@ func (o *OrderResponsePlusRelatedResources) GetIncludedResources() map[string]in
 func (o *OrderResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -414,103 +434,123 @@ func (o *OrderResponsePlusRelatedResources) GetRevIncludedResources() map[string
 func (o *OrderResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedOrderResourcesReferencedByRequest != nil {
-		for _, r := range *o.IncludedOrderResourcesReferencedByRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrderResourcesReferencedByRequest {
+			rsc := (*o.IncludedOrderResourcesReferencedByRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedPractitionerResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedPractitionerResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedPractitionerResourcesReferencedByWho {
+			rsc := (*o.IncludedPractitionerResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedOrganizationResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByWho {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.IncludedDeviceResourcesReferencedByWho != nil {
-		for _, r := range *o.IncludedDeviceResourcesReferencedByWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedDeviceResourcesReferencedByWho {
+			rsc := (*o.IncludedDeviceResourcesReferencedByWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/organization.go
+++ b/models/organization.go
@@ -787,8 +787,9 @@ func (o *OrganizationPlusRelatedResources) GetRevIncludedLocationResourcesRefere
 func (o *OrganizationPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedOrganizationResourcesReferencedByPartof != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByPartof {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -797,338 +798,405 @@ func (o *OrganizationPlusRelatedResources) GetIncludedResources() map[string]int
 func (o *OrganizationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*o.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedReferralRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAccountResourcesReferencingOwner != nil {
-		for _, r := range *o.RevIncludedAccountResourcesReferencingOwner {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAccountResourcesReferencingOwner {
+			rsc := (*o.RevIncludedAccountResourcesReferencingOwner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*o.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*o.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedEpisodeOfCareResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedEpisodeOfCareResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
-		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			rsc := (*o.RevIncludedEpisodeOfCareResourcesReferencingTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMedicationResourcesReferencingManufacturer != nil {
-		for _, r := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
+			rsc := (*o.RevIncludedMedicationResourcesReferencingManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingCustodian != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingCustodian)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingSource != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingSource {
+			rsc := (*o.RevIncludedOrderResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*o.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationResourcesReferencingManufacturer != nil {
-		for _, r := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
+			rsc := (*o.RevIncludedImmunizationResourcesReferencingManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDeviceResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedDeviceResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDeviceResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedDeviceResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*o.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedSupplyRequestResourcesReferencingSupplier != nil {
-		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
+			rsc := (*o.RevIncludedSupplyRequestResourcesReferencingSupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*o.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPractitionerResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPractitionerResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPersonResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPersonResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPersonResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPersonResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *o.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedContractResourcesReferencingActor {
+			rsc := (*o.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *o.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*o.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*o.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrganizationResourcesReferencingPartof != nil {
-		for _, r := range *o.RevIncludedOrganizationResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrganizationResourcesReferencingPartof {
+			rsc := (*o.RevIncludedOrganizationResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessRequestResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedProcessRequestResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedDiagnosticReportResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedHealthcareServiceResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedHealthcareServiceResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *o.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*o.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPatientResourcesReferencingCareprovider != nil {
-		for _, r := range *o.RevIncludedPatientResourcesReferencingCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPatientResourcesReferencingCareprovider {
+			rsc := (*o.RevIncludedPatientResourcesReferencingCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPatientResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPatientResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPatientResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPatientResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCoverageResourcesReferencingIssuer != nil {
-		for _, r := range *o.RevIncludedCoverageResourcesReferencingIssuer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCoverageResourcesReferencingIssuer {
+			rsc := (*o.RevIncludedCoverageResourcesReferencingIssuer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequestorganization != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequestorganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedLocationResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedLocationResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedLocationResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedLocationResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -1137,343 +1205,411 @@ func (o *OrganizationPlusRelatedResources) GetRevIncludedResources() map[string]
 func (o *OrganizationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if o.IncludedOrganizationResourcesReferencedByPartof != nil {
-		for _, r := range *o.IncludedOrganizationResourcesReferencedByPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *o.IncludedOrganizationResourcesReferencedByPartof {
+			rsc := (*o.IncludedOrganizationResourcesReferencedByPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*o.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedReferralRequestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedReferralRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAccountResourcesReferencingOwner != nil {
-		for _, r := range *o.RevIncludedAccountResourcesReferencingOwner {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAccountResourcesReferencingOwner {
+			rsc := (*o.RevIncludedAccountResourcesReferencingOwner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*o.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*o.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*o.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*o.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedEpisodeOfCareResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedEpisodeOfCareResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedEpisodeOfCareResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
-		for _, r := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			rsc := (*o.RevIncludedEpisodeOfCareResourcesReferencingTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMedicationResourcesReferencingManufacturer != nil {
-		for _, r := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMedicationResourcesReferencingManufacturer {
+			rsc := (*o.RevIncludedMedicationResourcesReferencingManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *o.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedListResourcesReferencingItem {
+			rsc := (*o.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingCustodian != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingCustodian {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingCustodian)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*o.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingSource != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingSource {
+			rsc := (*o.RevIncludedOrderResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*o.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *o.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*o.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImmunizationResourcesReferencingManufacturer != nil {
-		for _, r := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImmunizationResourcesReferencingManufacturer {
+			rsc := (*o.RevIncludedImmunizationResourcesReferencingManufacturer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDeviceResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedDeviceResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDeviceResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedDeviceResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*o.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedSupplyRequestResourcesReferencingSupplier != nil {
-		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedSupplyRequestResourcesReferencingSupplier {
+			rsc := (*o.RevIncludedSupplyRequestResourcesReferencingSupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*o.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPractitionerResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPractitionerResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPractitionerResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPersonResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPersonResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPersonResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPersonResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *o.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedContractResourcesReferencingActor {
+			rsc := (*o.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *o.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*o.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*o.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*o.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrganizationResourcesReferencingPartof != nil {
-		for _, r := range *o.RevIncludedOrganizationResourcesReferencingPartof {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrganizationResourcesReferencingPartof {
+			rsc := (*o.RevIncludedOrganizationResourcesReferencingPartof)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessRequestResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessRequestResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedProcessRequestResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
-		for _, r := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			rsc := (*o.RevIncludedDiagnosticReportResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*o.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedHealthcareServiceResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedHealthcareServiceResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedHealthcareServiceResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *o.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*o.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *o.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*o.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*o.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *o.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*o.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*o.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPatientResourcesReferencingCareprovider != nil {
-		for _, r := range *o.RevIncludedPatientResourcesReferencingCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPatientResourcesReferencingCareprovider {
+			rsc := (*o.RevIncludedPatientResourcesReferencingCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedPatientResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedPatientResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedPatientResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedPatientResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *o.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*o.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedCoverageResourcesReferencingIssuer != nil {
-		for _, r := range *o.RevIncludedCoverageResourcesReferencingIssuer {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedCoverageResourcesReferencingIssuer {
+			rsc := (*o.RevIncludedCoverageResourcesReferencingIssuer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*o.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedProcessResponseResourcesReferencingRequestorganization != nil {
-		for _, r := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedProcessResponseResourcesReferencingRequestorganization {
+			rsc := (*o.RevIncludedProcessResponseResourcesReferencingRequestorganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*o.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
-		for _, r := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			rsc := (*o.RevIncludedMessageHeaderResourcesReferencingResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if o.RevIncludedLocationResourcesReferencingOrganization != nil {
-		for _, r := range *o.RevIncludedLocationResourcesReferencingOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *o.RevIncludedLocationResourcesReferencingOrganization {
+			rsc := (*o.RevIncludedLocationResourcesReferencingOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/patient.go
+++ b/models/patient.go
@@ -1512,23 +1512,27 @@ func (p *PatientPlusRelatedResources) GetRevIncludedBodySiteResourcesReferencing
 func (p *PatientPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPatientResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByLink {
+			rsc := (*p.IncludedPatientResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByCareprovider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByCareprovider != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -1537,668 +1541,801 @@ func (p *PatientPlusRelatedResources) GetIncludedResources() map[string]interfac
 func (p *PatientPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*p.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAccountResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGoalResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedGoalResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGoalResourcesReferencingPatient {
+			rsc := (*p.RevIncludedGoalResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*p.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEnrollmentRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedEnrollmentRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEnrollmentRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEnrollmentRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingSubject {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSubject {
+			rsc := (*p.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingPatient {
+			rsc := (*p.RevIncludedListResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSource {
+			rsc := (*p.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*p.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedVisionPrescriptionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedVisionPrescriptionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*p.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMediaResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDeviceUseRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceUseRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*p.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingPatient {
+			rsc := (*p.RevIncludedFlagResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRelatedPersonResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
+			rsc := (*p.RevIncludedRelatedPersonResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*p.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingPatient {
+			rsc := (*p.RevIncludedPersonResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingActor {
+			rsc := (*p.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSubject {
+			rsc := (*p.RevIncludedContractResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingPatient {
+			rsc := (*p.RevIncludedContractResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*p.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingPatient {
+			rsc := (*p.RevIncludedBasicResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*p.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingStudyResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImagingStudyResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
+			rsc := (*p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedNutritionOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedNutritionOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingPatientPath1 != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingPatientPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingPatientPath2 != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingPatientPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			rsc := (*p.RevIncludedConditionResourcesReferencingAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedConditionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPatientResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPatientResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPatientResourcesReferencingLink {
+			rsc := (*p.RevIncludedPatientResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseStatementResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDeviceUseStatementResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseStatementResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceUseStatementResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*p.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClaimResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedClaimResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClaimResourcesReferencingPatient {
+			rsc := (*p.RevIncludedClaimResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationRecommendationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImmunizationRecommendationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBodySiteResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedBodySiteResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBodySiteResourcesReferencingPatient {
+			rsc := (*p.RevIncludedBodySiteResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -2207,688 +2344,825 @@ func (p *PatientPlusRelatedResources) GetRevIncludedResources() map[string]inter
 func (p *PatientPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPatientResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByLink {
+			rsc := (*p.IncludedPatientResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByCareprovider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByCareprovider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByCareprovider != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByCareprovider {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*p.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAccountResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGoalResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedGoalResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGoalResourcesReferencingPatient {
+			rsc := (*p.RevIncludedGoalResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGoalResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedGoalResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGoalResourcesReferencingSubject {
+			rsc := (*p.RevIncludedGoalResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEnrollmentRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEnrollmentRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedEnrollmentRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEnrollmentRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEnrollmentRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEnrollmentRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingSubject {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSubject {
+			rsc := (*p.RevIncludedListResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingPatient {
+			rsc := (*p.RevIncludedListResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSource {
+			rsc := (*p.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*p.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedVisionPrescriptionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedVisionPrescriptionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedVisionPrescriptionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*p.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMediaResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDeviceUseRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceUseRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*p.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingPatient {
+			rsc := (*p.RevIncludedFlagResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRelatedPersonResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRelatedPersonResourcesReferencingPatient {
+			rsc := (*p.RevIncludedRelatedPersonResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingSubject {
+			rsc := (*p.RevIncludedObservationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingPatient {
+			rsc := (*p.RevIncludedPersonResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingActor {
+			rsc := (*p.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSubject {
+			rsc := (*p.RevIncludedContractResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingPatient {
+			rsc := (*p.RevIncludedContractResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*p.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingSubject {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingPatient {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingPatient {
+			rsc := (*p.RevIncludedBasicResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*p.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingStudyResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingStudyResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImagingStudyResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient {
+			rsc := (*p.RevIncludedFamilyMemberHistoryResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedNutritionOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedNutritionOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedNutritionOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingPatient {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingPatientPath1 != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingPatientPath1 {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingPatientPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingPatientPath2 != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingPatientPath2 {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingPatientPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedMedicationOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			rsc := (*p.RevIncludedConditionResourcesReferencingAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedConditionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPatientResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPatientResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPatientResourcesReferencingLink {
+			rsc := (*p.RevIncludedPatientResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingPatient {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseStatementResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseStatementResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDeviceUseStatementResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDeviceUseStatementResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDeviceUseStatementResourcesReferencingPatient {
+			rsc := (*p.RevIncludedDeviceUseStatementResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*p.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingPatient {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPatient {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClaimResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedClaimResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClaimResourcesReferencingPatient {
+			rsc := (*p.RevIncludedClaimResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationRecommendationResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationRecommendationResourcesReferencingPatient {
+			rsc := (*p.RevIncludedImmunizationRecommendationResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBodySiteResourcesReferencingPatient != nil {
-		for _, r := range *p.RevIncludedBodySiteResourcesReferencingPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBodySiteResourcesReferencingPatient {
+			rsc := (*p.RevIncludedBodySiteResourcesReferencingPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/paymentnotice.go
+++ b/models/paymentnotice.go
@@ -264,83 +264,99 @@ func (p *PaymentNoticePlusRelatedResources) GetIncludedResources() map[string]in
 func (p *PaymentNoticePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -349,83 +365,99 @@ func (p *PaymentNoticePlusRelatedResources) GetRevIncludedResources() map[string
 func (p *PaymentNoticePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/paymentreconciliation.go
+++ b/models/paymentreconciliation.go
@@ -286,83 +286,99 @@ func (p *PaymentReconciliationPlusRelatedResources) GetIncludedResources() map[s
 func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -371,83 +387,99 @@ func (p *PaymentReconciliationPlusRelatedResources) GetRevIncludedResources() ma
 func (p *PaymentReconciliationPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/person.go
+++ b/models/person.go
@@ -371,43 +371,51 @@ func (p *PersonPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferen
 func (p *PersonPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByLink {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByLink {
+			rsc := (*p.IncludedPatientResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPersonResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPersonResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPersonResourcesReferencedByLink {
+			rsc := (*p.IncludedPersonResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByLink {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByRelatedperson != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByRelatedperson)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -416,88 +424,105 @@ func (p *PersonPlusRelatedResources) GetIncludedResources() map[string]interface
 func (p *PersonPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -506,128 +531,153 @@ func (p *PersonPlusRelatedResources) GetRevIncludedResources() map[string]interf
 func (p *PersonPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPractitioner != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPractitioner {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByLink {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByLink {
+			rsc := (*p.IncludedPatientResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPersonResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedPersonResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPersonResourcesReferencedByLink {
+			rsc := (*p.IncludedPersonResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByLink != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByLink {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByRelatedperson != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByRelatedperson {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByRelatedperson)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/practitioner.go
+++ b/models/practitioner.go
@@ -1120,13 +1120,15 @@ func (p *PractitionerPlusRelatedResources) GetRevIncludedClaimResourcesReferenci
 func (p *PractitionerPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -1135,493 +1137,591 @@ func (p *PractitionerPlusRelatedResources) GetIncludedResources() map[string]int
 func (p *PractitionerPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*p.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingCollector != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingCollector {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingCollector {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingCollector)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSource {
+			rsc := (*p.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingSource {
+			rsc := (*p.RevIncludedOrderResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*p.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingRequester {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber != nil {
-		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
+			rsc := (*p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*p.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingOperator != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingOperator {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingOperator {
+			rsc := (*p.RevIncludedMediaResourcesReferencingOperator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*p.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedPersonResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingActor {
+			rsc := (*p.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*p.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*p.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessRequestResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
+			rsc := (*p.RevIncludedProcessRequestResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingDispenser != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingDispenser)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedNutritionOrderResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
+			rsc := (*p.RevIncludedNutritionOrderResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationOrderResourcesReferencingPrescriber != nil {
-		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
+			rsc := (*p.RevIncludedMedicationOrderResourcesReferencingPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			rsc := (*p.RevIncludedConditionResourcesReferencingAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPatientResourcesReferencingCareprovider != nil {
-		for _, r := range *p.RevIncludedPatientResourcesReferencingCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPatientResourcesReferencingCareprovider {
+			rsc := (*p.RevIncludedPatientResourcesReferencingCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequestprovider != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequestprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*p.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingSupplier != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingSupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAssessor != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAssessor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingEnterer != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingEnterer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClaimResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedClaimResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClaimResourcesReferencingProvider {
+			rsc := (*p.RevIncludedClaimResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -1630,503 +1730,603 @@ func (p *PractitionerPlusRelatedResources) GetRevIncludedResources() map[string]
 func (p *PractitionerPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedAppointmentResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedReferralRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedReferralRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedReferralRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAccountResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedAccountResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAccountResourcesReferencingSubject {
+			rsc := (*p.RevIncludedAccountResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSpecimenResourcesReferencingCollector != nil {
-		for _, r := range *p.RevIncludedSpecimenResourcesReferencingCollector {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSpecimenResourcesReferencingCollector {
+			rsc := (*p.RevIncludedSpecimenResourcesReferencingCollector)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingRecorder)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*p.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingTeammember != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingTeammember {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingTeammember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager != nil {
-		for _, r := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager {
+			rsc := (*p.RevIncludedEpisodeOfCareResourcesReferencingCaremanager)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingSource {
+			rsc := (*p.RevIncludedListResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingSubject {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthenticator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingSource {
+			rsc := (*p.RevIncludedOrderResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingTarget {
+			rsc := (*p.RevIncludedOrderResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingRequester {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImmunizationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImmunizationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedImmunizationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber != nil {
-		for _, r := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber {
+			rsc := (*p.RevIncludedVisionPrescriptionResourcesReferencingPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*p.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMediaResourcesReferencingOperator != nil {
-		for _, r := range *p.RevIncludedMediaResourcesReferencingOperator {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMediaResourcesReferencingOperator {
+			rsc := (*p.RevIncludedMediaResourcesReferencingOperator)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingSubject {
+			rsc := (*p.RevIncludedFlagResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedFlagResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedFlagResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedFlagResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedFlagResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyRequestResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyRequestResourcesReferencingSource {
+			rsc := (*p.RevIncludedSupplyRequestResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAppointmentResponseResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAppointmentResponseResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedAppointmentResponseResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*p.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedPersonResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *p.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*p.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingActor {
+			rsc := (*p.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *p.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*p.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedRiskAssessmentResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedRiskAssessmentResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedRiskAssessmentResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *p.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*p.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessRequestResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessRequestResourcesReferencingProvider {
+			rsc := (*p.RevIncludedProcessRequestResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingResponsibleparty)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationDispenseResourcesReferencingDispenser != nil {
-		for _, r := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationDispenseResourcesReferencingDispenser {
+			rsc := (*p.RevIncludedMedicationDispenseResourcesReferencingDispenser)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingPerformer != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingPerformer {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedNutritionOrderResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedNutritionOrderResourcesReferencingProvider {
+			rsc := (*p.RevIncludedNutritionOrderResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingPractitioner != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingPractitioner {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMedicationOrderResourcesReferencingPrescriber != nil {
-		for _, r := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMedicationOrderResourcesReferencingPrescriber {
+			rsc := (*p.RevIncludedMedicationOrderResourcesReferencingPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*p.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedConditionResourcesReferencingAsserter != nil {
-		for _, r := range *p.RevIncludedConditionResourcesReferencingAsserter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedConditionResourcesReferencingAsserter {
+			rsc := (*p.RevIncludedConditionResourcesReferencingAsserter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingAttester != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingAttester {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingAttester {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingAttester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1 {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingActorPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2 {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingActorPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticOrderResourcesReferencingOrderer != nil {
-		for _, r := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticOrderResourcesReferencingOrderer {
+			rsc := (*p.RevIncludedDiagnosticOrderResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedPatientResourcesReferencingCareprovider != nil {
-		for _, r := range *p.RevIncludedPatientResourcesReferencingCareprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedPatientResourcesReferencingCareprovider {
+			rsc := (*p.RevIncludedPatientResourcesReferencingCareprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingWho != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingWho {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingWho {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingWho)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequestprovider != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequestprovider {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequestprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *p.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*p.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedSupplyDeliveryResourcesReferencingSupplier != nil {
-		for _, r := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedSupplyDeliveryResourcesReferencingSupplier {
+			rsc := (*p.RevIncludedSupplyDeliveryResourcesReferencingSupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAssessor != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAssessor {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAssessor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingReceiver != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingReceiver {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingAuthor != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingAuthor {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingResponsible != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingResponsible {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingResponsible)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingEnterer != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingEnterer {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingEnterer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClaimResourcesReferencingProvider != nil {
-		for _, r := range *p.RevIncludedClaimResourcesReferencingProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClaimResourcesReferencingProvider {
+			rsc := (*p.RevIncludedClaimResourcesReferencingProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -422,48 +422,57 @@ func (p *ProcedurePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefe
 func (p *ProcedurePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*p.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*p.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*p.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -472,98 +481,117 @@ func (p *ProcedurePlusRelatedResources) GetIncludedResources() map[string]interf
 func (p *ProcedurePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingProcedure != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingProcedure {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingProcedure {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingProcedure)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingIndication != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingIndication {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -572,143 +600,171 @@ func (p *ProcedurePlusRelatedResources) GetRevIncludedResources() map[string]int
 func (p *ProcedurePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*p.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*p.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*p.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingProcedure != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingProcedure {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingProcedure {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingProcedure)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedEncounterResourcesReferencingIndication != nil {
-		for _, r := range *p.RevIncludedEncounterResourcesReferencingIndication {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedEncounterResourcesReferencingIndication {
+			rsc := (*p.RevIncludedEncounterResourcesReferencingIndication)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/procedurerequest.go
+++ b/models/procedurerequest.go
@@ -451,63 +451,75 @@ func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedMessageHeaderResour
 func (p *ProcedureRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*p.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*p.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByOrderer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedDeviceResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedDeviceResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedDeviceResourcesReferencedByOrderer {
+			rsc := (*p.IncludedDeviceResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByOrderer {
+			rsc := (*p.IncludedPatientResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*p.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -516,103 +528,123 @@ func (p *ProcedureRequestPlusRelatedResources) GetIncludedResources() map[string
 func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -621,163 +653,195 @@ func (p *ProcedureRequestPlusRelatedResources) GetRevIncludedResources() map[str
 func (p *ProcedureRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByPerformer {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPerformer {
+			rsc := (*p.IncludedPatientResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByPerformer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByPerformer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*p.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*p.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByOrderer {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedDeviceResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedDeviceResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedDeviceResourcesReferencedByOrderer {
+			rsc := (*p.IncludedDeviceResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByOrderer {
+			rsc := (*p.IncludedPatientResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByOrderer != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByOrderer {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *p.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*p.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*p.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/processrequest.go
+++ b/models/processrequest.go
@@ -314,13 +314,15 @@ func (p *ProcessRequestPlusRelatedResources) GetRevIncludedMessageHeaderResource
 func (p *ProcessRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -329,93 +331,111 @@ func (p *ProcessRequestPlusRelatedResources) GetIncludedResources() map[string]i
 func (p *ProcessRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -424,103 +444,123 @@ func (p *ProcessRequestPlusRelatedResources) GetRevIncludedResources() map[strin
 func (p *ProcessRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByProvider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByProvider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByProvider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByProvider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*p.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/processresponse.go
+++ b/models/processresponse.go
@@ -304,18 +304,21 @@ func (p *ProcessResponsePlusRelatedResources) GetRevIncludedMessageHeaderResourc
 func (p *ProcessResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByRequestprovider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByRequestprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByRequestorganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByRequestorganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -324,83 +327,99 @@ func (p *ProcessResponsePlusRelatedResources) GetIncludedResources() map[string]
 func (p *ProcessResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -409,98 +428,117 @@ func (p *ProcessResponsePlusRelatedResources) GetRevIncludedResources() map[stri
 func (p *ProcessResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedOrganizationResourcesReferencedByOrganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByOrganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByOrganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByOrganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPractitionerResourcesReferencedByRequestprovider != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByRequestprovider {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByRequestprovider)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByRequestorganization != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByRequestorganization {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByRequestorganization)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/provenance.go
+++ b/models/provenance.go
@@ -364,38 +364,45 @@ func (p *ProvenancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRef
 func (p *ProvenancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByAgent {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByAgent {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedDeviceResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedDeviceResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedDeviceResourcesReferencedByAgent {
+			rsc := (*p.IncludedDeviceResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByAgent {
+			rsc := (*p.IncludedPatientResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -404,83 +411,99 @@ func (p *ProvenancePlusRelatedResources) GetIncludedResources() map[string]inter
 func (p *ProvenancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -489,118 +512,141 @@ func (p *ProvenancePlusRelatedResources) GetRevIncludedResources() map[string]in
 func (p *ProvenancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if p.IncludedPractitionerResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedPractitionerResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPractitionerResourcesReferencedByAgent {
+			rsc := (*p.IncludedPractitionerResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedOrganizationResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedOrganizationResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedOrganizationResourcesReferencedByAgent {
+			rsc := (*p.IncludedOrganizationResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedDeviceResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedDeviceResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedDeviceResourcesReferencedByAgent {
+			rsc := (*p.IncludedDeviceResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByAgent {
+			rsc := (*p.IncludedPatientResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedRelatedPersonResourcesReferencedByAgent != nil {
-		for _, r := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedRelatedPersonResourcesReferencedByAgent {
+			rsc := (*p.IncludedRelatedPersonResourcesReferencedByAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *p.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*p.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.IncludedLocationResourcesReferencedByLocation != nil {
-		for _, r := range *p.IncludedLocationResourcesReferencedByLocation {
-			resourceMap[r.Id] = &r
+		for idx := range *p.IncludedLocationResourcesReferencedByLocation {
+			rsc := (*p.IncludedLocationResourcesReferencedByLocation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *p.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*p.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *p.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedListResourcesReferencingItem {
+			rsc := (*p.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*p.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *p.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*p.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*p.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *p.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*p.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *p.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*p.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*p.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*p.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*p.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*p.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*p.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if p.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *p.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *p.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*p.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/questionnaire.go
+++ b/models/questionnaire.go
@@ -297,88 +297,105 @@ func (q *QuestionnairePlusRelatedResources) GetIncludedResources() map[string]in
 func (q *QuestionnairePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*q.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *q.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedListResourcesReferencingItem {
+			rsc := (*q.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*q.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*q.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*q.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*q.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*q.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*q.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*q.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -387,88 +404,105 @@ func (q *QuestionnairePlusRelatedResources) GetRevIncludedResources() map[string
 func (q *QuestionnairePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*q.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *q.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedListResourcesReferencingItem {
+			rsc := (*q.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*q.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*q.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*q.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*q.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*q.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingQuestionnaire)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*q.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*q.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/questionnaireresponse.go
+++ b/models/questionnaireresponse.go
@@ -433,53 +433,63 @@ func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedMessageHeaderR
 func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if q.IncludedQuestionnaireResourcesReferencedByQuestionnaire != nil {
-		for _, r := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
+			rsc := (*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*q.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*q.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*q.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*q.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*q.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *q.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*q.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*q.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedBySource {
+			rsc := (*q.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedRelatedPersonResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedRelatedPersonResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedRelatedPersonResourcesReferencedBySource {
+			rsc := (*q.IncludedRelatedPersonResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -488,93 +498,111 @@ func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedResources() map[s
 func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*q.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *q.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedListResourcesReferencingItem {
+			rsc := (*q.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*q.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
-		for _, r := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
+			rsc := (*q.RevIncludedObservationResourcesReferencingRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*q.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*q.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*q.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*q.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*q.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*q.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -583,143 +611,171 @@ func (q *QuestionnaireResponsePlusRelatedResources) GetRevIncludedResources() ma
 func (q *QuestionnaireResponsePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if q.IncludedQuestionnaireResourcesReferencedByQuestionnaire != nil {
-		for _, r := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedQuestionnaireResourcesReferencedByQuestionnaire {
+			rsc := (*q.IncludedQuestionnaireResourcesReferencedByQuestionnaire)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPractitionerResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedPractitionerResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPractitionerResourcesReferencedByAuthor {
+			rsc := (*q.IncludedPractitionerResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedDeviceResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedDeviceResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedDeviceResourcesReferencedByAuthor {
+			rsc := (*q.IncludedDeviceResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedByAuthor {
+			rsc := (*q.IncludedPatientResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedRelatedPersonResourcesReferencedByAuthor != nil {
-		for _, r := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedRelatedPersonResourcesReferencedByAuthor {
+			rsc := (*q.IncludedRelatedPersonResourcesReferencedByAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*q.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *q.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*q.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*q.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedPatientResourcesReferencedBySource {
+			rsc := (*q.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.IncludedRelatedPersonResourcesReferencedBySource != nil {
-		for _, r := range *q.IncludedRelatedPersonResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *q.IncludedRelatedPersonResourcesReferencedBySource {
+			rsc := (*q.IncludedRelatedPersonResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *q.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*q.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *q.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedListResourcesReferencingItem {
+			rsc := (*q.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*q.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *q.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*q.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedObservationResourcesReferencingRelatedtarget != nil {
-		for _, r := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedObservationResourcesReferencingRelatedtarget {
+			rsc := (*q.RevIncludedObservationResourcesReferencingRelatedtarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*q.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *q.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*q.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *q.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*q.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*q.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*q.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*q.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*q.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedClinicalImpressionResourcesReferencingInvestigation != nil {
-		for _, r := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedClinicalImpressionResourcesReferencingInvestigation {
+			rsc := (*q.RevIncludedClinicalImpressionResourcesReferencingInvestigation)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if q.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *q.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *q.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*q.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/referralrequest.go
+++ b/models/referralrequest.go
@@ -393,33 +393,39 @@ func (r *ReferralRequestPlusRelatedResources) GetRevIncludedMessageHeaderResourc
 func (r *ReferralRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedOrganizationResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedOrganizationResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedOrganizationResourcesReferencedByRequester {
+			rsc := (*r.IncludedOrganizationResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByRequester {
+			rsc := (*r.IncludedPatientResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *r.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*r.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -428,113 +434,135 @@ func (r *ReferralRequestPlusRelatedResources) GetIncludedResources() map[string]
 func (r *ReferralRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral != nil {
-		for _, r := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
+			rsc := (*r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*r.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEncounterResourcesReferencingIncomingreferral != nil {
-		for _, r := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
+			rsc := (*r.RevIncludedEncounterResourcesReferencingIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -543,143 +571,171 @@ func (r *ReferralRequestPlusRelatedResources) GetRevIncludedResources() map[stri
 func (r *ReferralRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedPractitionerResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByRequester {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedOrganizationResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedOrganizationResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedOrganizationResourcesReferencedByRequester {
+			rsc := (*r.IncludedOrganizationResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByRequester != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByRequester {
+			rsc := (*r.IncludedPatientResourcesReferencedByRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPractitionerResourcesReferencedByRecipient != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByRecipient {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedOrganizationResourcesReferencedByRecipient != nil {
-		for _, r := range *r.IncludedOrganizationResourcesReferencedByRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedOrganizationResourcesReferencedByRecipient {
+			rsc := (*r.IncludedOrganizationResourcesReferencedByRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral != nil {
-		for _, r := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral {
+			rsc := (*r.RevIncludedEpisodeOfCareResourcesReferencingIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDiagnosticReportResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDiagnosticReportResourcesReferencingRequest {
+			rsc := (*r.RevIncludedDiagnosticReportResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEncounterResourcesReferencingIncomingreferral != nil {
-		for _, r := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEncounterResourcesReferencingIncomingreferral {
+			rsc := (*r.RevIncludedEncounterResourcesReferencingIncomingreferral)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/relatedperson.go
+++ b/models/relatedperson.go
@@ -591,8 +591,9 @@ func (r *RelatedPersonPlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (r *RelatedPersonPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -601,243 +602,291 @@ func (r *RelatedPersonPlusRelatedResources) GetIncludedResources() map[string]in
 func (r *RelatedPersonPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*r.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*r.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*r.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*r.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*r.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *r.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*r.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedPersonResourcesReferencingRelatedperson != nil {
-		for _, r := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
+			rsc := (*r.RevIncludedPersonResourcesReferencingRelatedperson)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedContractResourcesReferencingActor {
+			rsc := (*r.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *r.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*r.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEncounterResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedEncounterResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEncounterResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedEncounterResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *r.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*r.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*r.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -846,248 +895,297 @@ func (r *RelatedPersonPlusRelatedResources) GetRevIncludedResources() map[string
 func (r *RelatedPersonPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAppointmentResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedAppointmentResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAppointmentResourcesReferencingActor {
+			rsc := (*r.RevIncludedAppointmentResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingAgent != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingAgent {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingAgent {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingAgent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAllergyIntoleranceResourcesReferencingReporter != nil {
-		for _, r := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAllergyIntoleranceResourcesReferencingReporter {
+			rsc := (*r.RevIncludedAllergyIntoleranceResourcesReferencingReporter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCarePlanResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCarePlanResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedCarePlanResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedProcedureResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedProcedureResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureRequestResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureRequestResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedProcedureRequestResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcedureRequestResourcesReferencingOrderer != nil {
-		for _, r := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcedureRequestResourcesReferencingOrderer {
+			rsc := (*r.RevIncludedProcedureRequestResourcesReferencingOrderer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAppointmentResponseResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAppointmentResponseResourcesReferencingActor {
+			rsc := (*r.RevIncludedAppointmentResponseResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedObservationResourcesReferencingPerformer != nil {
-		for _, r := range *r.RevIncludedObservationResourcesReferencingPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedObservationResourcesReferencingPerformer {
+			rsc := (*r.RevIncludedObservationResourcesReferencingPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner != nil {
-		for _, r := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner {
+			rsc := (*r.RevIncludedMedicationAdministrationResourcesReferencingPractitioner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMedicationStatementResourcesReferencingSource != nil {
-		for _, r := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMedicationStatementResourcesReferencingSource {
+			rsc := (*r.RevIncludedMedicationStatementResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedPersonResourcesReferencingLink != nil {
-		for _, r := range *r.RevIncludedPersonResourcesReferencingLink {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedPersonResourcesReferencingLink {
+			rsc := (*r.RevIncludedPersonResourcesReferencingLink)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedPersonResourcesReferencingRelatedperson != nil {
-		for _, r := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedPersonResourcesReferencingRelatedperson {
+			rsc := (*r.RevIncludedPersonResourcesReferencingRelatedperson)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedContractResourcesReferencingActor {
+			rsc := (*r.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedContractResourcesReferencingSigner != nil {
-		for _, r := range *r.RevIncludedContractResourcesReferencingSigner {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedContractResourcesReferencingSigner {
+			rsc := (*r.RevIncludedContractResourcesReferencingSigner)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingRequester != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingRequester {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingRequester)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingSender != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingSender {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationRequestResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationRequestResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedCommunicationRequestResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedBasicResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedImagingObjectSelectionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedEncounterResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedEncounterResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedEncounterResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedEncounterResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingParticipant != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingParticipant {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingParticipant)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationResourcesReferencingSender != nil {
-		for _, r := range *r.RevIncludedCommunicationResourcesReferencingSender {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationResourcesReferencingSender {
+			rsc := (*r.RevIncludedCommunicationResourcesReferencingSender)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCommunicationResourcesReferencingRecipient != nil {
-		for _, r := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCommunicationResourcesReferencingRecipient {
+			rsc := (*r.RevIncludedCommunicationResourcesReferencingRecipient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingAuthor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSource != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSource {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedScheduleResourcesReferencingActor != nil {
-		for _, r := range *r.RevIncludedScheduleResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedScheduleResourcesReferencingActor {
+			rsc := (*r.RevIncludedScheduleResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/riskassessment.go
+++ b/models/riskassessment.go
@@ -355,38 +355,45 @@ func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedMessageHeaderResource
 func (r *RiskAssessmentPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *r.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*r.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedDeviceResourcesReferencedByPerformer != nil {
-		for _, r := range *r.IncludedDeviceResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedDeviceResourcesReferencedByPerformer {
+			rsc := (*r.IncludedDeviceResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *r.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*r.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*r.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *r.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*r.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -395,83 +402,99 @@ func (r *RiskAssessmentPlusRelatedResources) GetIncludedResources() map[string]i
 func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -480,118 +503,141 @@ func (r *RiskAssessmentPlusRelatedResources) GetRevIncludedResources() map[strin
 func (r *RiskAssessmentPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if r.IncludedConditionResourcesReferencedByCondition != nil {
-		for _, r := range *r.IncludedConditionResourcesReferencedByCondition {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedConditionResourcesReferencedByCondition {
+			rsc := (*r.IncludedConditionResourcesReferencedByCondition)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPractitionerResourcesReferencedByPerformer != nil {
-		for _, r := range *r.IncludedPractitionerResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPractitionerResourcesReferencedByPerformer {
+			rsc := (*r.IncludedPractitionerResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedDeviceResourcesReferencedByPerformer != nil {
-		for _, r := range *r.IncludedDeviceResourcesReferencedByPerformer {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedDeviceResourcesReferencedByPerformer {
+			rsc := (*r.IncludedDeviceResourcesReferencedByPerformer)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *r.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*r.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*r.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *r.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*r.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *r.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *r.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*r.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *r.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*r.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *r.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedListResourcesReferencingItem {
+			rsc := (*r.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*r.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *r.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*r.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*r.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *r.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*r.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *r.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*r.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*r.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*r.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*r.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*r.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*r.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if r.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *r.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *r.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*r.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/schedule.go
+++ b/models/schedule.go
@@ -336,33 +336,39 @@ func (s *SchedulePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (s *SchedulePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*s.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByActor {
+			rsc := (*s.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*s.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*s.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedLocationResourcesReferencedByActor {
+			rsc := (*s.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -371,88 +377,105 @@ func (s *SchedulePlusRelatedResources) GetIncludedResources() map[string]interfa
 func (s *SchedulePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSlotResourcesReferencingSchedule != nil {
-		for _, r := range *s.RevIncludedSlotResourcesReferencingSchedule {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSlotResourcesReferencingSchedule {
+			rsc := (*s.RevIncludedSlotResourcesReferencingSchedule)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -461,118 +484,141 @@ func (s *SchedulePlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (s *SchedulePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPractitionerResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByActor {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedDeviceResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedDeviceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedDeviceResourcesReferencedByActor {
+			rsc := (*s.IncludedDeviceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByActor {
+			rsc := (*s.IncludedPatientResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedHealthcareServiceResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedHealthcareServiceResourcesReferencedByActor {
+			rsc := (*s.IncludedHealthcareServiceResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedRelatedPersonResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedRelatedPersonResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedRelatedPersonResourcesReferencedByActor {
+			rsc := (*s.IncludedRelatedPersonResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedLocationResourcesReferencedByActor != nil {
-		for _, r := range *s.IncludedLocationResourcesReferencedByActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedLocationResourcesReferencedByActor {
+			rsc := (*s.IncludedLocationResourcesReferencedByActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSlotResourcesReferencingSchedule != nil {
-		for _, r := range *s.RevIncludedSlotResourcesReferencingSchedule {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSlotResourcesReferencingSchedule {
+			rsc := (*s.RevIncludedSlotResourcesReferencingSchedule)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/searchparameter.go
+++ b/models/searchparameter.go
@@ -275,83 +275,99 @@ func (s *SearchParameterPlusRelatedResources) GetIncludedResources() map[string]
 func (s *SearchParameterPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -360,83 +376,99 @@ func (s *SearchParameterPlusRelatedResources) GetRevIncludedResources() map[stri
 func (s *SearchParameterPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/slot.go
+++ b/models/slot.go
@@ -269,8 +269,9 @@ func (s *SlotPlusRelatedResources) GetRevIncludedMessageHeaderResourcesReferenci
 func (s *SlotPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedScheduleResourcesReferencedBySchedule != nil {
-		for _, r := range *s.IncludedScheduleResourcesReferencedBySchedule {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedScheduleResourcesReferencedBySchedule {
+			rsc := (*s.IncludedScheduleResourcesReferencedBySchedule)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -279,83 +280,99 @@ func (s *SlotPlusRelatedResources) GetIncludedResources() map[string]interface{}
 func (s *SlotPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -364,88 +381,105 @@ func (s *SlotPlusRelatedResources) GetRevIncludedResources() map[string]interfac
 func (s *SlotPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedScheduleResourcesReferencedBySchedule != nil {
-		for _, r := range *s.IncludedScheduleResourcesReferencedBySchedule {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedScheduleResourcesReferencedBySchedule {
+			rsc := (*s.IncludedScheduleResourcesReferencedBySchedule)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/specimen.go
+++ b/models/specimen.go
@@ -430,38 +430,45 @@ func (s *SpecimenPlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefer
 func (s *SpecimenPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedSpecimenResourcesReferencedByParent != nil {
-		for _, r := range *s.IncludedSpecimenResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSpecimenResourcesReferencedByParent {
+			rsc := (*s.IncludedSpecimenResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*s.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*s.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*s.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedSubstanceResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSubstanceResourcesReferencedBySubject {
+			rsc := (*s.IncludedSubstanceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedByCollector != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByCollector {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByCollector {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByCollector)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -470,113 +477,135 @@ func (s *SpecimenPlusRelatedResources) GetIncludedResources() map[string]interfa
 func (s *SpecimenPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSpecimenResourcesReferencingParent != nil {
-		for _, r := range *s.RevIncludedSpecimenResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSpecimenResourcesReferencingParent {
+			rsc := (*s.RevIncludedSpecimenResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*s.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedObservationResourcesReferencingSpecimen != nil {
-		for _, r := range *s.RevIncludedObservationResourcesReferencingSpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedObservationResourcesReferencingSpecimen {
+			rsc := (*s.RevIncludedObservationResourcesReferencingSpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticReportResourcesReferencingSpecimen != nil {
-		for _, r := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
+			rsc := (*s.RevIncludedDiagnosticReportResourcesReferencingSpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 != nil {
-		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
+			rsc := (*s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 != nil {
-		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
+			rsc := (*s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -585,148 +614,177 @@ func (s *SpecimenPlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (s *SpecimenPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedSpecimenResourcesReferencedByParent != nil {
-		for _, r := range *s.IncludedSpecimenResourcesReferencedByParent {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSpecimenResourcesReferencedByParent {
+			rsc := (*s.IncludedSpecimenResourcesReferencedByParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedGroupResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedGroupResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedGroupResourcesReferencedBySubject {
+			rsc := (*s.IncludedGroupResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedDeviceResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedDeviceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedDeviceResourcesReferencedBySubject {
+			rsc := (*s.IncludedDeviceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedBySubject {
+			rsc := (*s.IncludedPatientResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedSubstanceResourcesReferencedBySubject != nil {
-		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSubstanceResourcesReferencedBySubject {
+			rsc := (*s.IncludedSubstanceResourcesReferencedBySubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedByCollector != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByCollector {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByCollector {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByCollector)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSpecimenResourcesReferencingParent != nil {
-		for _, r := range *s.RevIncludedSpecimenResourcesReferencingParent {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSpecimenResourcesReferencingParent {
+			rsc := (*s.RevIncludedSpecimenResourcesReferencingParent)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMediaResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedMediaResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMediaResourcesReferencingSubject {
+			rsc := (*s.RevIncludedMediaResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedObservationResourcesReferencingSpecimen != nil {
-		for _, r := range *s.RevIncludedObservationResourcesReferencingSpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedObservationResourcesReferencingSpecimen {
+			rsc := (*s.RevIncludedObservationResourcesReferencingSpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticReportResourcesReferencingSpecimen != nil {
-		for _, r := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticReportResourcesReferencingSpecimen {
+			rsc := (*s.RevIncludedDiagnosticReportResourcesReferencingSpecimen)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 != nil {
-		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1 {
+			rsc := (*s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath1)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 != nil {
-		for _, r := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2 {
+			rsc := (*s.RevIncludedDiagnosticOrderResourcesReferencingSpecimenPath2)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/structuredefinition.go
+++ b/models/structuredefinition.go
@@ -370,8 +370,9 @@ func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedMessageHeaderRes
 func (s *StructureDefinitionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedValueSetResourcesReferencedByValueset != nil {
-		for _, r := range *s.IncludedValueSetResourcesReferencedByValueset {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedValueSetResourcesReferencedByValueset {
+			rsc := (*s.IncludedValueSetResourcesReferencedByValueset)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -380,113 +381,135 @@ func (s *StructureDefinitionPlusRelatedResources) GetIncludedResources() map[str
 func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingSource != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingSource {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingTarget {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingSourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOperationDefinitionResourcesReferencingProfile != nil {
-		for _, r := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
+			rsc := (*s.RevIncludedOperationDefinitionResourcesReferencingProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConformanceResourcesReferencingProfile != nil {
-		for _, r := range *s.RevIncludedConformanceResourcesReferencingProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConformanceResourcesReferencingProfile {
+			rsc := (*s.RevIncludedConformanceResourcesReferencingProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConformanceResourcesReferencingSupportedprofile != nil {
-		for _, r := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
+			rsc := (*s.RevIncludedConformanceResourcesReferencingSupportedprofile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -495,118 +518,141 @@ func (s *StructureDefinitionPlusRelatedResources) GetRevIncludedResources() map[
 func (s *StructureDefinitionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedValueSetResourcesReferencedByValueset != nil {
-		for _, r := range *s.IncludedValueSetResourcesReferencedByValueset {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedValueSetResourcesReferencedByValueset {
+			rsc := (*s.IncludedValueSetResourcesReferencedByValueset)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingSource != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingSource {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingTarget {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
-		for _, r := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConceptMapResourcesReferencingSourceuri {
+			rsc := (*s.RevIncludedConceptMapResourcesReferencingSourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOperationDefinitionResourcesReferencingProfile != nil {
-		for _, r := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOperationDefinitionResourcesReferencingProfile {
+			rsc := (*s.RevIncludedOperationDefinitionResourcesReferencingProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConformanceResourcesReferencingProfile != nil {
-		for _, r := range *s.RevIncludedConformanceResourcesReferencingProfile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConformanceResourcesReferencingProfile {
+			rsc := (*s.RevIncludedConformanceResourcesReferencingProfile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedConformanceResourcesReferencingSupportedprofile != nil {
-		for _, r := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedConformanceResourcesReferencingSupportedprofile {
+			rsc := (*s.RevIncludedConformanceResourcesReferencingSupportedprofile)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -270,83 +270,99 @@ func (s *SubscriptionPlusRelatedResources) GetIncludedResources() map[string]int
 func (s *SubscriptionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -355,83 +371,99 @@ func (s *SubscriptionPlusRelatedResources) GetRevIncludedResources() map[string]
 func (s *SubscriptionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/substance.go
+++ b/models/substance.go
@@ -340,8 +340,9 @@ func (s *SubstancePlusRelatedResources) GetRevIncludedMessageHeaderResourcesRefe
 func (s *SubstancePlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedSubstanceResourcesReferencedBySubstance != nil {
-		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubstance {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSubstanceResourcesReferencedBySubstance {
+			rsc := (*s.IncludedSubstanceResourcesReferencedBySubstance)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -350,113 +351,135 @@ func (s *SubstancePlusRelatedResources) GetIncludedResources() map[string]interf
 func (s *SubstancePlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*s.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMedicationResourcesReferencingIngredient != nil {
-		for _, r := range *s.RevIncludedMedicationResourcesReferencingIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMedicationResourcesReferencingIngredient {
+			rsc := (*s.RevIncludedMedicationResourcesReferencingIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*s.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *s.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedContractResourcesReferencingActor {
+			rsc := (*s.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *s.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*s.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSubstanceResourcesReferencingSubstance != nil {
-		for _, r := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
+			rsc := (*s.RevIncludedSubstanceResourcesReferencingSubstance)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -465,118 +488,141 @@ func (s *SubstancePlusRelatedResources) GetRevIncludedResources() map[string]int
 func (s *SubstancePlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedSubstanceResourcesReferencedBySubstance != nil {
-		for _, r := range *s.IncludedSubstanceResourcesReferencedBySubstance {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedSubstanceResourcesReferencedBySubstance {
+			rsc := (*s.IncludedSubstanceResourcesReferencedBySubstance)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSpecimenResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedSpecimenResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSpecimenResourcesReferencingSubject {
+			rsc := (*s.RevIncludedSpecimenResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMedicationResourcesReferencingIngredient != nil {
-		for _, r := range *s.RevIncludedMedicationResourcesReferencingIngredient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMedicationResourcesReferencingIngredient {
+			rsc := (*s.RevIncludedMedicationResourcesReferencingIngredient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingSubject {
+			rsc := (*s.RevIncludedOrderResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedContractResourcesReferencingActor != nil {
-		for _, r := range *s.RevIncludedContractResourcesReferencingActor {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedContractResourcesReferencingActor {
+			rsc := (*s.RevIncludedContractResourcesReferencingActor)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedGroupResourcesReferencingMember != nil {
-		for _, r := range *s.RevIncludedGroupResourcesReferencingMember {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedGroupResourcesReferencingMember {
+			rsc := (*s.RevIncludedGroupResourcesReferencingMember)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedSubstanceResourcesReferencingSubstance != nil {
-		for _, r := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedSubstanceResourcesReferencingSubstance {
+			rsc := (*s.RevIncludedSubstanceResourcesReferencingSubstance)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/supplydelivery.go
+++ b/models/supplydelivery.go
@@ -294,18 +294,21 @@ func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedMessageHeaderResource
 func (s *SupplyDeliveryPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedBySupplier != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedBySupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedBySupplier {
+			rsc := (*s.IncludedPractitionerResourcesReferencedBySupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -314,83 +317,99 @@ func (s *SupplyDeliveryPlusRelatedResources) GetIncludedResources() map[string]i
 func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -399,98 +418,117 @@ func (s *SupplyDeliveryPlusRelatedResources) GetRevIncludedResources() map[strin
 func (s *SupplyDeliveryPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPractitionerResourcesReferencedByReceiver != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedByReceiver {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedByReceiver {
+			rsc := (*s.IncludedPractitionerResourcesReferencedByReceiver)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedBySupplier != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedBySupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedBySupplier {
+			rsc := (*s.IncludedPractitionerResourcesReferencedBySupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/supplyrequest.go
+++ b/models/supplyrequest.go
@@ -354,28 +354,33 @@ func (s *SupplyRequestPlusRelatedResources) GetRevIncludedMessageHeaderResources
 func (s *SupplyRequestPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedOrganizationResourcesReferencedBySupplier != nil {
-		for _, r := range *s.IncludedOrganizationResourcesReferencedBySupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedOrganizationResourcesReferencedBySupplier {
+			rsc := (*s.IncludedOrganizationResourcesReferencedBySupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*s.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedOrganizationResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedOrganizationResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedOrganizationResourcesReferencedBySource {
+			rsc := (*s.IncludedOrganizationResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedBySource {
+			rsc := (*s.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -384,98 +389,117 @@ func (s *SupplyRequestPlusRelatedResources) GetIncludedResources() map[string]in
 func (s *SupplyRequestPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*s.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -484,123 +508,147 @@ func (s *SupplyRequestPlusRelatedResources) GetRevIncludedResources() map[string
 func (s *SupplyRequestPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if s.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*s.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedOrganizationResourcesReferencedBySupplier != nil {
-		for _, r := range *s.IncludedOrganizationResourcesReferencedBySupplier {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedOrganizationResourcesReferencedBySupplier {
+			rsc := (*s.IncludedOrganizationResourcesReferencedBySupplier)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPractitionerResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedPractitionerResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPractitionerResourcesReferencedBySource {
+			rsc := (*s.IncludedPractitionerResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedOrganizationResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedOrganizationResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedOrganizationResourcesReferencedBySource {
+			rsc := (*s.IncludedOrganizationResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.IncludedPatientResourcesReferencedBySource != nil {
-		for _, r := range *s.IncludedPatientResourcesReferencedBySource {
-			resourceMap[r.Id] = &r
+		for idx := range *s.IncludedPatientResourcesReferencedBySource {
+			rsc := (*s.IncludedPatientResourcesReferencedBySource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *s.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*s.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*s.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *s.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedListResourcesReferencingItem {
+			rsc := (*s.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*s.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *s.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*s.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*s.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *s.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*s.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *s.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*s.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*s.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*s.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*s.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*s.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingAction != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingAction {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingAction)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*s.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if s.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *s.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *s.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*s.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/testscript.go
+++ b/models/testscript.go
@@ -400,83 +400,99 @@ func (t *TestScriptPlusRelatedResources) GetIncludedResources() map[string]inter
 func (t *TestScriptPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if t.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *t.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*t.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*t.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*t.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *t.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedListResourcesReferencingItem {
+			rsc := (*t.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*t.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *t.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*t.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*t.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *t.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*t.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*t.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *t.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*t.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*t.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*t.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*t.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*t.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*t.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *t.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*t.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -485,83 +501,99 @@ func (t *TestScriptPlusRelatedResources) GetRevIncludedResources() map[string]in
 func (t *TestScriptPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if t.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *t.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*t.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*t.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*t.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *t.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedListResourcesReferencingItem {
+			rsc := (*t.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*t.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *t.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*t.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*t.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *t.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*t.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*t.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *t.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*t.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*t.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*t.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*t.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*t.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*t.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if t.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *t.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *t.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*t.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/valueset.go
+++ b/models/valueset.go
@@ -404,103 +404,123 @@ func (v *ValueSetPlusRelatedResources) GetIncludedResources() map[string]interfa
 func (v *ValueSetPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*v.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedStructureDefinitionResourcesReferencingValueset != nil {
-		for _, r := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
+			rsc := (*v.RevIncludedStructureDefinitionResourcesReferencingValueset)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *v.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedListResourcesReferencingItem {
+			rsc := (*v.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingSource != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingSource {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingTarget {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingSourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*v.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*v.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*v.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*v.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*v.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*v.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*v.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*v.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -509,103 +529,123 @@ func (v *ValueSetPlusRelatedResources) GetRevIncludedResources() map[string]inte
 func (v *ValueSetPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*v.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedStructureDefinitionResourcesReferencingValueset != nil {
-		for _, r := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedStructureDefinitionResourcesReferencingValueset {
+			rsc := (*v.RevIncludedStructureDefinitionResourcesReferencingValueset)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *v.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedListResourcesReferencingItem {
+			rsc := (*v.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingSource != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSource {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingSource {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingSource)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingTarget {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedConceptMapResourcesReferencingSourceuri != nil {
-		for _, r := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedConceptMapResourcesReferencingSourceuri {
+			rsc := (*v.RevIncludedConceptMapResourcesReferencingSourceuri)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*v.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*v.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*v.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*v.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*v.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*v.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*v.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*v.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/models/visionprescription.go
+++ b/models/visionprescription.go
@@ -332,18 +332,21 @@ func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedMessageHeaderReso
 func (v *VisionPrescriptionPlusRelatedResources) GetIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if v.IncludedPractitionerResourcesReferencedByPrescriber != nil {
-		for _, r := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
+			rsc := (*v.IncludedPractitionerResourcesReferencedByPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *v.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*v.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *v.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*v.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -352,93 +355,111 @@ func (v *VisionPrescriptionPlusRelatedResources) GetIncludedResources() map[stri
 func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*v.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*v.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *v.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedListResourcesReferencingItem {
+			rsc := (*v.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*v.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*v.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*v.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*v.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*v.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*v.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*v.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*v.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap
@@ -447,108 +468,129 @@ func (v *VisionPrescriptionPlusRelatedResources) GetRevIncludedResources() map[s
 func (v *VisionPrescriptionPlusRelatedResources) GetIncludedAndRevIncludedResources() map[string]interface{} {
 	resourceMap := make(map[string]interface{})
 	if v.IncludedPractitionerResourcesReferencedByPrescriber != nil {
-		for _, r := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedPractitionerResourcesReferencedByPrescriber {
+			rsc := (*v.IncludedPractitionerResourcesReferencedByPrescriber)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.IncludedPatientResourcesReferencedByPatient != nil {
-		for _, r := range *v.IncludedPatientResourcesReferencedByPatient {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedPatientResourcesReferencedByPatient {
+			rsc := (*v.IncludedPatientResourcesReferencedByPatient)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.IncludedEncounterResourcesReferencedByEncounter != nil {
-		for _, r := range *v.IncludedEncounterResourcesReferencedByEncounter {
-			resourceMap[r.Id] = &r
+		for idx := range *v.IncludedEncounterResourcesReferencedByEncounter {
+			rsc := (*v.IncludedEncounterResourcesReferencedByEncounter)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedProvenanceResourcesReferencingTarget != nil {
-		for _, r := range *v.RevIncludedProvenanceResourcesReferencingTarget {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProvenanceResourcesReferencingTarget {
+			rsc := (*v.RevIncludedProvenanceResourcesReferencingTarget)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingContentref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingContentref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingContentref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentManifestResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentManifestResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentManifestResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCarePlanResourcesReferencingActivityreference != nil {
-		for _, r := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCarePlanResourcesReferencingActivityreference {
+			rsc := (*v.RevIncludedCarePlanResourcesReferencingActivityreference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedListResourcesReferencingItem != nil {
-		for _, r := range *v.RevIncludedListResourcesReferencingItem {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedListResourcesReferencingItem {
+			rsc := (*v.RevIncludedListResourcesReferencingItem)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDocumentReferenceResourcesReferencingRelatedref != nil {
-		for _, r := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDocumentReferenceResourcesReferencingRelatedref {
+			rsc := (*v.RevIncludedDocumentReferenceResourcesReferencingRelatedref)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResourcesReferencingDetail != nil {
-		for _, r := range *v.RevIncludedOrderResourcesReferencingDetail {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResourcesReferencingDetail {
+			rsc := (*v.RevIncludedOrderResourcesReferencingDetail)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedBasicResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedBasicResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedBasicResourcesReferencingSubject {
+			rsc := (*v.RevIncludedBasicResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedAuditEventResourcesReferencingReference != nil {
-		for _, r := range *v.RevIncludedAuditEventResourcesReferencingReference {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedAuditEventResourcesReferencingReference {
+			rsc := (*v.RevIncludedAuditEventResourcesReferencingReference)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingSubject {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedCompositionResourcesReferencingEntry != nil {
-		for _, r := range *v.RevIncludedCompositionResourcesReferencingEntry {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedCompositionResourcesReferencingEntry {
+			rsc := (*v.RevIncludedCompositionResourcesReferencingEntry)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedDetectedIssueResourcesReferencingImplicated != nil {
-		for _, r := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedDetectedIssueResourcesReferencingImplicated {
+			rsc := (*v.RevIncludedDetectedIssueResourcesReferencingImplicated)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedOrderResponseResourcesReferencingFulfillment != nil {
-		for _, r := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedOrderResponseResourcesReferencingFulfillment {
+			rsc := (*v.RevIncludedOrderResponseResourcesReferencingFulfillment)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedQuestionnaireResponseResourcesReferencingSubject != nil {
-		for _, r := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedQuestionnaireResponseResourcesReferencingSubject {
+			rsc := (*v.RevIncludedQuestionnaireResponseResourcesReferencingSubject)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedProcessResponseResourcesReferencingRequest != nil {
-		for _, r := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedProcessResponseResourcesReferencingRequest {
+			rsc := (*v.RevIncludedProcessResponseResourcesReferencingRequest)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingTrigger != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingTrigger {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingTrigger)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedClinicalImpressionResourcesReferencingPlan != nil {
-		for _, r := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedClinicalImpressionResourcesReferencingPlan {
+			rsc := (*v.RevIncludedClinicalImpressionResourcesReferencingPlan)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	if v.RevIncludedMessageHeaderResourcesReferencingData != nil {
-		for _, r := range *v.RevIncludedMessageHeaderResourcesReferencingData {
-			resourceMap[r.Id] = &r
+		for idx := range *v.RevIncludedMessageHeaderResourcesReferencingData {
+			rsc := (*v.RevIncludedMessageHeaderResourcesReferencingData)[idx]
+			resourceMap[rsc.Id] = &rsc
 		}
 	}
 	return resourceMap

--- a/server/routing.go
+++ b/server/routing.go
@@ -28,7 +28,7 @@ func RegisterRoutes(e *echo.Echo, config map[string][]echo.Middleware, serverCon
 
 	e.Post("/", BatchHandler)
 
-	// Resource, useSmartAuths
+	// Resources
 
 	RegisterController("Appointment", e, config["Appointment"], serverConfig)
 	RegisterController("ReferralRequest", e, config["ReferralRequest"], serverConfig)


### PR DESCRIPTION
The old code had things like this:

```go
for _, r := range *a.IncludedOrganizationResourcesReferencedByOwner {
	resourceMap[r.Id] = &r
}
```

The problem with this is that `r` uses the same memory for every iteration, so `&r` will be the same address on every iteration too.  So the last resource in the iteration is the one that wins (and you get lots of repeats of it).

The new code looks like this:

```go
for idx := range *a.IncludedOrganizationResourcesReferencedByOwner {
	rsc := (*a.IncludedOrganizationResourcesReferencedByOwner)[idx]
	resourceMap[rsc.Id] = &rsc
}
```

I had to use `idx` instead of `i` because `i` is already defined for resources whose name starts with "I" (it's the alias).  For the same reason, I changed `r` to `rsc` to avoid confusion with resources whose name starts with "R" (and therefore already have a defined `r` in scope).
