### PR TITLE
When parsing dates, parse them into local timezone.

### DIFF
--- a/models/fhirdatetime.go
+++ b/models/fhirdatetime.go
@@ -20,7 +20,7 @@ type FHIRDateTime struct {
 func (f *FHIRDateTime) UnmarshalJSON(data []byte) (err error) {
 	if len(data) <= 12 {
 		f.Precision = Precision("date")
-		f.Time, err = time.Parse("\"2006-01-02\"", string(data))
+		f.Time, err = time.ParseInLocation("\"2006-01-02\"", string(data), time.Local)
 	} else {
 		f.Precision = Precision("timestamp")
 		f.Time = time.Time{}

--- a/models/fhirdatetime_test.go
+++ b/models/fhirdatetime_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/pebbe/util"
 	check "gopkg.in/check.v1"
@@ -31,10 +32,11 @@ func (s *FDSuite) TestFHIRDateTime(c *check.C) {
 	util.CheckErr(err)
 
 	c.Assert(simple.Foo, check.HasLen, 3)
-	c.Assert(simple.Foo[0].Time.Unix(), check.Equals, int64(665420400))
+	loc, err := time.LoadLocation("America/New_York")
+	c.Assert(simple.Foo[0].Time.Equal(time.Date(1991, time.February, 1, 10, 0, 0, 0, loc)), check.Equals, true)
 	c.Assert(simple.Foo[0].Precision, check.Equals, Precision(Timestamp))
-	c.Assert(simple.Foo[1].Time.Unix(), check.Equals, int64(696902400))
+	c.Assert(simple.Foo[1].Time.Equal(time.Date(1992, time.February, 1, 0, 0, 0, 0, time.Local)), check.Equals, true)
 	c.Assert(simple.Foo[1].Precision, check.Equals, Precision(Date))
-	c.Assert(simple.Foo[2].Time.Unix(), check.Equals, int64(728578800))
+	c.Assert(simple.Foo[2].Time.Equal(time.Date(1993, time.February, 1, 10, 0, 0, 0, loc)), check.Equals, true)
 	c.Assert(simple.Foo[2].Precision, check.Equals, Precision(Timestamp))
 }


### PR DESCRIPTION
When parsing dates, parse them into local timezone.  Why?  Because otherwise they get stored as UTC, which for our local timezone (America/New York) puts them back one day.  By storing in local timezone, we avoid that problem.  Of course, this would be a moot point if we had better handling of dates without times.

To show the problem more specifically,  if you store a date as `2012-01-02T00:00:00.0+00:00`, when you pull it out of MongoDB in the local TZ, you get `2012-01-01T19:00:00:00.0-05:00`.  For the FHIR `Date` type, this ends up changing the day from `2012-01-02` to `2012-01-01`. 