### PR TITLE
Fix gin binding for application/json+fhir

### DIFF
--- a/server.go
+++ b/server.go
@@ -8,8 +8,12 @@ import (
 
 func main() {
 	smartAuth := flag.Bool("smart", false, "Enables SMART Authorization")
+	reqLog := flag.Bool("reqlog", false, "Enables request logging -- do NOT use in production")
 	flag.Parse()
 	s := server.NewServer("localhost")
+	if *reqLog {
+		s.Engine.Use(server.RequestLoggerHandler)
+	}
 
 	config := server.Config{UseSmartAuth: *smartAuth}
 	s.Run(config)

--- a/server/batch_controller.go
+++ b/server/batch_controller.go
@@ -28,7 +28,7 @@ func NewBatchController(dal DataAccessLayer) *BatchController {
 // Post processes and incoming batch request
 func (b *BatchController) Post(c *gin.Context) {
 	bundle := &models.Bundle{}
-	err := c.Bind(bundle)
+	err := FHIRBind(c, bundle)
 	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return

--- a/server/bind.go
+++ b/server/bind.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+)
+
+const (
+	MIMEJSONFHIR = "application/json+fhir"
+	MIMEXMLFHIR  = "application/xml+fhir"
+)
+
+func FHIRBind(c *gin.Context, obj interface{}) error {
+	if c.Request.Method == "Get" {
+		return c.BindWith(obj, binding.Form)
+	}
+	switch c.ContentType() {
+	case MIMEJSONFHIR:
+		return c.BindJSON(obj)
+	case MIMEXMLFHIR:
+		return c.BindWith(obj, binding.XML)
+	}
+	return c.Bind(obj)
+}

--- a/server/bind_test.go
+++ b/server/bind_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/intervention-engine/fhir/models"
+	. "gopkg.in/check.v1"
+)
+
+type BindSuite struct {
+}
+
+var _ = Suite(&BindSuite{})
+
+func (b *BindSuite) TestJSONBinding(c *C) {
+	testBinding(c, "application/json")
+}
+
+func (b *BindSuite) TestJSONFHIRBinding(c *C) {
+	testBinding(c, "application/json+fhir")
+}
+
+func testBinding(c *C, contentType string) {
+	data, _ := os.Open("../fixtures/condition.json")
+
+	ctx, _, _ := gin.CreateTestContext()
+	ctx.Request, _ = http.NewRequest("POST", "/Condition", data)
+	ctx.Request.Header.Add("Content-Type", contentType)
+
+	var condition models.Condition
+	FHIRBind(ctx, &condition)
+
+	c.Assert(condition.ResourceType, Equals, "Condition")
+	c.Assert(condition.Id, Equals, "8664777288161060797")
+	c.Assert(condition.VerificationStatus, Equals, "confirmed")
+	c.Assert(condition.Patient, NotNil)
+	c.Assert(condition.Patient.Reference, Equals, "https://example.com/base/Patient/4954037118555241963")
+	c.Assert(condition.Code, NotNil)
+	c.Assert(condition.Code.Text, Equals, "Heart failure")
+	c.Assert(condition.Code.Coding, HasLen, 3)
+	c.Assert(condition.Code.MatchesCode("http://snomed.info/sct", "10091002"), Equals, true)
+	c.Assert(condition.Code.MatchesCode("http://hl7.org/fhir/sid/icd-9", "428.0"), Equals, true)
+	c.Assert(condition.Code.MatchesCode("http://hl7.org/fhir/sid/icd-10", "I50.1"), Equals, true)
+	c.Assert(condition.OnsetDateTime, NotNil)
+	tz, _ := time.LoadLocation("America/New_York")
+	c.Assert(condition.OnsetDateTime.Time.Equal(time.Date(2012, time.March, 1, 7, 0, 0, 0, tz)), Equals, true)
+	c.Assert(condition.OnsetDateTime.Precision, Equals, models.Precision(models.Timestamp))
+}

--- a/server/request_logger.go
+++ b/server/request_logger.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestLoggerHandler is a handler intended to be used during debugging to log out the request details including
+// the request headers and the request body.  This should not be used in production as it has performance implications.
+func RequestLoggerHandler(c *gin.Context) {
+	if c.Request != nil {
+
+		buf, _ := ioutil.ReadAll(c.Request.Body)
+		c.Request.Body.Close()
+
+		log.Println("-----------------------------------------------------------------------------------------------------")
+		log.Println("REQUEST HEADERS:")
+		for k, v := range c.Request.Header {
+			log.Printf("\t%s: %s\n", k, v)
+		}
+		log.Printf("\nREQUEST BODY:\n%s\n", buf)
+		log.Println("-----------------------------------------------------------------------------------------------------")
+
+		c.Request.Body = ioutil.NopCloser(bytes.NewReader(buf))
+	}
+	c.Next()
+}

--- a/server/resource_controller.go
+++ b/server/resource_controller.go
@@ -84,7 +84,7 @@ func (rc *ResourceController) ShowHandler(c *gin.Context) {
 
 func (rc *ResourceController) CreateHandler(c *gin.Context) {
 	resource := models.NewStructForResourceName(rc.Name)
-	err := c.Bind(resource)
+	err := FHIRBind(c, resource)
 	if err != nil {
 		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
 		c.JSON(http.StatusBadRequest, oo)
@@ -108,7 +108,7 @@ func (rc *ResourceController) CreateHandler(c *gin.Context) {
 
 func (rc *ResourceController) UpdateHandler(c *gin.Context) {
 	resource := models.NewStructForResourceName(rc.Name)
-	err := c.Bind(resource)
+	err := FHIRBind(c, resource)
 	if err != nil {
 		oo := models.NewOperationOutcome("fatal", "exception", err.Error())
 		c.JSON(http.StatusBadRequest, oo)


### PR DESCRIPTION
When an incoming request has `Content-Type: application/json+fhir`, gin doesn't know what to do with it.  This PR adds a binding helper function that detects `application/json+fhir` and `application/xml+fhir`, delegating to the proper binding technologies.

BONUS: As part of debugging what was going on (before I realized it was an issue with `Content-Type`), I created a request logger middleware, that will log out the incoming request header and body.  You can enable it using the `--reqlog` flag.