### PR TITLE
STU3-style sorts

### DIFF
--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -117,11 +117,20 @@ func (q *Query) Options() *QueryOptions {
 				options.Offset = offset
 			}
 		case SortParam:
-			sortParam, ok := SearchParameterDictionary[q.Resource][queryParam.Value]
-			if !ok {
-				panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
+			// The following supports both DSTU2-style sorts and STU3-style sorts
+			keys := strings.Split(queryParam.Value, ",")
+			for _, key := range keys {
+				desc := strings.HasPrefix(key, "-") || modifier == "desc"
+				sortParam, ok := SearchParameterDictionary[q.Resource][strings.TrimPrefix(key, "-")]
+				if !ok {
+					panic(createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
+				}
+				options.Sort = append(options.Sort, SortOption{Descending: desc, Parameter: sortParam})
 			}
-			options.Sort = append(options.Sort, SortOption{Descending: modifier == "desc", Parameter: sortParam})
+			// If this was an STU3-style sort, remember that so we reconstruct the query URL correctly
+			if len(keys) > 1 || strings.HasPrefix(queryParam.Value, "-") {
+				options.IsSTU3Sort = true
+			}
 		case IncludeParam:
 			incls := strings.Split(queryParam.Value, ":")
 			if len(incls) < 2 || len(incls) > 3 {
@@ -222,6 +231,7 @@ type QueryOptions struct {
 	Sort       []SortOption
 	Include    []IncludeOption
 	RevInclude []RevIncludeOption
+	IsSTU3Sort bool
 }
 
 // NewQueryOptions constructs a new QueryOptions with default values (offset = 0, Count = 100)
@@ -232,12 +242,24 @@ func NewQueryOptions() *QueryOptions {
 // URLQueryParameters returns URLQueryParameters representing the query options.
 func (o *QueryOptions) URLQueryParameters() URLQueryParameters {
 	var queryParams URLQueryParameters
-	for _, sort := range o.Sort {
-		sortParamKey := SortParam
-		if sort.Descending {
-			sortParamKey += ":desc"
+	if o.IsSTU3Sort {
+		keys := make([]string, len(o.Sort))
+		for i := range o.Sort {
+			if o.Sort[i].Descending {
+				keys[i] = fmt.Sprintf("-%s", o.Sort[i].Parameter.Name)
+			} else {
+				keys[i] = o.Sort[i].Parameter.Name
+			}
 		}
-		queryParams.Add(sortParamKey, sort.Parameter.Name)
+		queryParams.Add(SortParam, strings.Join(keys, ","))
+	} else {
+		for _, sort := range o.Sort {
+			sortParamKey := SortParam
+			if sort.Descending {
+				sortParamKey += ":desc"
+			}
+			queryParams.Add(sortParamKey, sort.Parameter.Name)
+		}
 	}
 	queryParams.Set(OffsetParam, strconv.Itoa(o.Offset))
 	queryParams.Set(CountParam, strconv.Itoa(o.Count))

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1530,6 +1530,18 @@ func (s *SearchPTSuite) TestQueryOptions(c *C) {
 	c.Assert(o.RevInclude[1].Parameter.Name, Equals, "patient")
 }
 
+func (s *SearchPTSuite) TestQueryOptionsWithSTU3Sort(c *C) {
+	q := Query{Resource: "Patient", Query: "_sort=family,given,-birthdate"}
+	o := q.Options()
+	c.Assert(o.Sort, HasLen, 3)
+	c.Assert(o.Sort[0].Descending, Equals, false)
+	c.Assert(o.Sort[0].Parameter.Name, Equals, "family")
+	c.Assert(o.Sort[1].Descending, Equals, false)
+	c.Assert(o.Sort[1].Parameter.Name, Equals, "given")
+	c.Assert(o.Sort[2].Descending, Equals, true)
+	c.Assert(o.Sort[2].Parameter.Name, Equals, "birthdate")
+}
+
 func (s *SearchPTSuite) TestQueryOptionsInvalidSortParam(c *C) {
 	q := Query{Resource: "Patient", Query: "_sort=foo"}
 	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_sort\" content is invalid"))
@@ -1651,6 +1663,13 @@ func (s *SearchPTSuite) TestReconstructQueryStringWithSorts(c *C) {
 	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=male&_sort=family&_sort%3Adesc=given&_sort%3Aasc=birthdate&_offset=20&_count=10&_include=Patient%3Acareprovider&_include=Patient%3Aorganization&_revinclude=Condition%3Apatient&_revinclude=Encounter%3Apatient"}
 	params := q.URLQueryParameters(true)
 	c.Assert(params.Encode(), Equals, "name%3Aexact=Robert+Smith&gender=male&_sort=family&_sort%3Adesc=given&_sort=birthdate&_offset=20&_count=10&_include=Patient%3Acareprovider&_include=Patient%3Aorganization&_revinclude=Condition%3Apatient&_revinclude=Encounter%3Apatient")
+}
+
+func (s *SearchPTSuite) TestReconstructQueryStringWithSTU3Sorts(c *C) {
+	// The main purpose of this is to ensure that STU3-style sort gets reconstructed in STU3-style
+	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=male&_sort=family%2C-given%2Cbirthdate&_offset=20&_count=10&_include=Patient%3Acareprovider&_include=Patient%3Aorganization&_revinclude=Condition%3Apatient&_revinclude=Encounter%3Apatient"}
+	params := q.URLQueryParameters(true)
+	c.Assert(params.Encode(), Equals, "name%3Aexact=Robert+Smith&gender=male&_sort=family%2C-given%2Cbirthdate&_offset=20&_count=10&_include=Patient%3Acareprovider&_include=Patient%3Aorganization&_revinclude=Condition%3Apatient&_revinclude=Encounter%3Apatient")
 }
 
 func (s *SearchPTSuite) TestQueryOptionsURLQueryParameters(c *C) {


### PR DESCRIPTION
Add support for STU3 style sorts as described in the change request:
http://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=9558

For example: http://example.org/fhir/Patient?_sort=gender,-birthdate,family

Note that DSTU2-style sorts also still work. The DSTU2-style version of above is:
http://example.org/fhir/Patient?_sort=gender&_sort:desc=birthdate&_sort=family