### PR TITLE
Support Middleware for Batch Operations

### DIFF
--- a/server/routing.go
+++ b/server/routing.go
@@ -31,7 +31,10 @@ func RegisterRoutes(e *gin.Engine, config map[string][]gin.HandlerFunc, dal Data
 
 	// Batch Support
 	batch := NewBatchController(dal)
-	e.POST("/", batch.Post)
+	batchHandlers := make([]gin.HandlerFunc, len(config["Batch"]))
+	copy(batchHandlers, config["Batch"])
+	batchHandlers = append(batchHandlers, batch.Post)
+	e.POST("/", batchHandlers...)
 
 	// Resources
 


### PR DESCRIPTION
If middleware was registered for "Batch", then add it to the batch handler chain.  Previously batch operations couldn't have middleware.  IE needs to setup a subscription that triggers on posted bundles, so this functionality was necessary.