### PR TITLE
Custom Parameter Support

### DIFF
--- a/search/mongo_registry.go
+++ b/search/mongo_registry.go
@@ -1,0 +1,48 @@
+package search
+
+import (
+	"fmt"
+	"sync"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+var mongoRegistry *MongoRegistry
+var mongoRegistryOnce sync.Once
+
+// GlobalMongoRegistry returns an instance of the global search parameter registry
+func GlobalMongoRegistry() *MongoRegistry {
+	mongoRegistryOnce.Do(func() {
+		mongoRegistry = new(MongoRegistry)
+		mongoRegistry.builders = make(map[string]BSONBuilder)
+	})
+	return mongoRegistry
+}
+
+// MongoRegistry supports the registration and lookup of Mongo search parameter implementations as BSON builders.
+type MongoRegistry struct {
+	buildersLock sync.RWMutex
+	builders     map[string]BSONBuilder
+}
+
+// RegisterBSONBuilder registers a BSON builder for a given parameter type.
+func (r *MongoRegistry) RegisterBSONBuilder(paramType string, builder BSONBuilder) {
+	r.buildersLock.Lock()
+	defer r.buildersLock.Unlock()
+	r.builders[paramType] = builder
+}
+
+// LookupBSONBuilder looks up a BSON builder by type.  If no builder is registered, it will return an error.
+func (r *MongoRegistry) LookupBSONBuilder(paramType string) (builder BSONBuilder, err error) {
+	r.buildersLock.RLock()
+	defer r.buildersLock.RUnlock()
+	b, ok := r.builders[paramType]
+	if !ok {
+		return nil, fmt.Errorf("Could not find BSON builder for %s", paramType)
+	}
+	return b, nil
+}
+
+// BSONBuilder returns a BSON object representing the passed in search parameter.  This BSON object is expected to be
+// merged with other objects and passed into Mongo's Find function.
+type BSONBuilder func(param SearchParam, searcher *MongoSearcher) (object bson.M, err error)

--- a/search/mongo_registry_test.go
+++ b/search/mongo_registry_test.go
@@ -1,0 +1,31 @@
+package search
+
+import (
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type MongoRegistrySuite struct{}
+
+var _ = Suite(&MongoRegistrySuite{})
+
+func (s *MongoRegistrySuite) TestRegisterAndLookupBSONBuilder(c *C) {
+	build := func(param SearchParam, search *MongoSearcher) (bson.M, error) {
+		return bson.M{"foo": param.(*StringParam).String}, nil
+	}
+
+	GlobalMongoRegistry().RegisterBSONBuilder("test", build)
+	obtained, err := GlobalMongoRegistry().LookupBSONBuilder("test")
+	util.CheckErr(err)
+	bmap, err := obtained(&StringParam{String: "bar"}, NewMongoSearcher(nil))
+	util.CheckErr(err)
+	c.Assert(bmap, HasLen, 1)
+	c.Assert(bmap["foo"], Equals, "bar")
+}
+
+func (s *MongoRegistrySuite) TestLookupNonExistingBSONBuilder(c *C) {
+	obtained, err := GlobalMongoRegistry().LookupBSONBuilder("nope")
+	c.Assert(err, Not(IsNil))
+	c.Assert(obtained, IsNil)
+}

--- a/search/registry.go
+++ b/search/registry.go
@@ -1,0 +1,83 @@
+package search
+
+import (
+	"fmt"
+	"sync"
+)
+
+var registry *Registry
+var registryOnce sync.Once
+
+// GlobalRegistry returns an instance of the global search parameter registry
+func GlobalRegistry() *Registry {
+	registryOnce.Do(func() {
+		registry = new(Registry)
+		registry.infos = make(map[string]map[string]SearchParamInfo)
+		registry.parsers = make(map[string]ParameterParser)
+	})
+	return registry
+}
+
+// Registry supports the registration and lookup of FHIR search parameters, both standard and custom.  For custom
+// search parameters, a parameter type implementation may also need to be registered.
+type Registry struct {
+	infosLock   sync.RWMutex
+	infos       map[string]map[string]SearchParamInfo
+	parsersLock sync.RWMutex
+	parsers     map[string]ParameterParser
+}
+
+// RegisterParameterInfo registers search param info for a given resource and name (as represented in the info).  If the
+// parameter is not of a standard fhir type (e.g., token, date, etc), then a SearchParameter for the given type should
+// also be registered.
+func (r *Registry) RegisterParameterInfo(param SearchParamInfo) {
+	r.infosLock.Lock()
+	defer r.infosLock.Unlock()
+	rMap, ok := r.infos[param.Resource]
+	if !ok {
+		rMap = make(map[string]SearchParamInfo)
+		r.infos[param.Resource] = rMap
+	}
+	rMap[param.Name] = param
+
+	// For now, also register in SearchParameterDictionary
+	rMap, ok = SearchParameterDictionary[param.Resource]
+	if !ok {
+		rMap = make(map[string]SearchParamInfo)
+		SearchParameterDictionary[param.Resource] = rMap
+	}
+	rMap[param.Name] = param
+}
+
+// LookupParameterInfo looks up search parameter info by resource and name.  If no parameter info is registered, it will
+// return an error.
+func (r *Registry) LookupParameterInfo(resource, name string) (param SearchParamInfo, err error) {
+	r.infosLock.RLock()
+	defer r.infosLock.RUnlock()
+	param, ok := r.infos[resource][name]
+	if !ok {
+		return SearchParamInfo{}, fmt.Errorf("Could not find info for parameter %s for resource %s", name, resource)
+	}
+	return param, nil
+}
+
+// RegisterParameterParser registers a parameter parser for a given type name.
+func (r *Registry) RegisterParameterParser(paramType string, parser ParameterParser) {
+	r.parsersLock.Lock()
+	defer r.parsersLock.Unlock()
+	r.parsers[paramType] = parser
+}
+
+// LookupParameterParser looks up a parameter parser by type.  If no parser is registered, it will return an error.
+func (r *Registry) LookupParameterParser(paramType string) (parser ParameterParser, err error) {
+	r.parsersLock.RLock()
+	defer r.parsersLock.RUnlock()
+	p, ok := r.parsers[paramType]
+	if !ok {
+		return nil, fmt.Errorf("Could not find parameter parser for %s", paramType)
+	}
+	return p, nil
+}
+
+// ParameterParser parses search parameter data into a SearchParam implementation.
+type ParameterParser func(info SearchParamInfo, data SearchParamData) (SearchParam, error)

--- a/search/registry_test.go
+++ b/search/registry_test.go
@@ -1,0 +1,56 @@
+package search
+
+import (
+	"github.com/pebbe/util"
+	. "gopkg.in/check.v1"
+)
+
+type RegistrySuite struct{}
+
+var _ = Suite(&RegistrySuite{})
+
+func (s *RegistrySuite) TestRegisterAndLookupParameterInfo(c *C) {
+	info := SearchParamInfo{
+		Resource: "Blah",
+		Name:     "foo",
+		Type:     "test",
+	}
+
+	GlobalRegistry().RegisterParameterInfo(info)
+	obtained, err := GlobalRegistry().LookupParameterInfo("Blah", "foo")
+	util.CheckErr(err)
+	c.Assert(obtained, DeepEquals, info)
+}
+
+func (s *RegistrySuite) TestLookupNonExistingParameterInfo(c *C) {
+	obtained, err := GlobalRegistry().LookupParameterInfo("Foo", "Bar")
+	c.Assert(err, Not(IsNil))
+	c.Assert(obtained, DeepEquals, SearchParamInfo{}) // Zero Object
+}
+
+func (s *RegistrySuite) TestRegisterAndLookupParameterParser(c *C) {
+	info := SearchParamInfo{
+		Resource: "Blah",
+		Name:     "foo",
+		Type:     "test",
+	}
+	parser := func(info SearchParamInfo, data SearchParamData) (SearchParam, error) {
+		return ParseStringParam("bar", info), nil
+	}
+
+	GlobalRegistry().RegisterParameterParser("test", parser)
+	obtained, err := GlobalRegistry().LookupParameterParser("test")
+	util.CheckErr(err)
+	param, err := obtained(info, SearchParamData{Value: "bar"})
+	util.CheckErr(err)
+	c.Assert(param.getInfo(), DeepEquals, info)
+	p, v := param.getQueryParamAndValue()
+	c.Assert(p, Equals, "foo")
+	c.Assert(v, Equals, "bar")
+}
+
+func (s *RegistrySuite) TestLookupNonExistingParameterParser(c *C) {
+	obtained, err := GlobalRegistry().LookupParameterParser("nope")
+	c.Assert(err, Not(IsNil))
+	c.Assert(obtained, IsNil)
+}


### PR DESCRIPTION
New registries for registering param info, param parsers, and param bson builders (for Mongo implementation).

Currently, this is implemented just to support custom parameters, but the standard parameters should be refactored to use this system as well.