### PR TITLE
Format parameter fix

### DIFF
--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -30,7 +30,7 @@ const (
 	ContainedParam     = "_contained"
 	ContainedTypeParam = "_containedType"
 	OffsetParam        = "_offset" // Custom param, not in FHIR spec
-	FormatParam		   = "_format"
+	FormatParam        = "_format"
 )
 
 var globalSearchParams = map[string]bool{IDParam: true, LastUpdatedParam: true, TagParam: true,
@@ -191,7 +191,7 @@ func (q *Query) Options() *QueryOptions {
 				// Currently we only support JSON
 				panic(createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_format\" content is invalid"))
 			}
-			
+
 		default:
 			panic(createUnsupportedSearchError("MSG_PARAM_UNKNOWN", fmt.Sprintf("Parameter \"%s\" not understood", param)))
 		}

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1686,6 +1686,16 @@ func (s *SearchPTSuite) TestQueryOptionsInvalidRevIncludeParams(c *C) {
 	c.Assert(func() { q.Options() }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"_revinclude\" content is invalid"))
 }
 
+func (s *SearchPTSuite) TestQueryOptionsInvalidFormatParam(c *C) {
+	// Format that is not supported (XML)
+	q := Query{Resource: "Patient", Query:"_format=xml"}
+	c.Assert(func() { q.Options() }, Panics, createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_format\" content is invalid"))
+
+	// Valid format (json)
+	q = Query{Resource: "Patient", Query:"_format=json"}
+	q.Options()
+}
+
 func (s *SearchPTSuite) TestReconstructQueryWithPassedInOptions(c *C) {
 	q := Query{Resource: "Patient", Query: "name%3Aexact=Robert+Smith&gender=male&_sort=family&_sort%3Adesc=given&_sort%3Aasc=birthdate&_offset=20&_count=10&_include=Patient%3Acareprovider&_include=Patient%3Aorganization&_revinclude=Condition%3Apatient&_revinclude=Encounter%3Apatient"}
 	params := q.URLQueryParameters(true)

--- a/server/resource_controller.go
+++ b/server/resource_controller.go
@@ -31,7 +31,7 @@ func (rc *ResourceController) IndexHandler(c *gin.Context) {
 	defer func() {
 		if r := recover(); r != nil {
 			switch x := r.(type) {
-			case search.Error:
+			case *search.Error:
 				c.JSON(x.HTTPStatus, x.OperationOutcome)
 				return
 			default:


### PR DESCRIPTION
Added support for the _format parameter. Supported formats are “json”, “application/json”, and “application/json+fhir”. Unsupported formats (e.g. xml) error out.

Also fixed a small pointer bug that interferes with the content of error responses.