### PR TITLE
Updated interceptor model

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The *fhir* server accepts connections on port 3001 by default.
 
 If you wish to test the server with synthetic patient data, please reference [Generate and Upload Synthetic Patient Data](https://github.com/intervention-engine/ie/blob/master/docs/dev_install.md#generate-and-upload-synthetic-patient-data).
 
+
 Development
 -----------
 
@@ -74,6 +75,18 @@ $ go test ./models ./search ./server ./upload
 
 This will ensure that the vendor directory is not included when running the test
 suite.
+
+Testing Interceptors
+--------------------
+
+This server supports "interceptors", functions that allow interaction with resources before, after, and following a failed database operation. These are invoked at the data access layer. To test the interceptors:
+
+```
+$ cd $GOPATH/src/github.com/intervention-engine/fhir/test
+$ go build
+$ ./test
+```
+This runs a testing variant of the fhir server with some test interceptors installed. Follow the testing instructions in `test/interceptor.go` to verify that the interceptors are working correctly.
 
 License
 -------

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -36,7 +36,7 @@ type Interceptor struct {
 }
 
 // InterceptorHandler is an interface that defines three methods that are executed on a resource
-// before the database operation, after the database operation SUCCEEDS, and fter the database
+// before the database operation, after the database operation SUCCEEDS, and after the database
 // operation FAILS.
 type InterceptorHandler interface {
 	Before(resource interface{})
@@ -44,7 +44,7 @@ type InterceptorHandler interface {
 	OnError(err error, resource interface{})
 }
 
-// invokeInterceptorsAfter invokes the interceptor list for the given resource type before a database
+// invokeInterceptorsBefore invokes the interceptor list for the given resource type before a database
 // operation occurs.
 func (dal *mongoDataAccessLayer) invokeInterceptorsBefore(op, resourceType string, resource interface{}) {
 

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"errors"
+	"fmt"
 	"github.com/intervention-engine/fhir/models"
 	"github.com/intervention-engine/fhir/search"
 	"gopkg.in/mgo.v2"
@@ -9,8 +11,6 @@ import (
 	"reflect"
 	"strconv"
 	"time"
-	"errors"
-	"fmt"
 )
 
 // NewMongoDataAccessLayer returns an implementation of DataAccessLayer that is backed by a Mongo database

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -32,7 +32,7 @@ type InterceptorList []Interceptor
 // types use a "*" as the resourceType.
 type Interceptor struct {
 	ResourceType string
-	Handler InterceptorHandler
+	Handler      InterceptorHandler
 }
 
 // InterceptorHandler is an interface that defines three methods that are executed on a resource

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+	"errors"
+	"fmt"
 )
 
 // NewMongoDataAccessLayer returns an implementation of DataAccessLayer that is backed by a Mongo database
@@ -275,6 +277,10 @@ func (dal *mongoDataAccessLayer) ConditionalDelete(query search.Query) (count in
 					if elementInSlice(id, successfulIds) {
 						// This resource was confirmed deleted
 						dal.invokeInterceptorsAfter("Delete", resourceType, elem.Resource)
+					} else {
+						// This resource was not confirmed deleted, which is an error
+						resourceErr := errors.New(fmt.Sprintf("ConditionalDelete: failed to delete resource %s with ID %s", resourceType, id))
+						dal.invokeInterceptorsOnError("Delete", resourceType, resourceErr, elem.Resource)
 					}
 				}
 			}

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -21,8 +21,8 @@ func (f *FHIRServer) AddMiddleware(key string, middleware gin.HandlerFunc) {
 
 // AddInterceptor adds a new interceptor for a particular database operation and FHIR resource.
 // For example:
-// AddInterceptor("Create", "Patient", handleFunc) would register the function "handleFunc"
-// to be run against a Patient resource when it is created, after being added to the database.
+// AddInterceptor("Create", "Patient", patientInterceptorHandler) would register the
+// patientInterceptorHandler methods to be run against a Patient resource when it is created.
 //
 // To run a handler against ALL resources pass "*" as the resourceType.
 //

--- a/test/interceptor.go
+++ b/test/interceptor.go
@@ -55,7 +55,7 @@ func setupTestInterceptors(s *server.FHIRServer) {
 // ----------------------------------------------------------------------------
 
 // TestPatientCreateInterceptor operates on a Patient resource after it is created
-type TestPatientCreateInterceptor struct {}
+type TestPatientCreateInterceptor struct{}
 
 func (s *TestPatientCreateInterceptor) Before(resource interface{}) {}
 
@@ -65,10 +65,9 @@ func (s *TestPatientCreateInterceptor) After(resource interface{}) {
 
 func (s *TestPatientCreateInterceptor) OnError(err error, resource interface{}) {}
 
-
-// TestPatientUpdateInterceptor operates on a Patient resource both before and 
+// TestPatientUpdateInterceptor operates on a Patient resource both before and
 // after it is updated
-type TestPatientUpdateInterceptor struct {}
+type TestPatientUpdateInterceptor struct{}
 
 func (s *TestPatientUpdateInterceptor) Before(resource interface{}) {
 	fmt.Println("TestPatientUpdateInterceptor: Before()")
@@ -81,7 +80,7 @@ func (s *TestPatientUpdateInterceptor) After(resource interface{}) {
 func (s *TestPatientUpdateInterceptor) OnError(err error, resource interface{}) {}
 
 // TestPatientDeleteInterceptor operates on a Patient resource only before it is deleted
-type TestPatientDeleteInterceptor struct {}
+type TestPatientDeleteInterceptor struct{}
 
 func (s *TestPatientDeleteInterceptor) Before(resource interface{}) {
 	fmt.Println("TestPatientDeleteInterceptor: Before()")
@@ -95,7 +94,7 @@ func (s *TestPatientDeleteInterceptor) OnError(err error, resource interface{}) 
 // ----------------------------------------------------------------------------
 
 // TestUniversalCreateInterceptor operates on any resource after it is created
-type TestUniversalCreateInterceptor struct {}
+type TestUniversalCreateInterceptor struct{}
 
 func (s *TestUniversalCreateInterceptor) Before(resource interface{}) {}
 
@@ -107,7 +106,7 @@ func (s *TestUniversalCreateInterceptor) OnError(err error, resource interface{}
 
 // TestUniversalUpdateInterceptor operates on any resource both before and after
 // it is updated
-type TestUniversalUpdateInterceptor struct {}
+type TestUniversalUpdateInterceptor struct{}
 
 func (s *TestUniversalUpdateInterceptor) Before(resource interface{}) {
 	fmt.Println("TestUniversalUpdateInterceptor: Before()")
@@ -120,7 +119,7 @@ func (s *TestUniversalUpdateInterceptor) After(resource interface{}) {
 func (s *TestUniversalUpdateInterceptor) OnError(err error, resource interface{}) {}
 
 // TestUniversalDeleteInterceptor operates on any resource after it is deleted
-type TestUniversalDeleteInterceptor struct {}
+type TestUniversalDeleteInterceptor struct{}
 
 func (s *TestUniversalDeleteInterceptor) Before(resource interface{}) {}
 

--- a/test/interceptor.go
+++ b/test/interceptor.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/intervention-engine/fhir/server"
-	"reflect"
 )
 
 func main() {
@@ -21,21 +20,21 @@ func main() {
 }
 
 // With this test server running, verfiy the following (by viewing server log):
-// =======================================================================================
+// ================================================================================================
 // 1.  GET    /Patient           -- verify that no interceptor is called
 // 2.  GET    /Condition         -- verify that no interceptor is called
 // 3.  POST   /Patient           -- verify that BOTH Create interceptors are called
-// 4.  POST   /Condition         -- verify that only the allPostsInterceptor is called
+// 4.  POST   /Condition         -- verify that only the TestUniversalCreateInterceptor is called
 // 5.  PUT    /Patient/:id       -- verify that BOTH Update interceptors are called
-// 6.  PUT    /Condition/:id     -- verify that only the allPutsInterceptor is called
+// 6.  PUT    /Condition/:id     -- verify that only the TestUniversalUpdateInterceptor is called
 // 7.  DELETE /Patient/:id       -- verify that BOTH Delete interceptors are called
-// 8.  DELETE /Condition/:id     -- verify that only the allDeletesInterceptor is called
+// 8.  DELETE /Condition/:id     -- verify that only the TestUniversalDeleteInterceptor is called
 // 9-10: repeat steps 3 and 4
 // 11: PUT    /Patient?_id=:id   -- verify that BOTH Update interceptors are called
-// 12: PUT    /Condition?_id=:id -- verify that only the allPutsInterceptor is called
+// 12: PUT    /Condition?_id=:id -- verify that only the TestUniversalUpdateInterceptor is called
 // 13: DELETE /Patient?_id=:id   -- verify that BOTH Delete interceptors are called
-// 14: DELETE /Condition?_id=:id -- verify that only the allDeletesInterceptor is called
-// =======================================================================================
+// 14: DELETE /Condition?_id=:id -- verify that only the TestUniversalDeleteInterceptor is called
+// ================================================================================================
 // Next, run ./test -noint (run the test server without any interceptors) and verify that
 // the new interceptor logic does not interfere with normal server operation.
 //
@@ -44,41 +43,89 @@ func main() {
 // https://syntheticmass.mitre.org/fhir/baseDstu3/Condition
 //
 func setupTestInterceptors(s *server.FHIRServer) {
-	s.AddInterceptor("Create", "Patient", postInterceptor)
-	s.AddInterceptor("Create", "*", allPostsInterceptor)
-
-	s.AddInterceptor("Update", "Patient", putInterceptor)
-	s.AddInterceptor("Update", "*", allPutsInterceptor)
-
-	s.AddInterceptor("Delete", "Patient", deleteInterceptor)
-	s.AddInterceptor("Delete", "*", allDeletesInterceptor)
+	s.AddInterceptor("Create", "Patient", &TestPatientCreateInterceptor{})
+	s.AddInterceptor("Update", "Patient", &TestPatientUpdateInterceptor{})
+	s.AddInterceptor("Delete", "Patient", &TestPatientDeleteInterceptor{})
+	s.AddInterceptor("Create", "*", &TestUniversalCreateInterceptor{})
+	s.AddInterceptor("Update", "*", &TestUniversalUpdateInterceptor{})
+	s.AddInterceptor("Delete", "*", &TestUniversalDeleteInterceptor{})
 }
 
-func postInterceptor(resource interface{}) {
-	fmt.Printf("Create intercepted for resource: %s\n", getResourceType(resource))
+// Interceptors that will be registered to operate on Patient resources only:
+// ----------------------------------------------------------------------------
+
+// TestPatientCreateInterceptor operates on a Patient resource after it is created
+type TestPatientCreateInterceptor struct {}
+
+func (s *TestPatientCreateInterceptor) Before(resource interface{}) {}
+
+func (s *TestPatientCreateInterceptor) After(resource interface{}) {
+	fmt.Println("TestPatientCreateInterceptor: After()")
 }
 
-func allPostsInterceptor(resource interface{}) {
-	fmt.Printf("Create intercepted for ALL resources\n")
+func (s *TestPatientCreateInterceptor) OnError(err error, resource interface{}) {}
+
+
+// TestPatientUpdateInterceptor operates on a Patient resource both before and 
+// after it is updated
+type TestPatientUpdateInterceptor struct {}
+
+func (s *TestPatientUpdateInterceptor) Before(resource interface{}) {
+	fmt.Println("TestPatientUpdateInterceptor: Before()")
 }
 
-func putInterceptor(resource interface{}) {
-	fmt.Printf("Update intercepted for resource: %s\n", getResourceType(resource))
+func (s *TestPatientUpdateInterceptor) After(resource interface{}) {
+	fmt.Println("TestPatientUpdateInterceptor: After()")
 }
 
-func allPutsInterceptor(resource interface{}) {
-	fmt.Printf("Update intercepted for ALL resources\n")
+func (s *TestPatientUpdateInterceptor) OnError(err error, resource interface{}) {}
+
+// TestPatientDeleteInterceptor operates on a Patient resource only before it is deleted
+type TestPatientDeleteInterceptor struct {}
+
+func (s *TestPatientDeleteInterceptor) Before(resource interface{}) {
+	fmt.Println("TestPatientDeleteInterceptor: Before()")
 }
 
-func deleteInterceptor(resource interface{}) {
-	fmt.Printf("Delete intercepted for resource: %s\n", getResourceType(resource))
+func (s *TestPatientDeleteInterceptor) After(resource interface{}) {}
+
+func (s *TestPatientDeleteInterceptor) OnError(err error, resource interface{}) {}
+
+// Interceptors that will be registered to operate on ANY resource:
+// ----------------------------------------------------------------------------
+
+// TestUniversalCreateInterceptor operates on any resource after it is created
+type TestUniversalCreateInterceptor struct {}
+
+func (s *TestUniversalCreateInterceptor) Before(resource interface{}) {}
+
+func (s *TestUniversalCreateInterceptor) After(resource interface{}) {
+	fmt.Println("TestUniversalCreateInterceptor: After()")
 }
 
-func allDeletesInterceptor(resource interface{}) {
-	fmt.Printf("Delete intercepted for ALL resources\n")
+func (s *TestUniversalCreateInterceptor) OnError(err error, resource interface{}) {}
+
+// TestUniversalUpdateInterceptor operates on any resource both before and after
+// it is updated
+type TestUniversalUpdateInterceptor struct {}
+
+func (s *TestUniversalUpdateInterceptor) Before(resource interface{}) {
+	fmt.Println("TestUniversalUpdateInterceptor: Before()")
 }
 
-func getResourceType(resource interface{}) string {
-	resType := reflect.TypeOf(resource).Elem().Name()
-	return resType
+func (s *TestUniversalUpdateInterceptor) After(resource interface{}) {
+	fmt.Println("TestUniversalUpdateInterceptor: After()")
 }
+
+func (s *TestUniversalUpdateInterceptor) OnError(err error, resource interface{}) {}
+
+// TestUniversalDeleteInterceptor operates on any resource after it is deleted
+type TestUniversalDeleteInterceptor struct {}
+
+func (s *TestUniversalDeleteInterceptor) Before(resource interface{}) {}
+
+func (s *TestUniversalDeleteInterceptor) After(resource interface{}) {
+	fmt.Println("TestUniversalDeleteInterceptor: After()")
+}
+
+func (s *TestUniversalDeleteInterceptor) OnError(err error, resource interface{}) {}


### PR DESCRIPTION
Interceptors now have Before(), After(), and OnError() methods that run before, after, and following a failed database operation, respectively. This was primarily motivated by the need for update interceptors to have access to resources both before AND after an update, so any changes to the resource can be detected.