### PR TITLE
Work with the *gin.Engine after FHIR routes

### DIFF
--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -9,10 +9,13 @@ import (
 	"gopkg.in/mgo.v2"
 )
 
+type AfterRoutes func(*gin.Engine)
+
 type FHIRServer struct {
 	DatabaseHost     string
 	Engine           *gin.Engine
 	MiddlewareConfig map[string][]gin.HandlerFunc
+	AfterRoutes      []AfterRoutes
 }
 
 func (f *FHIRServer) AddMiddleware(key string, middleware gin.HandlerFunc) {
@@ -50,6 +53,10 @@ func (f *FHIRServer) Run(config Config) {
 	Database = session.DB("fhir")
 
 	RegisterRoutes(f.Engine, f.MiddlewareConfig, NewMongoDataAccessLayer(Database), config)
+
+	for _, ar := range f.AfterRoutes {
+		ar(f.Engine)
+	}
 
 	f.Engine.Run(":3001")
 }


### PR DESCRIPTION
Users of the server of the library have the ability to add middleware to the
FHIR resources. The way that the API works, users have access to the underlying
*gin.Engine to add any kind of middleware, but anything they do with it will
happen *before* the FHIR routes. This means that any routes registered will not
be passed through the middleware registered by the main FHIR server. This is a
huge problem when it comes to things like security. This commit lets users
register functions that will set up routes *after* the FHIR server is set up.
That allows them to be protected by security, or any other middleware, that the
FHIR server creates.