### PR TITLE
Fix boolean search + Update Travis to Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-- 1.6
-script: go test ./models ./search ./server ./upload
+- 1.7
+script: go test $(go list ./... | grep -v /vendor/)
 install: true
 services:
 - mongodb

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -584,7 +584,16 @@ func (m *MongoSearcher) createTokenQueryObject(t *TokenParam) bson.M {
 			if !t.AnySystem {
 				criteria["use"] = ci(t.System)
 			}
-		case "code", "boolean", "string", "id":
+		case "boolean":
+			switch t.Code {
+			case "true":
+				return buildBSON(p.Path, true)
+			case "false":
+				return buildBSON(p.Path, false)
+			default:
+				panic(createInvalidSearchError("MSG_PARAM_INVALID", fmt.Sprintf("Parameter \"%s\" content is invalid", t.Name)))
+			}
+		case "code", "string", "id":
 			// criteria isn't a bson, so just return the right answer
 			return buildBSON(p.Path, ci(t.Code))
 		}

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -297,7 +297,36 @@ func getIdentifiersComparisonValue(iSlice []models.Identifier, descending bool) 
 	return strs[0]
 }
 
-// TODO: Test token searches on boolean, code, string, and ContactPoint
+// Tests token searches on boolean
+
+func (m *MongoSearchSuite) TestImmunizationNotGivenQueryObject(c *C) {
+	q := Query{"Immunization", "notgiven=false"}
+	o := m.MongoSearcher.createQueryObject(q)
+	c.Assert(o, DeepEquals, bson.M{
+		"wasNotGiven": false,
+	})
+}
+
+func (m *MongoSearchSuite) TestImmunizationNotGivenQuery(c *C) {
+	q := Query{"Immunization", "notgiven=false"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	num, err := mq.Count()
+	util.CheckErr(err)
+	c.Assert(num, Equals, 1)
+
+	q = Query{"Immunization", "notgiven=true"}
+	mq = m.MongoSearcher.CreateQuery(q)
+	num, err = mq.Count()
+	util.CheckErr(err)
+	c.Assert(num, Equals, 0)
+}
+
+func (m *MongoSearchSuite) TestInvalidBooleanValuePanics(c *C) {
+	q := Query{"Immunization", "notgiven=maybe"}
+	c.Assert(func() { m.MongoSearcher.CreateQuery(q) }, Panics, createInvalidSearchError("MSG_PARAM_INVALID", "Parameter \"notgiven\" content is invalid"))
+}
+
+// TODO: Test token searches on code, string, and ContactPoint
 
 // Tests reference searches by reference id
 


### PR DESCRIPTION
This PR fixes boolean search behavior and also updates the Travis config to use Go 1.7.  In addition, Travis will now test all sub-packages (without having to hard-code the names).