### PR TITLE
Fix ServerURL in server.DefaultConfig

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -11,7 +11,7 @@ var Database *mgo.Database
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:       "localhost",
+	ServerURL:       "http://localhost:3001",
 	IndexConfigPath: "config/indexes.conf",
 	DatabaseName:    "fhir",
 	Auth:            auth.None(),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -41,7 +41,7 @@ func (s *ServerSuite) SetUpSuite(c *C) {
 
 	// Set up the database
 	var err error
-	s.Session, err = mgo.Dial(config.ServerURL)
+	s.Session, err = mgo.Dial("localhost")
 	util.CheckErr(err)
 	s.Database = s.Session.DB(config.DatabaseName)
 


### PR DESCRIPTION
The config's ServerURL is used by auth middleware to indicate redirects.  It must be a full URL -- so the default has been changed from "localhost" to "http://localhost:3001".