### PR TITLE
Fix chained searches with modifiers

### DIFF
--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -494,6 +494,30 @@ func (m *MongoSearchSuite) TestBundleReferenceQueryByMessageDestination(c *C) {
 	c.Assert(num, Equals, 0)
 }
 
+// These tests ensure that a modifier works with a chained search
+func (m *MongoSearchSuite) TestBundleReferenceQueryObjectByMessageHeaderDestination(c *C) {
+	q := Query{"Bundle", "message:MessageHeader.destination-uri=http://acme.com/ehr/fhir"}
+	o := m.MongoSearcher.createQueryObject(q)
+	c.Assert(o, DeepEquals, bson.M{
+		"entry.0.resource.resourceType":         "MessageHeader",
+		"entry.0.resource.destination.endpoint": "http://acme.com/ehr/fhir",
+	})
+}
+
+func (m *MongoSearchSuite) TestBundleReferenceQueryByMessageHeaderDestination(c *C) {
+	q := Query{"Bundle", "message:MessageHeader.destination-uri=http://acme.com/ehr/fhir"}
+	mq := m.MongoSearcher.CreateQuery(q)
+	num, err := mq.Count()
+	util.CheckErr(err)
+	c.Assert(num, Equals, 1)
+
+	q = Query{"Bundle", "message:MessageHeader.destination-uri=http://acme.com/ehr/foo"}
+	mq = m.MongoSearcher.CreateQuery(q)
+	num, err = mq.Count()
+	util.CheckErr(err)
+	c.Assert(num, Equals, 0)
+}
+
 // Test date searches on DateTime / Period
 
 func (m *MongoSearchSuite) TestConditionOnsetQueryObject(c *C) {

--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -994,8 +994,8 @@ func ParseParamNameModifierAndPostFix(fullParam string) (param string, modifier 
 		param = split[0]
 		postfix = split[1]
 	}
-	if strings.Contains(fullParam, ":") {
-		split := strings.SplitN(fullParam, ":", 2)
+	if strings.Contains(param, ":") {
+		split := strings.SplitN(param, ":", 2)
 		param = split[0]
 		modifier = split[1]
 	}

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -17,6 +17,42 @@ func (s *SearchPTSuite) SetUpSuite(c *C) {
 }
 
 /******************************************************************************
+ * PARAMETER NAMES
+ ******************************************************************************/
+
+func (s *SearchPTSuite) TestSimpleName(c *C) {
+	param, modifier, postfix := ParseParamNameModifierAndPostFix("foo")
+
+	c.Assert(param, Equals, "foo")
+	c.Assert(modifier, Equals, "")
+	c.Assert(postfix, Equals, "")
+}
+
+func (s *SearchPTSuite) TestSimpleNameWithModifier(c *C) {
+	param, modifier, postfix := ParseParamNameModifierAndPostFix("foo:Bar")
+
+	c.Assert(param, Equals, "foo")
+	c.Assert(modifier, Equals, "Bar")
+	c.Assert(postfix, Equals, "")
+}
+
+func (s *SearchPTSuite) TestSimpleNameWithPostfix(c *C) {
+	param, modifier, postfix := ParseParamNameModifierAndPostFix("foo.baz")
+
+	c.Assert(param, Equals, "foo")
+	c.Assert(modifier, Equals, "")
+	c.Assert(postfix, Equals, "baz")
+}
+
+func (s *SearchPTSuite) TestSimpleNameWithModifierAndPostfix(c *C) {
+	param, modifier, postfix := ParseParamNameModifierAndPostFix("foo:Bar.baz")
+
+	c.Assert(param, Equals, "foo")
+	c.Assert(modifier, Equals, "Bar")
+	c.Assert(postfix, Equals, "baz")
+}
+
+/******************************************************************************
  * COMPOSITE
  ******************************************************************************/
 
@@ -1688,11 +1724,11 @@ func (s *SearchPTSuite) TestQueryOptionsInvalidRevIncludeParams(c *C) {
 
 func (s *SearchPTSuite) TestQueryOptionsInvalidFormatParam(c *C) {
 	// Format that is not supported (XML)
-	q := Query{Resource: "Patient", Query:"_format=xml"}
+	q := Query{Resource: "Patient", Query: "_format=xml"}
 	c.Assert(func() { q.Options() }, Panics, createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_format\" content is invalid"))
 
 	// Valid format (json)
-	q = Query{Resource: "Patient", Query:"_format=json"}
+	q = Query{Resource: "Patient", Query: "_format=json"}
 	q.Options()
 }
 


### PR DESCRIPTION
Chained searches with modifiers (e.g., `foo:Bar.baz`) were not properly parsed and resulted in errors.  Now they are properly parsed (e.g., param is `foo`, modifier is `Bar`, and chained query is `baz`).  Addresses #93.