### PR TITLE
Added X-Forwarded-Proto Header

### DIFF
--- a/server/resource_controller.go
+++ b/server/resource_controller.go
@@ -243,10 +243,10 @@ func (rc *ResourceController) ConditionalDeleteHandler(c *gin.Context) {
 
 func responseURL(r *http.Request, paths ...string) *url.URL {
 	responseURL := url.URL{}
-	if r.TLS == nil {
-		responseURL.Scheme = "http"
-	} else {
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		responseURL.Scheme = "https"
+	} else {
+		responseURL.Scheme = "http"
 	}
 	responseURL.Host = r.Host
 	responseURL.Path = fmt.Sprintf("/%s", strings.Join(paths, "/"))


### PR DESCRIPTION
We now check the X-Forwarded-Proto header (in addition to the request's TLS settings) to determine what the original protocol of the request was before building the pagination URLs