### PR TITLE
Controllers Use ServerURL to Generate Response URLs

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -11,7 +11,7 @@ var Database *mgo.Database
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:       "http://localhost:3001",
+	ServerURL:       "",
 	IndexConfigPath: "config/indexes.conf",
 	DatabaseName:    "fhir",
 	Auth:            auth.None(),

--- a/server/routing.go
+++ b/server/routing.go
@@ -12,7 +12,7 @@ import (
 
 // RegisterController registers the CRUD routes (and middleware) for a FHIR resource
 func RegisterController(name string, e *gin.Engine, m []gin.HandlerFunc, dal DataAccessLayer, config Config) {
-	rc := NewResourceController(name, dal)
+	rc := NewResourceController(name, dal, config)
 	rcBase := e.Group("/" + name)
 
 	if len(m) > 0 {
@@ -87,7 +87,7 @@ func RegisterRoutes(e *gin.Engine, config map[string][]gin.HandlerFunc, dal Data
 	}
 
 	// Batch Support
-	batch := NewBatchController(dal)
+	batch := NewBatchController(dal, serverConfig)
 	batchHandlers := make([]gin.HandlerFunc, len(config["Batch"]))
 	copy(batchHandlers, config["Batch"])
 	batchHandlers = append(batchHandlers, batch.Post)


### PR DESCRIPTION
The resource and batch controllers are now passed the main server Config object. If a ServerURL is set, the controllers use the ServerURL to build the responseURLs used for pagination.