### PR TITLE
Fixes confusion with JSON mime type

### DIFF
--- a/server/bind.go
+++ b/server/bind.go
@@ -1,24 +1,20 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-)
-
-const (
-	MIMEJSONFHIR = "application/json+fhir"
-	MIMEXMLFHIR  = "application/xml+fhir"
 )
 
 func FHIRBind(c *gin.Context, obj interface{}) error {
 	if c.Request.Method == "GET" {
 		return c.BindWith(obj, binding.Form)
 	}
-	switch c.ContentType() {
-	case MIMEJSONFHIR:
+
+	if strings.Contains(c.ContentType(), "json") {
 		return c.BindJSON(obj)
-	case MIMEXMLFHIR:
-		return c.BindWith(obj, binding.XML)
 	}
+
 	return c.Bind(obj)
 }

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"log"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -36,6 +38,8 @@ func NewServer(databaseHost string) *FHIRServer {
 		ValidateHeaders: false,
 	}))
 
+	server.Engine.Use(AbortNonJSONRequests)
+
 	return server
 }
 
@@ -63,4 +67,13 @@ func (f *FHIRServer) Run(config Config) {
 	}
 
 	f.Engine.Run(":3001")
+}
+
+// AbortNonJSONRequests is middleware that responds to any request that Accepts a format
+// other than JSON with a 406 Not Acceptable status.
+func AbortNonJSONRequests(c *gin.Context) {
+	acceptHeader := c.Request.Header.Get("Accept")
+	if acceptHeader != "" && !strings.Contains(acceptHeader, "json") && !strings.Contains(acceptHeader, "*/*") {
+		c.AbortWithStatus(http.StatusNotAcceptable)
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -49,6 +49,7 @@ func (s *ServerSuite) SetUpSuite(c *C) {
 
 	// Build routes for testing
 	s.Engine = gin.New()
+	s.Engine.Use(AbortNonJSONRequests)
 	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.Database), config)
 
 	// Create httptest server
@@ -512,6 +513,14 @@ func (s *ServerSuite) TestConditionalDelete(c *C) {
 	// Only the 8 females should be left
 	count, err = patientCollection.Count()
 	c.Assert(count, Equals, 8)
+}
+
+func (s *ServerSuite) TestRejectXML(c *C) {
+	req, err := http.NewRequest("GET", s.Server.URL+"/Patient", nil)
+	util.CheckErr(err)
+	req.Header.Add("Accept", "application/xml")
+	resp, err := http.DefaultClient.Do(req)
+	c.Assert(resp.StatusCode, Equals, http.StatusNotAcceptable)
 }
 
 func performSearch(c *C, url string) *models.Bundle {


### PR DESCRIPTION
STU3 changes the mime type for FHIR. The new code simply checks to see if "json"
is contained in the ContentType header.

Provided testing for the AbortNonJSONRequests function
Replaced magic number for the status with the constant from the http package.