### PR TITLE
Removed case-insensitive matching from codes

### DIFF
--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -591,13 +591,13 @@ func (m *MongoSearcher) createTokenQueryObject(t *TokenParam) bson.M {
 				panic(createInvalidSearchError("MSG_PARAM_INVALID", fmt.Sprintf("Parameter \"%s\" content is invalid", t.Name)))
 			}
 		case "code", "string":
-			// criteria isn't a bson, so just return the right answer
+			// We do case-insensitive matching for any string parameter. The "codes" that fall-through to this case
+			// are also case-insensitive matched. In practice only the "gender" code falls into this category. Case-sensitive
+			// codes are in violation of the FHIR spec but are a necessary performance tradeoff to avoid the use of regular expressions.
 			return buildBSON(p.Path, ci(t.Code))
 
 		case "id":
-			// code and id do not need the case-insensitive match. Case-sensitive codes
-			// are in violation of the FHIR spec but are a necessary performance tradeoff
-			// to avoid the use of regular expressions.
+			// IDs do not need the case-insensitive match.
 			return buildBSON(p.Path, t.Code)
 		}
 

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -455,7 +455,7 @@ func (m *MongoSearcher) createQuantityQueryObject(q *QuantityParam) bson.M {
 				bson.M{"unit": ci(q.Code)},
 			}
 		} else {
-			criteria["code"] = ci(q.Code)
+			criteria["code"] = q.Code
 			criteria["system"] = ci(q.System)
 		}
 		return buildBSON(p.Path, criteria)
@@ -561,23 +561,23 @@ func (m *MongoSearcher) createTokenQueryObject(t *TokenParam) bson.M {
 		switch p.Type {
 		case "Coding":
 			criteria = bson.M{}
-			criteria["code"] = ci(t.Code)
+			criteria["code"] = t.Code
 			if !t.AnySystem {
 				criteria["system"] = ci(t.System)
 			}
 		case "CodeableConcept":
 			if t.AnySystem {
-				criteria["coding.code"] = ci(t.Code)
+				criteria["coding.code"] = t.Code
 			} else {
-				criteria["coding"] = bson.M{"$elemMatch": bson.M{"system": ci(t.System), "code": ci(t.Code)}}
+				criteria["coding"] = bson.M{"$elemMatch": bson.M{"system": ci(t.System), "code": t.Code}}
 			}
 		case "Identifier":
-			criteria["value"] = ci(t.Code)
+			criteria["value"] = t.Code
 			if !t.AnySystem {
 				criteria["system"] = ci(t.System)
 			}
 		case "ContactPoint":
-			criteria["value"] = ci(t.Code)
+			criteria["value"] = t.Code
 			if !t.AnySystem {
 				criteria["use"] = ci(t.System)
 			}
@@ -595,7 +595,9 @@ func (m *MongoSearcher) createTokenQueryObject(t *TokenParam) bson.M {
 			return buildBSON(p.Path, ci(t.Code))
 
 		case "id":
-			// id does not need the case-insensitive match
+			// code and id do not need the case-insensitive match. Case-sensitive codes
+			// are in violation of the FHIR spec but are a necessary performance tradeoff
+			// to avoid the use of regular expressions.
 			return buildBSON(p.Path, t.Code)
 		}
 

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -85,7 +85,7 @@ func (m *MongoSearchSuite) TestConditionCodeQueryObjectBySystemAndCode(c *C) {
 		"code.coding": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^http://snomed\\.info/sct$", Options: "i"},
-				"code":   bson.RegEx{Pattern: "^123641001$", Options: "i"},
+				"code":   "123641001",
 			},
 		},
 	})
@@ -122,7 +122,7 @@ func (m *MongoSearchSuite) TestConditionCodeQueryObjectByCode(c *C) {
 	q := Query{"Condition", "code=123641001"}
 
 	o := m.MongoSearcher.createQueryObject(q)
-	c.Assert(o, DeepEquals, bson.M{"code.coding.code": bson.RegEx{Pattern: "^123641001$", Options: "i"}})
+	c.Assert(o, DeepEquals, bson.M{"code.coding.code": "123641001"})
 }
 
 func (m *MongoSearchSuite) TestConditionCodeQueryByCode(c *C) {
@@ -197,7 +197,7 @@ func (m *MongoSearchSuite) TestImagingStudyBodySiteQueryObjectBySystemAndCode(c 
 		"series": bson.M{
 			"$elemMatch": bson.M{
 				"bodySite.system": bson.RegEx{Pattern: "^http://snomed\\.info/sct$", Options: "i"},
-				"bodySite.code":   bson.RegEx{Pattern: "^67734004$", Options: "i"},
+				"bodySite.code":   "67734004",
 			},
 		},
 	})
@@ -228,7 +228,7 @@ func (m *MongoSearchSuite) TestEncounterIdentifierQueryObjectBySystemAndValue(c 
 		"identifier": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^http://acme\\.com$", Options: "i"},
-				"value":  bson.RegEx{Pattern: "^1$", Options: "i"},
+				"value":  "1",
 			},
 		},
 	})
@@ -1306,14 +1306,14 @@ func (m *MongoSearchSuite) TestValueQuantityQueryObjectByValueAndSystemAndCode(c
 				"component": bson.M{
 					"$elemMatch": bson.M{
 						"valueQuantity.value":  bson.M{"$gte": 184.5, "$lt": 185.5},
-						"valueQuantity.code":   bson.RegEx{Pattern: "^\\[lb_av\\]$", Options: "i"},
+						"valueQuantity.code":   "[lb_av]",
 						"valueQuantity.system": bson.RegEx{Pattern: "^http://unitsofmeasure\\.org$", Options: "i"},
 					},
 				},
 			},
 			bson.M{
 				"valueQuantity.value":  bson.M{"$gte": 184.5, "$lt": 185.5},
-				"valueQuantity.code":   bson.RegEx{Pattern: "^\\[lb_av\\]$", Options: "i"},
+				"valueQuantity.code":   "[lb_av]",
 				"valueQuantity.system": bson.RegEx{Pattern: "^http://unitsofmeasure\\.org$", Options: "i"},
 			},
 		},
@@ -1562,7 +1562,7 @@ func (m *MongoSearchSuite) TestConditionTagQueryObject(c *C) {
 		"meta.tag": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^foo$", Options: "i"},
-				"code":   bson.RegEx{Pattern: "^bar$", Options: "i"},
+				"code":   "bar",
 			}},
 	})
 }
@@ -1597,21 +1597,21 @@ func (m *MongoSearchSuite) TestConditionMultipleCodesQueryObject(c *C) {
 				"code.coding": bson.M{
 					"$elemMatch": bson.M{
 						"system": bson.RegEx{Pattern: "^http://hl7\\.org/fhir/sid/icd-9$", Options: "i"},
-						"code":   bson.RegEx{Pattern: "^428\\.0$", Options: "i"},
+						"code":   "428.0",
 					}},
 			},
 			bson.M{
 				"code.coding": bson.M{
 					"$elemMatch": bson.M{
 						"system": bson.RegEx{Pattern: "^http://snomed\\.info/sct$", Options: "i"},
-						"code":   bson.RegEx{Pattern: "^981000124106$", Options: "i"},
+						"code":   "981000124106",
 					}},
 			},
 			bson.M{
 				"code.coding": bson.M{
 					"$elemMatch": bson.M{
 						"system": bson.RegEx{Pattern: "^http://hl7\\.org/fhir/sid/icd-10$", Options: "i"},
-						"code":   bson.RegEx{Pattern: "^I20\\.0$", Options: "i"},
+						"code":   "I20.0",
 					}},
 			},
 		},
@@ -1650,7 +1650,7 @@ func (m *MongoSearchSuite) TestConditionPatientAndCodeAndOnsetQueryObject(c *C) 
 	c.Assert(o["code.coding"], DeepEquals, bson.M{
 		"$elemMatch": bson.M{
 			"system": bson.RegEx{Pattern: "^http://hl7\\.org/fhir/sid/icd-9$", Options: "i"},
-			"code":   bson.RegEx{Pattern: "^428\\.0$", Options: "i"},
+			"code":   "428.0",
 		},
 	})
 
@@ -1720,7 +1720,7 @@ func (m *MongoSearchSuite) TestConditionPatientAndMultipleCodesQueryObject(c *C)
 			"code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://hl7\\.org/fhir/sid/icd-9$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^428\\.0$", Options: "i"},
+					"code":   "428.0",
 				},
 			},
 		},
@@ -1728,7 +1728,7 @@ func (m *MongoSearchSuite) TestConditionPatientAndMultipleCodesQueryObject(c *C)
 			"code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://snomed\\.info/sct$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^981000124106$", Options: "i"},
+					"code":   "981000124106",
 				},
 			},
 		},
@@ -1762,7 +1762,7 @@ func (m *MongoSearchSuite) TestConditionMultiplePatientAndMultipleCodesQueryObje
 			"code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://hl7\\.org/fhir/sid/icd-9$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^428\\.0$", Options: "i"},
+					"code":   "428.0",
 				},
 			},
 		},
@@ -1770,7 +1770,7 @@ func (m *MongoSearchSuite) TestConditionMultiplePatientAndMultipleCodesQueryObje
 			"code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://snomed\\.info/sct$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^981000124106$", Options: "i"},
+					"code":   "981000124106",
 				},
 			},
 		},
@@ -1813,7 +1813,7 @@ func (m *MongoSearchSuite) TestEncounterTypeQueryOptionsWithCount(c *C) {
 		"type.coding": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^http://www\\.ama-assn\\.org/go/cpt$", Options: "i"},
-				"code":   bson.RegEx{Pattern: "^99201$", Options: "i"},
+				"code":   "99201",
 			},
 		},
 	})
@@ -1842,7 +1842,7 @@ func (m *MongoSearchSuite) TestEncounterTypeQueryOptionsForOffset(c *C) {
 		"type.coding": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^http://www\\.ama-assn\\.org/go/cpt$", Options: "i"},
-				"code":   bson.RegEx{Pattern: "^99201$", Options: "i"},
+				"code":   "99201",
 			},
 		},
 	})
@@ -1871,7 +1871,7 @@ func (m *MongoSearchSuite) TestEncounterTypeQueryOptionsForCountAndOffset(c *C) 
 		"type.coding": bson.M{
 			"$elemMatch": bson.M{
 				"system": bson.RegEx{Pattern: "^http://www\\.ama-assn\\.org/go/cpt$", Options: "i"},
-				"code":   bson.RegEx{Pattern: "^99201$", Options: "i"},
+				"code":   "99201",
 			},
 		},
 	})
@@ -1986,7 +1986,7 @@ func (m *MongoSearchSuite) TestObservationCodeQueryOptionsForInclude(c *C) {
 			"component.code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://loinc\\.org$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^17856-6$", Options: "i"},
+					"code":   "17856-6",
 				},
 			},
 		},
@@ -1994,7 +1994,7 @@ func (m *MongoSearchSuite) TestObservationCodeQueryOptionsForInclude(c *C) {
 			"code.coding": bson.M{
 				"$elemMatch": bson.M{
 					"system": bson.RegEx{Pattern: "^http://loinc\\.org$", Options: "i"},
-					"code":   bson.RegEx{Pattern: "^17856-6$", Options: "i"},
+					"code":   "17856-6",
 				},
 			},
 		},


### PR DESCRIPTION
Case sensitive matching of codes, for example in the query:

`https://syntheticmass.mitre.org/fhir/Encounter?type.code=185349003` 

has a huge performance impact. Although this goes against the FHIR spec, removing the matching on codes to improve performance.