### PR TITLE
Chained search

### DIFF
--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -445,7 +445,7 @@ func prependLookupKeyToSearchPaths(searchParams []SearchParam, numReferencePaths
 				}
 
 				for i, searchPath := range searchInfo.Paths {
-					searchInfo.Paths[i].Path = prependStr + strconv.Itoa(i) + "." + searchPath.Path
+					searchInfo.Paths[i].Path = prependStr + strconv.Itoa(i%numReferencePaths) + "." + searchPath.Path
 				}
 				item.setInfo(searchInfo)
 			}
@@ -457,7 +457,7 @@ func prependLookupKeyToSearchPaths(searchParams []SearchParam, numReferencePaths
 			}
 
 			for i, searchPath := range searchInfo.Paths {
-				searchInfo.Paths[i].Path = prependStr + strconv.Itoa(i) + "." + searchPath.Path
+				searchInfo.Paths[i].Path = prependStr + strconv.Itoa(i%numReferencePaths) + "." + searchPath.Path
 			}
 			matchParam.setInfo(searchInfo)
 		}
@@ -466,15 +466,19 @@ func prependLookupKeyToSearchPaths(searchParams []SearchParam, numReferencePaths
 }
 
 // duplicatePaths duplicates the paths in the SearchParamInfo n times.
+// Given paths [a, b] and n = 3, this would return [a, a, a, b, b, b]
 func duplicatePaths(info *SearchParamInfo, n int) {
 
 	paths := info.Paths
 	numPaths := len(paths)
 	newPaths := make([]SearchParamPath, numPaths*n)
 
-	for i := 0; i < numPaths*n; i++ {
-		newPaths[i] = paths[i%numPaths]
+	for i := 0; i < numPaths; i++ {
+		for j := 0; j < n; j++ {
+			newPaths[i*n+j] = paths[i]
+		}
 	}
+
 	info.Paths = newPaths
 }
 

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -696,8 +696,8 @@ func (m *MongoSearcher) createReferenceQueryObject(r *ReferenceParam) bson.M {
 			criteria["reference"] = ci(ref.URL)
 
 		case ChainedQueryReference:
-			// We want to build the BSON on the reference's SearchParam, not the ReferenceParam itself
-			return m.createQueryObjectFromParams(ref.ChainedQuery.Params())
+			// This should be handled exclusively by the createPipelineObject
+			panic(createInternalServerError("", ""))
 		}
 		return buildBSON(p.Path, criteria)
 	}

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -110,7 +110,7 @@ func (m *MongoSearcher) aggregate(bsonQuery *BSONQuery, options *QueryOptions) (
 		}}
 		countPipeline := make([]bson.M, len(bsonQuery.Pipeline)+1)
 		copy(countPipeline, bsonQuery.Pipeline)
-		countPipeline = append(countPipeline, countStage)
+		countPipeline[len(countPipeline)-1] = countStage
 
 		result := struct {
 			Total float64 `bson:"total"`

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -580,7 +580,7 @@ func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithMultipleReferenceP
 	})
 }
 
-func (m *MongoSearchSuite) TestChainedOrPipelineObjectWithMultipleReferencePathsAndOr(c *C) {
+func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithMultipleReferencePathsAndOr(c *C) {
 	q := Query{"AuditEvent", "patient.gender=foo,bar"}
 
 	bsonQuery := m.MongoSearcher.convertToBSON(q)

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -502,15 +502,50 @@ func (m *MongoSearchSuite) TestBundleReferenceQueryByMessageId(c *C) {
 
 // TODO: Test execution of reference search on PatientURL (as above)
 
-// Test reference searches on chained queries
-
-func (m *MongoSearchSuite) TestConditionReferenceQueryObjectByPatientGender(c *C) {
+func (m *MongoSearchSuite) TestConditionChainedSearchPipelineObject(c *C) {
 	q := Query{"Condition", "patient.gender=male"}
 
-	o := m.MongoSearcher.createQueryObject(q)
-	c.Assert(o, DeepEquals, bson.M{
-		"subject.referenceid": bson.M{"$in": []string{"4954037118555241963"}},
-		"subject.type":        "Patient",
+	bsonQuery := m.MongoSearcher.convertToBSON(q)
+	c.Assert(bsonQuery.Resource, Equals, "Condition")
+	c.Assert(bsonQuery.Query, IsNil)
+	c.Assert(bsonQuery.UsesPipeline(), Equals, true)
+
+	c.Assert(bsonQuery.Pipeline, DeepEquals, []bson.M{
+		bson.M{"$match": bson.M{}},
+		bson.M{"$lookup": bson.M{
+			"from":         "patients",
+			"localField":   "subject.referenceid",
+			"foreignField": "_id",
+			"as":           "_patients",
+		}},
+		bson.M{"$match": bson.M{
+			"_patients.gender": bson.RegEx{Pattern: "^male$", Options: "i"},
+		}},
+	})
+}
+
+func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithOr(c *C) {
+	q := Query{"Condition", "patient.gender=foo,bar"}
+
+	bsonQuery := m.MongoSearcher.convertToBSON(q)
+	c.Assert(bsonQuery.Resource, Equals, "Condition")
+	c.Assert(bsonQuery.Query, IsNil)
+	c.Assert(bsonQuery.UsesPipeline(), Equals, true)
+
+	c.Assert(bsonQuery.Pipeline, DeepEquals, []bson.M{
+		bson.M{"$match": bson.M{}},
+		bson.M{"$lookup": bson.M{
+			"from":         "patients",
+			"localField":   "subject.referenceid",
+			"foreignField": "_id",
+			"as":           "_patients",
+		}},
+		bson.M{"$match": bson.M{
+			"$or": []bson.M{
+				bson.M{"_patients.gender": bson.RegEx{Pattern: "^foo$", Options: "i"}},
+				bson.M{"_patients.gender": bson.RegEx{Pattern: "^bar$", Options: "i"}},
+			},
+		}},
 	})
 }
 
@@ -526,6 +561,20 @@ func (m *MongoSearchSuite) TestConditionReferenceQueryByPatientGender(c *C) {
 	util.CheckErr(err)
 	resultsVal = reflect.ValueOf(results).Elem()
 	c.Assert(resultsVal.Len(), Equals, 1)
+}
+
+func (m *MongoSearchSuite) TestConditionReferenceQueryByPatientGenderOr(c *C) {
+	q := Query{"Condition", "patient.gender=male,foo"}
+	results, _, err := m.MongoSearcher.Search(q)
+	util.CheckErr(err)
+	resultsVal := reflect.ValueOf(results).Elem()
+	c.Assert(resultsVal.Len(), Equals, 5)
+
+	q = Query{"Condition", "patient.gender=male,female"}
+	results, _, err = m.MongoSearcher.Search(q)
+	util.CheckErr(err)
+	resultsVal = reflect.ValueOf(results).Elem()
+	c.Assert(resultsVal.Len(), Equals, 6)
 }
 
 // These next tests ensure that the indexer is properly converted to a mongo
@@ -1558,6 +1607,10 @@ type BroParam struct {
 
 func (b *BroParam) getInfo() SearchParamInfo {
 	return b.info
+}
+
+func (b *BroParam) setInfo(info SearchParamInfo) {
+	b.info = info
 }
 
 func (b *BroParam) getQueryParamAndValue() (string, string) {

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -516,10 +516,10 @@ func (m *MongoSearchSuite) TestConditionChainedSearchPipelineObject(c *C) {
 			"from":         "patients",
 			"localField":   "subject.referenceid",
 			"foreignField": "_id",
-			"as":           "_patients",
+			"as":           "_lookup0",
 		}},
 		bson.M{"$match": bson.M{
-			"_patients.gender": bson.RegEx{Pattern: "^male$", Options: "i"},
+			"_lookup0.gender": bson.RegEx{Pattern: "^male$", Options: "i"},
 		}},
 	})
 }
@@ -538,12 +538,43 @@ func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithOr(c *C) {
 			"from":         "patients",
 			"localField":   "subject.referenceid",
 			"foreignField": "_id",
-			"as":           "_patients",
+			"as":           "_lookup0",
 		}},
 		bson.M{"$match": bson.M{
 			"$or": []bson.M{
-				bson.M{"_patients.gender": bson.RegEx{Pattern: "^foo$", Options: "i"}},
-				bson.M{"_patients.gender": bson.RegEx{Pattern: "^bar$", Options: "i"}},
+				bson.M{"_lookup0.gender": bson.RegEx{Pattern: "^foo$", Options: "i"}},
+				bson.M{"_lookup0.gender": bson.RegEx{Pattern: "^bar$", Options: "i"}},
+			},
+		}},
+	})
+}
+
+func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithMultipleReferencePaths(c *C) {
+	q := Query{"AuditEvent", "patient.gender=male"}
+
+	bsonQuery := m.MongoSearcher.convertToBSON(q)
+	c.Assert(bsonQuery.Resource, Equals, "AuditEvent")
+	c.Assert(bsonQuery.Query, IsNil)
+	c.Assert(bsonQuery.usesPipeline(), Equals, true)
+
+	c.Assert(bsonQuery.Pipeline, DeepEquals, []bson.M{
+		bson.M{"$match": bson.M{}},
+		bson.M{"$lookup": bson.M{
+			"from":         "patients",
+			"localField":   "agent.reference.referenceid",
+			"foreignField": "_id",
+			"as":           "_lookup0",
+		}},
+		bson.M{"$lookup": bson.M{
+			"from":         "patients",
+			"localField":   "entity.reference.referenceid",
+			"foreignField": "_id",
+			"as":           "_lookup1",
+		}},
+		bson.M{"$match": bson.M{
+			"$or": []bson.M{
+				bson.M{"_lookup0.gender": bson.RegEx{Pattern: "^male$", Options: "i"}},
+				bson.M{"_lookup1.gender": bson.RegEx{Pattern: "^male$", Options: "i"}},
 			},
 		}},
 	})

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -508,7 +508,7 @@ func (m *MongoSearchSuite) TestConditionChainedSearchPipelineObject(c *C) {
 	bsonQuery := m.MongoSearcher.convertToBSON(q)
 	c.Assert(bsonQuery.Resource, Equals, "Condition")
 	c.Assert(bsonQuery.Query, IsNil)
-	c.Assert(bsonQuery.UsesPipeline(), Equals, true)
+	c.Assert(bsonQuery.usesPipeline(), Equals, true)
 
 	c.Assert(bsonQuery.Pipeline, DeepEquals, []bson.M{
 		bson.M{"$match": bson.M{}},
@@ -530,7 +530,7 @@ func (m *MongoSearchSuite) TestChainedSearchPipelineObjectWithOr(c *C) {
 	bsonQuery := m.MongoSearcher.convertToBSON(q)
 	c.Assert(bsonQuery.Resource, Equals, "Condition")
 	c.Assert(bsonQuery.Query, IsNil)
-	c.Assert(bsonQuery.UsesPipeline(), Equals, true)
+	c.Assert(bsonQuery.usesPipeline(), Equals, true)
 
 	c.Assert(bsonQuery.Pipeline, DeepEquals, []bson.M{
 		bson.M{"$match": bson.M{}},

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1786,6 +1786,34 @@ func (s *SearchPTSuite) TestQueryOptionsURLQueryParameters(c *C) {
 	c.Assert(all[5], DeepEquals, URLQueryParameter{Key: RevIncludeParam, Value: "Encounter:patient"})
 }
 
+func (s *SearchPTSuite) TestQueryUsesChainedSearchAndPipeline(c *C) {
+	q := Query{"Condition", "patient.gender=male"}
+	c.Assert(q.UsesChainedSearch(), Equals, true)
+	c.Assert(q.UsesPipeline(), Equals, true)
+
+	q = Query{"Condition", "patient.gender=female,foo"}
+	c.Assert(q.UsesChainedSearch(), Equals, true)
+	c.Assert(q.UsesPipeline(), Equals, true)
+
+	q = Query{"Patient", "gender=male"}
+	c.Assert(q.UsesChainedSearch(), Equals, false)
+	c.Assert(q.UsesPipeline(), Equals, false)
+}
+
+func (s *SearchPTSuite) TestSearchParamInfoClone(c *C) {
+	original := SearchParamInfo{
+		Name:  "foo",
+		Type:  "number",
+		Paths: []SearchParamPath{SearchParamPath{Path: "bar", Type: "number"}},
+	}
+
+	clone := original.clone()
+	c.Assert(clone.Paths, DeepEquals, original.Paths)
+
+	clone.Paths[0].Path = "notbar"
+	c.Assert(clone.Paths, Not(DeepEquals), original.Paths)
+}
+
 // getAllIncludeNames obtains the names of all includes that would be included with
 // _include=* from the SearchParameterDictionary
 func getAllIncludeNames(resourceName string) []string {


### PR DESCRIPTION
Implemented chained search using the aggregation framework. This became
complicated when handling chained ORs (see comments in mongo_search.go). Also updated unit tests.