### PR TITLE
Configuration Updates

### DIFF
--- a/search/mongo_registry_test.go
+++ b/search/mongo_registry_test.go
@@ -18,7 +18,7 @@ func (s *MongoRegistrySuite) TestRegisterAndLookupBSONBuilder(c *C) {
 	GlobalMongoRegistry().RegisterBSONBuilder("test", build)
 	obtained, err := GlobalMongoRegistry().LookupBSONBuilder("test")
 	util.CheckErr(err)
-	bmap, err := obtained(&StringParam{String: "bar"}, NewMongoSearcher(nil, true))
+	bmap, err := obtained(&StringParam{String: "bar"}, NewMongoSearcher(nil, true, false)) // enableCISearches = true, readonly = false
 	util.CheckErr(err)
 	c.Assert(bmap, HasLen, 1)
 	c.Assert(bmap["foo"], Equals, "bar")

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"crypto/md5"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -29,18 +30,27 @@ func (b *BSONQuery) usesPipeline() bool {
 	return b.Query == nil
 }
 
+// CountCache is used to cache the total count of results for a specific query.
+// The Id is the md5 hash of the query string.
+type CountCache struct {
+	Id    string `bson:"_id"`
+	Count uint32 `bson:"count"`
+}
+
 // MongoSearcher implements FHIR searches using the Mongo database.
 type MongoSearcher struct {
 	db               *mgo.Database
 	enableCISearches bool
+	readonly         bool
 }
 
 // NewMongoSearcher creates a new instance of a MongoSearcher, given a pointer
 // to an mgo.Database.
-func NewMongoSearcher(db *mgo.Database, enableCISearches bool) *MongoSearcher {
+func NewMongoSearcher(db *mgo.Database, enableCISearches bool, readonly bool) *MongoSearcher {
 	return &MongoSearcher{
 		db:               db,
 		enableCISearches: enableCISearches,
+		readonly:         readonly,
 	}
 }
 
@@ -66,11 +76,25 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 	// build the BSON query (without any options)
 	bsonQuery := m.convertToBSON(query)
 
+	// Check to see if we already have a count cached for this query. If so, use it
+	// and tell the searcher to skip doing the count. This can only be done reliably if
+	// the server is in -readonly mode.
+	docount := true
+	queryHash := fmt.Sprintf("%x", md5.Sum([]byte(query.Query)))
+	if m.readonly {
+		countcache := &CountCache{}
+		err = m.db.C("countcache").FindId(queryHash).One(countcache)
+		if err == nil {
+			total = countcache.Count
+			docount = false
+		}
+	}
+
 	// execute the query
 	if bsonQuery.usesPipeline() {
 		// The (slower) aggregation pipeline is used if the query contains includes or revincludes
 		var mgoPipe *mgo.Pipe
-		mgoPipe, total, err = m.aggregate(bsonQuery, query.Options())
+		mgoPipe, total, err = m.aggregate(bsonQuery, query.Options(), docount)
 		if err != nil {
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
@@ -82,7 +106,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 	} else {
 		// Otherwise, the (faster) standard query is used
 		var mgoQuery *mgo.Query
-		mgoQuery, total, err = m.find(bsonQuery, query.Options())
+		mgoQuery, total, err = m.find(bsonQuery, query.Options(), docount)
 		if err != nil {
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
@@ -97,44 +121,59 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		return nil, 0, err
 	}
 
+	// If the count wasn't already in cache, add it to cache.
+	if m.readonly && docount {
+		countcache := &CountCache{
+			Id:    queryHash,
+			Count: total,
+		}
+		// Don't collect the error here since this should fail silently.
+		m.db.C("countcache").Insert(countcache)
+	}
+
 	return results, total, nil
 }
 
 // aggregate takes a BSONQuery and runs its Pipeline through the mongo aggregation framework. Any query options
 // will be added to the end of the pipeline.
-func (m *MongoSearcher) aggregate(bsonQuery *BSONQuery, options *QueryOptions) (pipe *mgo.Pipe, total uint32, err error) {
+func (m *MongoSearcher) aggregate(bsonQuery *BSONQuery, options *QueryOptions, docount bool) (pipe *mgo.Pipe, total uint32, err error) {
 	c := m.db.C(models.PluralizeLowerResourceName(bsonQuery.Resource))
 
 	// First get a count of the total results (doesn't apply any options)
-	if len(bsonQuery.Pipeline) == 1 {
-		// The pipeline is only being used for includes/revincludes, meaning the entire
-		// collection is being searched. It's faster just to get a total count from the
-		// collection after a find operation. The first stage in the Pipeline will
-		// always be a $match stage.
-		intTotal, err := c.Find(bsonQuery.Pipeline[0]["$match"]).Count()
-		if err != nil {
-			return nil, 0, err
+	if docount {
+		if len(bsonQuery.Pipeline) == 1 {
+			// The pipeline is only being used for includes/revincludes, meaning the entire
+			// collection is being searched. It's faster just to get a total count from the
+			// collection after a find operation. The first stage in the Pipeline will
+			// always be a $match stage.
+			intTotal, err := c.Find(bsonQuery.Pipeline[0]["$match"]).Count()
+			if err != nil {
+				return nil, 0, err
+			}
+			total = uint32(intTotal)
+		} else {
+			// Do the count in the aggregation framework
+			countStage := bson.M{"$group": bson.M{
+				"_id":   nil,
+				"total": bson.M{"$sum": 1},
+			}}
+			countPipeline := make([]bson.M, len(bsonQuery.Pipeline)+1)
+			copy(countPipeline, bsonQuery.Pipeline)
+			countPipeline[len(countPipeline)-1] = countStage
+
+			result := struct {
+				Total float64 `bson:"total"`
+			}{}
+
+			err = c.Pipe(countPipeline).One(&result)
+			if err != nil {
+				return nil, 0, err
+			}
+			total = uint32(result.Total)
 		}
-		total = uint32(intTotal)
 	} else {
-		// Do the count in the aggregation framework
-		countStage := bson.M{"$group": bson.M{
-			"_id":   nil,
-			"total": bson.M{"$sum": 1},
-		}}
-		countPipeline := make([]bson.M, len(bsonQuery.Pipeline)+1)
-		copy(countPipeline, bsonQuery.Pipeline)
-		countPipeline[len(countPipeline)-1] = countStage
-
-		result := struct {
-			Total float64 `bson:"total"`
-		}{}
-
-		err = c.Pipe(countPipeline).One(&result)
-		if err != nil {
-			return nil, 0, err
-		}
-		total = uint32(result.Total)
+		// The count was already cached, so return 0 and expect it to be overwritten in MongoSearcher.Search().
+		total = uint32(0)
 	}
 
 	// Now setup the search pipeline (applying options, if any)
@@ -147,15 +186,20 @@ func (m *MongoSearcher) aggregate(bsonQuery *BSONQuery, options *QueryOptions) (
 
 // find takes a BSONQuery and runs a standard mongo search on that query. Any query options are applied
 // after the initial search is performed.
-func (m *MongoSearcher) find(bsonQuery *BSONQuery, options *QueryOptions) (query *mgo.Query, total uint32, err error) {
+func (m *MongoSearcher) find(bsonQuery *BSONQuery, options *QueryOptions, docount bool) (query *mgo.Query, total uint32, err error) {
 	c := m.db.C(models.PluralizeLowerResourceName(bsonQuery.Resource))
 
 	// First get a count of the total results (doesn't apply any options)
-	intTotal, err := c.Find(bsonQuery.Query).Count()
-	if err != nil {
-		return nil, 0, err
+	if docount {
+		intTotal, err := c.Find(bsonQuery.Query).Count()
+		if err != nil {
+			return nil, 0, err
+		}
+		total = uint32(intTotal)
+	} else {
+		// The count was already cached, so return 0 and expect it to be overwritten in MongoSearcher.Search().
+		total = uint32(0)
 	}
-	total = uint32(intTotal)
 
 	searchQuery := c.Find(bsonQuery.Query)
 	if options != nil {

--- a/server/batch_controller_test.go
+++ b/server/batch_controller_test.go
@@ -41,7 +41,7 @@ func (s *BatchControllerSuite) SetUpSuite(c *C) {
 
 	// Build routes for testing
 	s.Engine = gin.New()
-	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, true), Config{})
+	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, DefaultConfig), DefaultConfig)
 
 	// Create httptest server
 	s.Server = httptest.NewServer(s.Engine)

--- a/server/config.go
+++ b/server/config.go
@@ -9,17 +9,7 @@ import (
 // Once ie removes the dependency on the global, this should go away
 var Database *mgo.Database
 
-// DefaultConfig is the default server configuration
-var DefaultConfig = Config{
-	ServerURL:        "",
-	IndexConfigPath:  "config/indexes.conf",
-	DatabaseName:     "fhir",
-	Auth:             auth.None(),
-	EnableCISearches: true,
-}
-
-// Config is used to hold information about the configuration of the FHIR
-// server.
+// Config is used to hold information about the configuration of the FHIR server.
 type Config struct {
 	// ServerURL is the full URL for the root of the server. This may be used
 	// by other middleware to compute redirect URLs
@@ -30,10 +20,26 @@ type Config struct {
 	// IndexConfigPath is the path to an indexes.conf configuration file, specifying
 	// what mongo indexes the server should create (or verify) on startup
 	IndexConfigPath string
+	// DatabaseHost is the url of the running mongo instance to use for the fhir database.
+	DatabaseHost string
 	// DatabaseName is the name of the mongo database used for the fhir database.
-	// Typically this will be the DefaultDatabaseName
+	// Typically this will be the default DatabaseName "fhir".
 	DatabaseName string
 	// EnableCISearches toggles whether the mongo searches uses regexes to maintain
 	// case-insesitivity when performing searches on string fields, codes, etc.
 	EnableCISearches bool
+	// ReadOnly toggles whether the server is in read-only mode. In read-only
+	// mode any HTTP verb other than GET, HEAD or OPTIONS is rejected.
+	ReadOnly bool
+}
+
+// DefaultConfig is the default server configuration
+var DefaultConfig = Config{
+	ServerURL:        "",
+	IndexConfigPath:  "config/indexes.conf",
+	DatabaseHost:     "localhost:27017",
+	DatabaseName:     "fhir",
+	Auth:             auth.None(),
+	EnableCISearches: true,
+	ReadOnly:         false,
 }

--- a/server/config.go
+++ b/server/config.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/intervention-engine/fhir/auth"
 	"gopkg.in/mgo.v2"
 )
@@ -25,6 +27,9 @@ type Config struct {
 	// DatabaseName is the name of the mongo database used for the fhir database.
 	// Typically this will be the default DatabaseName "fhir".
 	DatabaseName string
+	// DatabaseTimeout is the amount of time the mgo driver will wait for a response
+	// from mongo before timing out.
+	DatabaseTimeout time.Duration
 	// EnableCISearches toggles whether the mongo searches uses regexes to maintain
 	// case-insesitivity when performing searches on string fields, codes, etc.
 	EnableCISearches bool
@@ -39,6 +44,7 @@ var DefaultConfig = Config{
 	IndexConfigPath:  "config/indexes.conf",
 	DatabaseHost:     "localhost:27017",
 	DatabaseName:     "fhir",
+	DatabaseTimeout:  1 * time.Minute,
 	Auth:             auth.None(),
 	EnableCISearches: true,
 	ReadOnly:         false,

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AbortNonJSONRequestsMiddleware is middleware that responds to any request that Accepts a Content-Type
+// other than JSON (or a JSON flavor) with a 406 Not Acceptable status.
+func AbortNonJSONRequestsMiddleware(c *gin.Context) {
+	acceptHeader := c.Request.Header.Get("Accept")
+	if acceptHeader != "" && !strings.Contains(acceptHeader, "json") && !strings.Contains(acceptHeader, "*/*") {
+		c.AbortWithStatus(http.StatusNotAcceptable)
+	}
+	c.Next()
+}
+
+// ReadOnlyMiddleware makes the API read-only and responds to any requests that are not
+// GET, HEAD, or OPTIONS with a 405 Method Not Allowed error.
+func ReadOnlyMiddleware(c *gin.Context) {
+	method := c.Request.Method
+	switch method {
+	// allowed methods:
+	case "GET", "HEAD", "OPTIONS":
+		c.Next()
+	// all other methods:
+	default:
+		c.AbortWithStatus(http.StatusMethodNotAllowed)
+	}
+}

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"gopkg.in/mgo.v2/dbtest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/suite"
+)
+
+type MiddlewareTestSuite struct {
+	suite.Suite
+	DBServer      *dbtest.DBServer
+	MasterSession *MasterSession
+}
+
+func TestMiddlewareTestSuite(t *testing.T) {
+	suite.Run(t, new(MiddlewareTestSuite))
+}
+
+func (m *MiddlewareTestSuite) SetupSuite() {
+	// Create a temporary directory for the test database
+	var err error
+	err = os.Mkdir("./testdb", 0775)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// setup the mongo database
+	m.DBServer = &dbtest.DBServer{}
+	m.DBServer.SetPath("./testdb")
+	m.MasterSession = NewMasterSession(m.DBServer.Session(), "fhir-test")
+
+	// Set gin to release mode (less verbose output)
+	gin.SetMode(gin.ReleaseMode)
+}
+
+func (m *MiddlewareTestSuite) TearDownSuite() {
+	m.MasterSession.session.Close()
+	m.DBServer.Wipe()
+	m.DBServer.Stop()
+
+	// remove the temporary database directory
+	var err error
+	err = removeContents("./testdb")
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Remove("./testdb")
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (m *MiddlewareTestSuite) TestRejectXML() {
+	e := gin.New()
+	e.Use(AbortNonJSONRequestsMiddleware)
+	RegisterRoutes(e, nil, NewMongoDataAccessLayer(m.MasterSession, nil, DefaultConfig), DefaultConfig)
+	server := httptest.NewServer(e)
+
+	req, err := http.NewRequest("GET", server.URL+"/Patient", nil)
+	m.NoError(err)
+	req.Header.Add("Accept", "application/xml")
+	resp, err := http.DefaultClient.Do(req)
+	m.Equal(http.StatusNotAcceptable, resp.StatusCode)
+}
+
+func (m *MiddlewareTestSuite) TestReadOnlyMode() {
+	e := gin.New()
+	e.Use(ReadOnlyMiddleware)
+	config := DefaultConfig
+	config.ReadOnly = true
+	RegisterRoutes(e, nil, NewMongoDataAccessLayer(m.MasterSession, nil, config), config)
+	server := httptest.NewServer(e)
+
+	req, err := http.NewRequest("POST", server.URL+"/Patient", nil)
+	m.NoError(err)
+	resp, err := http.DefaultClient.Do(req)
+	m.Equal(http.StatusMethodNotAllowed, resp.StatusCode)
+}

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -80,11 +80,12 @@ func (ws *WorkerSession) Close() {
 }
 
 // NewMongoDataAccessLayer returns an implementation of DataAccessLayer that is backed by a Mongo database
-func NewMongoDataAccessLayer(ms *MasterSession, interceptors map[string]InterceptorList, enableCISearches bool) DataAccessLayer {
+func NewMongoDataAccessLayer(ms *MasterSession, interceptors map[string]InterceptorList, config Config) DataAccessLayer {
 	return &mongoDataAccessLayer{
 		MasterSession:    ms,
 		Interceptors:     interceptors,
-		enableCISearches: enableCISearches,
+		enableCISearches: config.EnableCISearches,
+		readonly:         config.ReadOnly,
 	}
 }
 
@@ -92,6 +93,7 @@ type mongoDataAccessLayer struct {
 	MasterSession    *MasterSession
 	Interceptors     map[string]InterceptorList
 	enableCISearches bool
+	readonly         bool
 }
 
 // InterceptorList is a list of interceptors registered for a given database operation
@@ -393,7 +395,7 @@ func (dal *mongoDataAccessLayer) Search(baseURL url.URL, searchQuery search.Quer
 	worker := dal.MasterSession.GetWorkerSession()
 	defer worker.Close()
 
-	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches)
+	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches, dal.readonly)
 
 	result, total, err := searcher.Search(searchQuery)
 	if err != nil {
@@ -458,7 +460,7 @@ func (dal *mongoDataAccessLayer) FindIDs(searchQuery search.Query) (IDs []string
 	newQuery := search.Query{Resource: searchQuery.Resource, Query: newParams.Encode()}
 
 	// Now search on that query, unmarshaling to a temporary struct and converting results to []string
-	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches)
+	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches, dal.readonly)
 	results, _, err := searcher.Search(newQuery)
 	if err != nil {
 		return nil, convertMongoErr(err)

--- a/server/mongo_indexes_test.go
+++ b/server/mongo_indexes_test.go
@@ -66,7 +66,7 @@ func (s *MongoIndexesTestSuite) SetupSuite() {
 
 	// Build routes for testing
 	s.Engine = gin.New()
-	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, true), s.Config)
+	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, s.Config), s.Config)
 
 	// Create httptest server
 	s.Server = httptest.NewServer(s.Engine)

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -16,7 +14,7 @@ import (
 type AfterRoutes func(*gin.Engine)
 
 type FHIRServer struct {
-	DatabaseHost     string
+	Config           Config
 	Engine           *gin.Engine
 	MiddlewareConfig map[string][]gin.HandlerFunc
 	AfterRoutes      []AfterRoutes
@@ -44,9 +42,9 @@ func (f *FHIRServer) AddInterceptor(op, resourceType string, handler Interceptor
 	return errors.New(fmt.Sprintf("AddInterceptor: unsupported database operation %s", op))
 }
 
-func NewServer(databaseHost string) *FHIRServer {
+func NewServer(config Config) *FHIRServer {
 	server := &FHIRServer{
-		DatabaseHost:     databaseHost,
+		Config:           config,
 		MiddlewareConfig: make(map[string][]gin.HandlerFunc),
 		Interceptors:     make(map[string]InterceptorList),
 	}
@@ -62,43 +60,50 @@ func NewServer(databaseHost string) *FHIRServer {
 		ValidateHeaders: false,
 	}))
 
-	server.Engine.Use(AbortNonJSONRequests)
+	server.Engine.Use(AbortNonJSONRequestsMiddleware)
+
+	if config.ReadOnly {
+		server.Engine.Use(ReadOnlyMiddleware)
+	}
 
 	return server
 }
 
-func (f *FHIRServer) Run(config Config) {
+func (f *FHIRServer) Run() {
 	var err error
 
 	// Establish initial connection to mongo
-	session, err := mgo.Dial(f.DatabaseHost)
+	session, err := mgo.Dial(f.Config.DatabaseHost)
 
 	if err != nil {
 		panic(err)
 	}
 
 	defer session.Close()
-	Database = session.DB(config.DatabaseName)
+	Database = session.DB(f.Config.DatabaseName)
 	log.Println("Connected to mongodb")
 
 	// Establish master session
-	masterSession := NewMasterSession(session, config.DatabaseName)
+	masterSession := NewMasterSession(session, f.Config.DatabaseName)
 
-	RegisterRoutes(f.Engine, f.MiddlewareConfig, NewMongoDataAccessLayer(masterSession, f.Interceptors, config.EnableCISearches), config)
-	ConfigureIndexes(masterSession, config)
+	RegisterRoutes(f.Engine, f.MiddlewareConfig, NewMongoDataAccessLayer(masterSession, f.Interceptors, f.Config), f.Config)
+	ConfigureIndexes(masterSession, f.Config)
 
 	for _, ar := range f.AfterRoutes {
 		ar(f.Engine)
 	}
 
-	f.Engine.Run(":3001")
-}
-
-// AbortNonJSONRequests is middleware that responds to any request that Accepts a format
-// other than JSON with a 406 Not Acceptable status.
-func AbortNonJSONRequests(c *gin.Context) {
-	acceptHeader := c.Request.Header.Get("Accept")
-	if acceptHeader != "" && !strings.Contains(acceptHeader, "json") && !strings.Contains(acceptHeader, "*/*") {
-		c.AbortWithStatus(http.StatusNotAcceptable)
+	// If not in -readonly mode, clear the count cache
+	if !f.Config.ReadOnly {
+		worker := masterSession.GetWorkerSession()
+		defer worker.Close()
+		err = worker.DB().C("countcache").DropCollection()
+		if err != nil {
+			log.Println("Failed to clear search result count cache")
+		}
+	} else {
+		log.Println("Running in read-only mode!")
 	}
+
+	f.Engine.Run(":3001")
 }

--- a/server/server_setup.go
+++ b/server/server_setup.go
@@ -74,12 +74,13 @@ func (f *FHIRServer) Run() {
 
 	// Establish initial connection to mongo
 	session, err := mgo.Dial(f.Config.DatabaseHost)
-
 	if err != nil {
 		panic(err)
 	}
-
 	defer session.Close()
+
+	session.SetSocketTimeout(f.Config.DatabaseTimeout)
+
 	Database = session.DB(f.Config.DatabaseName)
 	log.Println("Connected to mongodb")
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -52,8 +52,7 @@ func (s *ServerSuite) SetUpSuite(c *C) {
 
 	// Build routes for testing
 	s.Engine = gin.New()
-	s.Engine.Use(AbortNonJSONRequests)
-	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, true), config)
+	RegisterRoutes(s.Engine, make(map[string][]gin.HandlerFunc), NewMongoDataAccessLayer(s.MasterSession, s.Interceptors, DefaultConfig), DefaultConfig)
 
 	// Create httptest server
 	s.Server = httptest.NewServer(s.Engine)
@@ -558,14 +557,6 @@ func (s *ServerSuite) TestConditionalDelete(c *C) {
 	// Only the 8 females should be left
 	count, err = patientCollection.Count()
 	c.Assert(count, Equals, 8)
-}
-
-func (s *ServerSuite) TestRejectXML(c *C) {
-	req, err := http.NewRequest("GET", s.Server.URL+"/Patient", nil)
-	util.CheckErr(err)
-	req.Header.Add("Accept", "application/xml")
-	resp, err := http.DefaultClient.Do(req)
-	c.Assert(resp.StatusCode, Equals, http.StatusNotAcceptable)
 }
 
 func (s *ServerSuite) TestUnescapedLinksInJSONResponse(c *C) {

--- a/test/interceptor.go
+++ b/test/interceptor.go
@@ -4,21 +4,19 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/intervention-engine/fhir/auth"
 	"github.com/intervention-engine/fhir/server"
 )
 
 func main() {
 	noint := flag.Bool("noint", false, "Run the test server without interceptors")
 	flag.Parse()
-	s := server.NewServer("localhost")
+	s := server.NewServer(server.DefaultConfig)
 
 	if !*noint {
 		setupTestInterceptors(s)
 	}
 
-	config := server.Config{Auth: auth.None()}
-	s.Run(config)
+	s.Run()
 }
 
 // With this test server running, verfiy the following (by viewing server log):


### PR DESCRIPTION
This update improves and simplifies the way configuration is managed and shared when setting up a new server.  It also adds a feature to the search framework that caches the count from various searches to improve performance the next time that same search is made.

## Configuration Updates

The `Config` object now has 3 new options with sensible defaults:

1. `DatabaseHost` - replaces the original database host string argument to `server.NewServer()`
2. `ReadOnly` - when true, puts the server in read-only mode and enables the `ReadOnlyMiddleware`
3. `DatabaseTimeout` - can be used to increase or decrease the timeout when making requests to mongo. This is specifically the timeout for the _database_ operation, not the web layer.

`server.NewServer()` now takes a `server.Config` object instead of just a `databaseHost` string. The `Config` object is now used when setting up a new server to configure the FHIRServer, DataAccessLayer, middleware, and the Searcher.

`server.Run()` now takes no arguments and just starts the new, configured server.

A new `ReadOnlyMiddleware` handler was added to reject requests of any method but `GET`, `HEAD`, and `OPTIONS`. This was originally implemented in `synthetichealth/gofhir`.

## Search Performance Updates

At scale many searches are timing out because of the additional overhead needed to obtain count of the total results. When the server is in `ReadOnly` mode the `countcache` collection in mongo is used to store the count of a search, so subsequent searches with the same query can leverage the cache for a count and respond with results more quickly. The `_id` field in this collection is an md5 hash of the query URL.

The cache is only used when the server is configured with `ReadOnly=true`, ensuring the cache does not need to be cleared and refreshed since new data cannot be added to the server. The cache is automatically cleared when the server is started with `ReadOnly=false`.