### PR TITLE
Fixed search results bug

### DIFF
--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -95,7 +95,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 
 	// There's no point in running the query if we already know it will return 0 results.
 	if m.readonly && !doCount && total == 0 {
-		return nil, 0, nil
+		return results, 0, nil
 	}
 
 	// execute the query
@@ -107,7 +107,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		if err != nil {
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
-				return nil, 0, nil
+				return results, 0, nil
 			}
 			return nil, 0, err
 		}
@@ -119,7 +119,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		if err != nil {
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
-				return nil, 0, nil
+				return results, 0, nil
 			}
 			return nil, 0, err
 		}

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -750,7 +750,9 @@ func (m *MongoSearchSuite) TestPatientReferenceQueryByObservationCode(c *C) {
 	results, total, err = m.MongoSearcher.Search(q)
 	util.CheckErr(err)
 	c.Assert(total, Equals, uint32(0))
-	c.Assert(results, IsNil)
+	c.Assert(results, NotNil)
+	resultsVal = reflect.ValueOf(results).Elem()
+	c.Assert(resultsVal.Len(), Equals, 0)
 }
 
 func (m *MongoSearchSuite) TestPatientReferenceQueryByObservationCodeOr(c *C) {


### PR DESCRIPTION
Searches with 0 results were returning nil instead of an empty slice of resources. Fixed this to return the empty slice appropriate for the searched resource type.