### PR TITLE
Fixed conficting hashes when caching resource counts

### DIFF
--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -83,7 +83,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 	var queryHash string
 
 	if m.readonly {
-		queryHash = fmt.Sprintf("%x", md5.Sum([]byte(query.Query)))
+		queryHash = fmt.Sprintf("%x", md5.Sum([]byte(query.Resource+"?"+query.Query)))
 		countcache := &CountCache{}
 		err = m.db.C("countcache").FindId(queryHash).One(countcache)
 		if err == nil {

--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -2664,7 +2664,7 @@ func (m *MongoSearchSuite) TestCacheSearchCount(c *C) {
 	searcher := NewMongoSearcher(db, true, true) // enableCISearches = true, readonly = true
 
 	q := Query{"Device", "manufacturer=Acme"}
-	expectedHash := fmt.Sprintf("%x", md5.Sum([]byte(q.Query)))
+	expectedHash := fmt.Sprintf("%x", md5.Sum([]byte("Device?manufacturer=Acme")))
 
 	results, total, err := searcher.Search(q)
 	util.CheckErr(err)


### PR DESCRIPTION
The resource type was not incorporated into the hash of the query, so requests for different resource types would return the same hash, for example:

`GET [base]/Patient` and `GET [base]/Observation` were both hashing just the query portion of the request, or `""`. Now, requests to these endpoints hash `Patient?` and `Observation?` respectively, ensuring there is no conflict.