### PR TITLE
Disable Search Counts

### DIFF
--- a/search/mongo_registry_test.go
+++ b/search/mongo_registry_test.go
@@ -18,7 +18,7 @@ func (s *MongoRegistrySuite) TestRegisterAndLookupBSONBuilder(c *C) {
 	GlobalMongoRegistry().RegisterBSONBuilder("test", build)
 	obtained, err := GlobalMongoRegistry().LookupBSONBuilder("test")
 	util.CheckErr(err)
-	bmap, err := obtained(&StringParam{String: "bar"}, NewMongoSearcher(nil, true, false)) // enableCISearches = true, readonly = false
+	bmap, err := obtained(&StringParam{String: "bar"}, NewMongoSearcher(nil, true, true, false)) // countTotalResults = true, enableCISearches = true, readonly = false
 	util.CheckErr(err)
 	c.Assert(bmap, HasLen, 1)
 	c.Assert(bmap["foo"], Equals, "bar")

--- a/server/config.go
+++ b/server/config.go
@@ -30,6 +30,10 @@ type Config struct {
 	// DatabaseTimeout is the amount of time the mgo driver will wait for a response
 	// from mongo before timing out.
 	DatabaseTimeout time.Duration
+	// CountTotalResults toggles whether the searcher should also get a total
+	// count of the total results of a search. In practice this is a performance hit
+	// for large datasets.
+	CountTotalResults bool
 	// EnableCISearches toggles whether the mongo searches uses regexes to maintain
 	// case-insesitivity when performing searches on string fields, codes, etc.
 	EnableCISearches bool
@@ -40,12 +44,13 @@ type Config struct {
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:        "",
-	IndexConfigPath:  "config/indexes.conf",
-	DatabaseHost:     "localhost:27017",
-	DatabaseName:     "fhir",
-	DatabaseTimeout:  1 * time.Minute,
-	Auth:             auth.None(),
-	EnableCISearches: true,
-	ReadOnly:         false,
+	ServerURL:         "",
+	IndexConfigPath:   "config/indexes.conf",
+	DatabaseHost:      "localhost:27017",
+	DatabaseName:      "fhir",
+	DatabaseTimeout:   1 * time.Minute,
+	Auth:              auth.None(),
+	EnableCISearches:  true,
+	CountTotalResults: true,
+	ReadOnly:          false,
 }

--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -82,18 +82,20 @@ func (ws *WorkerSession) Close() {
 // NewMongoDataAccessLayer returns an implementation of DataAccessLayer that is backed by a Mongo database
 func NewMongoDataAccessLayer(ms *MasterSession, interceptors map[string]InterceptorList, config Config) DataAccessLayer {
 	return &mongoDataAccessLayer{
-		MasterSession:    ms,
-		Interceptors:     interceptors,
-		enableCISearches: config.EnableCISearches,
-		readonly:         config.ReadOnly,
+		MasterSession:     ms,
+		Interceptors:      interceptors,
+		countTotalResults: config.CountTotalResults,
+		enableCISearches:  config.EnableCISearches,
+		readonly:          config.ReadOnly,
 	}
 }
 
 type mongoDataAccessLayer struct {
-	MasterSession    *MasterSession
-	Interceptors     map[string]InterceptorList
-	enableCISearches bool
-	readonly         bool
+	MasterSession     *MasterSession
+	Interceptors      map[string]InterceptorList
+	countTotalResults bool
+	enableCISearches  bool
+	readonly          bool
 }
 
 // InterceptorList is a list of interceptors registered for a given database operation
@@ -395,7 +397,7 @@ func (dal *mongoDataAccessLayer) Search(baseURL url.URL, searchQuery search.Quer
 	worker := dal.MasterSession.GetWorkerSession()
 	defer worker.Close()
 
-	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches, dal.readonly)
+	searcher := search.NewMongoSearcher(worker.DB(), dal.countTotalResults, dal.enableCISearches, dal.readonly)
 
 	result, total, err := searcher.Search(searchQuery)
 	if err != nil {
@@ -432,7 +434,11 @@ func (dal *mongoDataAccessLayer) Search(baseURL url.URL, searchQuery search.Quer
 	bundle.Id = bson.NewObjectId().Hex()
 	bundle.Type = "searchset"
 	bundle.Entry = entryList
-	bundle.Total = &total
+
+	// Omit the total if 0, since it may never have been computed at all.
+	if total != 0 {
+		bundle.Total = &total
+	}
 
 	// Add links for paging
 	bundle.Link = generatePagingLinks(baseURL, searchQuery, total)
@@ -460,7 +466,7 @@ func (dal *mongoDataAccessLayer) FindIDs(searchQuery search.Query) (IDs []string
 	newQuery := search.Query{Resource: searchQuery.Resource, Query: newParams.Encode()}
 
 	// Now search on that query, unmarshaling to a temporary struct and converting results to []string
-	searcher := search.NewMongoSearcher(worker.DB(), dal.enableCISearches, dal.readonly)
+	searcher := search.NewMongoSearcher(worker.DB(), dal.countTotalResults, dal.enableCISearches, dal.readonly)
 	results, _, err := searcher.Search(newQuery)
 	if err != nil {
 		return nil, convertMongoErr(err)


### PR DESCRIPTION
The CountTotalResults config option may now be set to false to prevent the server from making a count of the total results of a search. This improves performance on large datasets.