### PR TITLE
Paging Links Without Counts

### DIFF
--- a/server/mongo_data_access.go
+++ b/server/mongo_data_access.go
@@ -407,9 +407,9 @@ func (dal *mongoDataAccessLayer) Search(baseURL url.URL, searchQuery search.Quer
 	includesMap := make(map[string]interface{})
 	var entryList []models.BundleEntryComponent
 	resultVal := reflect.ValueOf(result).Elem()
-	numResults := uint32(resultVal.Len())
+	numResults := resultVal.Len()
 
-	for i := 0; i < int(numResults); i++ {
+	for i := 0; i < numResults; i++ {
 		var entry models.BundleEntryComponent
 		entry.Resource = resultVal.Index(i).Addr().Interface()
 		entry.Search = &models.BundleEntrySearchComponent{Mode: "match"}
@@ -442,7 +442,7 @@ func (dal *mongoDataAccessLayer) Search(baseURL url.URL, searchQuery search.Quer
 		bundle.Total = &total
 	}
 
-	bundle.Link = dal.generatePagingLinks(baseURL, searchQuery, total, numResults)
+	bundle.Link = dal.generatePagingLinks(baseURL, searchQuery, total, uint32(numResults))
 
 	return &bundle, nil
 }
@@ -518,8 +518,6 @@ func (dal *mongoDataAccessLayer) generatePagingLinks(baseURL url.URL, query sear
 		prevCount := offset - prevOffset
 		links = append(links, newLink("previous", baseURL, params, prevOffset, prevCount))
 	}
-
-	fmt.Println("num: ", numResults)
 
 	// If counts are enabled, the total is accurate and can be used to compute the links.
 	if dal.countTotalResults {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -201,7 +201,7 @@ func (s *ServerSuite) TestGetPatientsPaging(c *C) {
 	assertPagingLink(c, bundle.Link[2], "last", 100, 0)
 }
 
-func (s *ServerSuite) TestPatientPaginingWithCountsDisabled(c *C) {
+func (s *ServerSuite) TestPatientPagingWithCountsDisabled(c *C) {
 	config := DefaultConfig
 	config.CountTotalResults = false
 	dal, ok := NewMongoDataAccessLayer(s.MasterSession, nil, config).(*mongoDataAccessLayer)


### PR DESCRIPTION
Fixed paging links to work without a result count. Without a total count we are unable to generate the 'last' link, but we can still reliably return a 'next' link. This still conforms to spec.