### PR TITLE
Added KillLongRunningOps

### DIFF
--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -112,6 +112,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		var mgoPipe *mgo.Pipe
 		mgoPipe, computedTotal, err = m.aggregate(bsonQuery, query.Options(), doCount)
 		if err != nil {
+			fmt.Println("Got error: ", err)
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
 				return results, 0, nil
@@ -124,6 +125,7 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		var mgoQuery *mgo.Query
 		mgoQuery, computedTotal, err = m.find(bsonQuery, query.Options(), doCount)
 		if err != nil {
+			fmt.Println("Got error: ", err)
 			if err == mgo.ErrNotFound {
 				// This was a valid search that returned zero results
 				return results, 0, nil

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+// This is a MongoDB internal error code for an interrupted operation, see:
+// https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err#L217
 var opInterruptedCode = 11601
 
 // BSONQuery is a BSON document constructed from the original string search query.

--- a/search/mongo_search.go
+++ b/search/mongo_search.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+var opInterruptedCode = 11601
+
 // BSONQuery is a BSON document constructed from the original string search query.
 type BSONQuery struct {
 	Resource string
@@ -105,33 +107,44 @@ func (m *MongoSearcher) Search(query Query) (results interface{}, total uint32, 
 		doCount = false
 	}
 
-	// execute the query
 	var computedTotal uint32
-	if bsonQuery.usesPipeline() {
+	var mgoPipe *mgo.Pipe
+	var mgoQuery *mgo.Query
+	usesPipeline := bsonQuery.usesPipeline()
+
+	// Execute the query
+	if usesPipeline {
 		// The (slower) aggregation pipeline is used if the query contains includes or revincludes
-		var mgoPipe *mgo.Pipe
 		mgoPipe, computedTotal, err = m.aggregate(bsonQuery, query.Options(), doCount)
-		if err != nil {
-			fmt.Println("Got error: ", err)
-			if err == mgo.ErrNotFound {
-				// This was a valid search that returned zero results
-				return results, 0, nil
-			}
-			return nil, 0, err
-		}
-		err = mgoPipe.All(results)
 	} else {
 		// Otherwise, the (faster) standard query is used
-		var mgoQuery *mgo.Query
 		mgoQuery, computedTotal, err = m.find(bsonQuery, query.Options(), doCount)
-		if err != nil {
-			fmt.Println("Got error: ", err)
-			if err == mgo.ErrNotFound {
-				// This was a valid search that returned zero results
-				return results, 0, nil
-			}
+	}
+
+	// Check if the query returned any errors
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			// This was a valid search that returned zero results
+			return results, 0, nil
+		}
+
+		e, ok := err.(*mgo.QueryError)
+		if !ok {
+			// This was not a mgo error
 			return nil, 0, err
 		}
+
+		if e.Code == opInterruptedCode {
+			// This query operation was interrupted
+			panic(createOpInterruptedError("Long-running operation interrupted"))
+		}
+		return nil, 0, err
+	}
+
+	// Collect the results
+	if usesPipeline {
+		err = mgoPipe.All(results)
+	} else {
 		err = mgoQuery.All(results)
 	}
 
@@ -1100,6 +1113,16 @@ func createOpOutcome(severity, code, detailsCode, detailsDisplay string) *models
 		}
 	}
 
+	if detailsCode == "" && detailsDisplay != "" {
+		outcome.Issue[0].Details = &models.CodeableConcept{
+			Coding: []models.Coding{
+				models.Coding{
+					Display: detailsDisplay},
+			},
+			Text: detailsDisplay,
+		}
+	}
+
 	return outcome
 }
 
@@ -1134,6 +1157,13 @@ func createInternalServerError(code, display string) *Error {
 	return &Error{
 		HTTPStatus:       http.StatusInternalServerError,
 		OperationOutcome: createOpOutcome("fatal", "exception", code, display),
+	}
+}
+
+func createOpInterruptedError(display string) *Error {
+	return &Error{
+		HTTPStatus:       http.StatusInternalServerError,
+		OperationOutcome: createOpOutcome("error", "too-costly", "", display),
 	}
 }
 

--- a/server/config.go
+++ b/server/config.go
@@ -16,41 +16,62 @@ type Config struct {
 	// ServerURL is the full URL for the root of the server. This may be used
 	// by other middleware to compute redirect URLs
 	ServerURL string
+
 	// Auth determines what, if any authentication and authorization will be used
 	// by the FHIR server
 	Auth auth.Config
+
 	// IndexConfigPath is the path to an indexes.conf configuration file, specifying
 	// what mongo indexes the server should create (or verify) on startup
 	IndexConfigPath string
+
 	// DatabaseHost is the url of the running mongo instance to use for the fhir database.
 	DatabaseHost string
+
 	// DatabaseName is the name of the mongo database used for the fhir database.
 	// Typically this will be the default DatabaseName "fhir".
 	DatabaseName string
-	// DatabaseTimeout is the amount of time the mgo driver will wait for a response
+
+	// DatabaseSocketTimeout is the amount of time the mgo driver will wait for a response
 	// from mongo before timing out.
-	DatabaseTimeout time.Duration
+	DatabaseSocketTimeout time.Duration
+
+	// DatabaseOpTimeout is the amount of time GoFHIR will wait before killing a long-running
+	// database process. This defaults to a reasonable upper bound for slow, pipelined queries: 30s.
+	DatabaseOpTimeout time.Duration
+
+	// DatabaseKillOpPeriod is the length of time between scans of the database to kill long-running ops.
+	DatabaseKillOpPeriod time.Duration
+
 	// CountTotalResults toggles whether the searcher should also get a total
 	// count of the total results of a search. In practice this is a performance hit
 	// for large datasets.
 	CountTotalResults bool
+
 	// EnableCISearches toggles whether the mongo searches uses regexes to maintain
 	// case-insesitivity when performing searches on string fields, codes, etc.
 	EnableCISearches bool
+
 	// ReadOnly toggles whether the server is in read-only mode. In read-only
 	// mode any HTTP verb other than GET, HEAD or OPTIONS is rejected.
 	ReadOnly bool
+
+	// Debug toggles debug-level logging.
+	Debug bool
 }
 
 // DefaultConfig is the default server configuration
 var DefaultConfig = Config{
-	ServerURL:         "",
-	IndexConfigPath:   "config/indexes.conf",
-	DatabaseHost:      "localhost:27017",
-	DatabaseName:      "fhir",
-	DatabaseTimeout:   1 * time.Minute,
-	Auth:              auth.None(),
-	EnableCISearches:  true,
-	CountTotalResults: true,
-	ReadOnly:          false,
+	ServerURL:             "",
+	IndexConfigPath:       "config/indexes.conf",
+	DatabaseHost:          "localhost:27017",
+	DatabaseName:          "fhir",
+	DatabaseSocketTimeout: 2 * time.Minute,
+	DatabaseOpTimeout:     90 * time.Second,
+	DatabaseKillOpPeriod:  10 * time.Second,
+	Auth:                  auth.None(),
+	EnableCISearches:      true,
+	CountTotalResults:     true,
+	ReadOnly:              false,
+	Debug:                 false,
 }

--- a/server/data_access.go
+++ b/server/data_access.go
@@ -40,3 +40,6 @@ var ErrNotFound = errors.New("Resource Not Found")
 
 // ErrMultipleMatches indicates that the conditional update query returned multiple matches
 var ErrMultipleMatches = errors.New("Multiple Matches")
+
+// ErrOpInterrupted indicates that the query was interrupted by a killOp() operation
+var ErrOpInterrupted = errors.New("Operation Interrupted")

--- a/server/mongo_admin.go
+++ b/server/mongo_admin.go
@@ -87,6 +87,11 @@ func killLongRunningOps(ticker *time.Ticker, masterAdminSession *MasterSession, 
 				continue
 			}
 
+			// Don't retry kills.
+			if op.KillPending {
+				continue
+			}
+
 			// Only interfere with operations on our database (e.g. "fhir").
 			if !strings.Contains(op.Namespace, config.DatabaseName) {
 				continue

--- a/server/mongo_admin.go
+++ b/server/mongo_admin.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	// OK when returned by MongoDB is really a float (0.0 = false, 1.0 = true)
+	OK = float64(1)
+)
+
+// CurrentOps is returned by db.currentOp() and contains
+// a list of all operations currently in-progress. The db.currentOp()
+// operation will itself be an element of InProg[].
+type CurrentOps struct {
+	InProg []CurrentOp `bson:"inprog" json:"inprog"`
+	Info   string      `bson:"info,omitempty" json:"info,omitempty"`
+	Ok     float64     `bson:"ok" json:"ok"`
+}
+
+// CurrentOp is a database operation currently in-progress.
+type CurrentOp struct {
+	Active           bool   `bson:"active" json:"active"`
+	OpID             uint32 `bson:"opid" json:"opid"`
+	SecsRunning      uint32 `bson:"secs_running" json:"secs_running"`
+	MicrosecsRunning uint64 `bson:"microsecs_running" json:"microsecs_running"`
+	OpType           string `bson:"op" json:"op"`
+	Namespace        string `bson:"ns" json:"ns"`
+	KillPending      bool   `bson:"killPending" json:"killPending"`
+	Query            bson.D `bson:"query" json:"query"`
+}
+
+// Reply is a response from a MongoDB command that doesn't return any results.
+type Reply struct {
+	Info string  `bson:"info,omitempty" json:"info,omitempty"`
+	Ok   float64 `bson:"ok" json:"ok"`
+}
+
+// killLongRunningOps is intended to be run as a separate goroutine, off of
+// the main server thread. killLongRunningOps periodically checks the admin
+// database for long-running client-initiated operations (e.g. a slow pipeline)
+// and kills those operations after the set Config.DatabaseOpTimeout.
+func killLongRunningOps(ticker *time.Ticker, masterAdminSession *MasterSession, config Config) {
+	logKLRO(nil, fmt.Sprintf("Monitoring database %s for long-running operations", config.DatabaseName))
+	workerSession := masterAdminSession.GetWorkerSession()
+	defer workerSession.Close()
+	adminDB := workerSession.DB()
+
+	for now := range ticker.C {
+		var err error
+		ops := CurrentOps{}
+		t := &now
+
+		logKLRO(t, "Scanning for long-running operations...")
+
+		// This will return a set of client-initiated currentOps ONLY. There are numerous
+		// more server operations that are returned when passed {"$all": true}.
+		err = adminDB.Run("currentOp", &ops)
+
+		if err != nil {
+			logKLRO(t, err.Error())
+		}
+
+		if ops.Ok != OK {
+			if ops.Info != "" {
+				logKLRO(t, "!OK: "+ops.Info)
+			} else {
+				logKLRO(t, "!OK: No additional information")
+			}
+			continue
+		}
+
+		for _, op := range ops.InProg {
+
+			// Only evaluate active operations.
+			if !op.Active {
+				continue
+			}
+
+			// Only interfere with our database operations.
+			if !strings.Contains(op.Namespace, config.DatabaseName) {
+				continue
+			}
+
+			// Check the current runtime.
+			if float64(op.SecsRunning) < config.DatabaseOpTimeout.Seconds() {
+				continue
+			}
+
+			// Operations that get here meet the following criteria:
+			// 1. Have a runtime exceeding the current config.DatabaseOpTimeout
+			// 2. Are in the config.DatabaseName namespace.
+			switch op.OpType {
+			case "command", "query", "getMore":
+				if len(op.Query) == 0 {
+					continue
+				}
+
+				queryDoc := op.Query[0]
+				switch queryDoc.Name {
+				case "$msg", "find", "aggregate":
+					// Only these select op types are eligible for termination.
+					// $msg occurs if the query was too big to fit in the response,
+					// which almost always means it's an aggregation pipeline.
+					err = killOp(adminDB, op.OpID)
+					if err != nil {
+						logKLRO(t, err.Error())
+					}
+
+					// Successfully killed the operation.
+					msg := fmt.Sprintf("killed op[%d] %s %s\n", op.OpID, queryDoc.Name, op.Namespace)
+					logKLRO(t, msg)
+				}
+			}
+		}
+	}
+}
+
+func killOp(adminDB *mgo.Database, opID uint32) error {
+	var err error
+	reply := Reply{}
+	err = adminDB.Run(bson.D{{"killOp", opID}}, &reply)
+	if reply.Ok != OK {
+		return errors.New(reply.Info)
+	}
+	return err
+}
+
+func logKLRO(t *time.Time, msg string) {
+	if t != nil {
+		log.Printf("%v KillLongRunningOps: %s\n", t, msg)
+		return
+	}
+	log.Printf("KillLongRunningOps: %s\n", msg)
+}

--- a/server/mongo_admin.go
+++ b/server/mongo_admin.go
@@ -47,6 +47,10 @@ type Reply struct {
 // the main server thread. killLongRunningOps periodically checks the admin
 // database for long-running client-initiated operations (e.g. a slow pipeline)
 // and kills those operations after the set Config.DatabaseOpTimeout.
+//
+// This is a common approach, similarly applied here:
+// 1. https://blog.mlab.com/2014/02/mongodb-currentop-killop
+// 2. https://dzone.com/articles/finding-and-terminating-long
 func killLongRunningOps(ticker *time.Ticker, masterAdminSession *MasterSession, config Config) {
 	logKLRO(nil, fmt.Sprintf("Monitoring database %s for long-running operations", config.DatabaseName))
 	workerSession := masterAdminSession.GetWorkerSession()

--- a/server/mongo_admin.go
+++ b/server/mongo_admin.go
@@ -106,21 +106,15 @@ func killLongRunningOps(ticker *time.Ticker, masterAdminSession *MasterSession, 
 				}
 
 				queryDoc := op.Query[0]
-				switch queryDoc.Name {
-				case "$msg", "find", "aggregate":
-					// Only these select op types are eligible for termination.
-					// $msg occurs if the query was too big to fit in the response,
-					// which almost always means it's an aggregation pipeline.
-					err = killOp(adminDB, op.OpID)
-					if err != nil {
-						logKLRO(t, err.Error())
-						continue
-					}
-
-					// Successfully killed the operation.
-					msg := fmt.Sprintf("killed op[%d] %s %s", op.OpID, queryDoc.Name, op.Namespace)
-					logKLRO(t, msg)
+				err = killOp(adminDB, op.OpID)
+				if err != nil {
+					logKLRO(t, err.Error())
+					continue
 				}
+
+				// Successfully killed the operation.
+				msg := fmt.Sprintf("killed op[%d] %s %s", op.OpID, queryDoc.Name, op.Namespace)
+				logKLRO(t, msg)
 			}
 		}
 	}

--- a/server/mongo_indexes_test.go
+++ b/server/mongo_indexes_test.go
@@ -237,7 +237,7 @@ func (s *MongoIndexesTestSuite) TestParseIndexBadCompoundKeySubKeyFormat() {
 
 func (s *MongoIndexesTestSuite) TestConfigureIndexes() {
 	// Configure test indexes
-	ConfigureIndexes(s.MasterSession, s.Config)
+	NewIndexer(s.Config).ConfigureIndexes(s.MasterSession)
 
 	// get the "testcollection" collection. This should have been auto-magically
 	// created by ConfigureIndexes
@@ -260,7 +260,7 @@ func (s *MongoIndexesTestSuite) TestConfigureIndexes() {
 func (s *MongoIndexesTestSuite) TestConfigureIndexesNoConfigFile() {
 
 	s.Config.IndexConfigPath = "./does_not_exist.conf"
-	s.NotPanics(func() { ConfigureIndexes(s.MasterSession, s.Config) }, "Should not panic if no config file is found")
+	s.NotPanics(func() { NewIndexer(s.Config).ConfigureIndexes(s.MasterSession) }, "Should not panic if no config file is found")
 }
 
 func (s *MongoIndexesTestSuite) compareIndexes(expected, actual []mgo.Index) {


### PR DESCRIPTION
Added a background thread to the server to periodically scan for long-running client-initiated operations, killing any operations that exceed Config.DatabaseOpTimeout. This thread is started _after_ ensuring all indexes, so no `ensureIndex()` processes are accidentally killed.

The following is the general idea:

* The `admin` database is queried for long-running ops once every 10 seconds.
* Long-running ops are killed if they've consumed more than 90 seconds of processing time and haven't yet completed.
* The socket connection to the database is killed after 2 minutes, in case the client operation hangs for some other reason.

I've tested this feature manually and things are working well. I'm not sure how to write a unit test for this though, since I can't think of a way to force the database into a long-running operation without significant quantities of data.