### PR TITLE
Implemented _summary=count

### DIFF
--- a/search/mongo_search_test.go
+++ b/search/mongo_search_test.go
@@ -2957,6 +2957,28 @@ func (m *MongoSearchSuite) TestCacheSearchCount(c *C) {
 	c.Assert(cc.Count, Equals, uint32(1))
 }
 
+func (m *MongoSearchSuite) TestSummaryCount(c *C) {
+	q := Query{"Patient", "_summary=count"}
+	results, total, err := m.MongoSearcher.Search(q)
+	util.CheckErr(err)
+	resultsVal := reflect.ValueOf(results).Elem()
+	c.Assert(resultsVal.Len(), Equals, 0)
+	c.Assert(total, Equals, uint32(2))
+}
+
+func (m *MongoSearchSuite) TestSummaryCountWithCountsDisabled(c *C) {
+	// The count should still be returned when requesting _summary=count, even if counts are disabled.
+	db := m.Session.DB("fhir-test")
+	searcher := NewMongoSearcher(db, false, true, false) // countTotalResults = false, enableCISearches = true, readonly = false
+
+	q := Query{"Patient", "_summary=count"}
+	results, total, err := searcher.Search(q)
+	util.CheckErr(err)
+	resultsVal := reflect.ValueOf(results).Elem()
+	c.Assert(resultsVal.Len(), Equals, 0)
+	c.Assert(total, Equals, uint32(2))
+}
+
 // Test internally used functions
 
 func (m *MongoSearchSuite) TestBuildBsonForCompositeCriteriaAndPathWithArrayAncestor(c *C) {

--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -302,7 +302,7 @@ func (q *Query) SupportsPaging() bool {
 	options := q.Options()
 
 	// not for $everything. $everything is defined as _id=<id>&_include=*&_revinclude=*
-	if options.IsIncludeAll && options.IsRevincludeAll && strings.Contains(q.Query, "_id") {
+	if q.isDollarEverything() {
 		return false
 	}
 
@@ -312,6 +312,11 @@ func (q *Query) SupportsPaging() bool {
 	}
 
 	return true
+}
+
+func (q *Query) isDollarEverything() bool {
+	de := regexp.MustCompile("_id=[0-9a-f]{24}&_include=\\*&_revinclude=\\*")
+	return de.MatchString(q.Query)
 }
 
 func getSingletonParamValue(param string, values []string) string {

--- a/search/search_param_types.go
+++ b/search/search_param_types.go
@@ -220,10 +220,17 @@ func (q *Query) Options() *QueryOptions {
 			options.RevInclude = append(options.RevInclude, RevIncludeOption{Resource: incls[0], Parameter: revInclParam})
 
 		case FormatParam:
-			if queryParam.Value != "json" && queryParam.Value != "application/json" && queryParam.Value != "application/json+fhir" {
+			if queryParam.Value != "json" && queryParam.Value != "application/json" && queryParam.Value != "application/json+fhir" && queryParam.Value != "application/fhir+json" {
 				// Currently we only support JSON
 				panic(createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_format\" content is invalid"))
 			}
+
+		case SummaryParam:
+			if queryParam.Value != "count" && queryParam.Value != "false" {
+				// We only support "count", and the default (implicit) setting is "false".
+				panic(createUnsupportedSearchError("MSG_PARAM_INVALID", "Parameter \"_summary\" content is invalid"))
+			}
+			options.Summary = queryParam.Value
 
 		default:
 			panic(createUnsupportedSearchError("MSG_PARAM_UNKNOWN", fmt.Sprintf("Parameter \"%s\" not understood", param)))
@@ -287,6 +294,24 @@ func (q *Query) UsesReverseChainedSearch() bool {
 // UsesPipeline returns true if the query requires a pipeline to execute
 func (q *Query) UsesPipeline() bool {
 	return q.UsesIncludes() || q.UsesRevIncludes() || q.UsesChainedSearch() || q.UsesReverseChainedSearch()
+}
+
+// SupportsPaging returns true if the query results can be paginated, false if not.
+// In practice, most queries can be paginated, but queries for $everything or _summary cannot.
+func (q *Query) SupportsPaging() bool {
+	options := q.Options()
+
+	// not for $everything. $everything is defined as _id=<id>&_include=*&_revinclude=*
+	if options.IsIncludeAll && options.IsRevincludeAll && strings.Contains(q.Query, "_id") {
+		return false
+	}
+
+	// not for _summary=count
+	if options.Summary == "count" {
+		return false
+	}
+
+	return true
 }
 
 func getSingletonParamValue(param string, values []string) string {
@@ -356,6 +381,7 @@ type QueryOptions struct {
 	IsSTU3Sort      bool
 	IsIncludeAll    bool
 	IsRevincludeAll bool
+	Summary         string
 }
 
 // NewQueryOptions constructs a new QueryOptions with default values (offset = 0, Count = 100)

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1881,16 +1881,32 @@ func (s *SearchPTSuite) TestQuerySupportsPaging(c *C) {
 	c.Assert(q.SupportsPaging(), Equals, true)
 
 	// Not supported for $everything...
-	q = Query{"Patient", "_id=123&_include=*&_revinclude=*"}
+	q = Query{"Patient", "_id=58b3663e3425def0f0f69505&_include=*&_revinclude=*"}
 	c.Assert(q.SupportsPaging(), Equals, false)
 
 	// ... but supported for any old _include=*&_revinclude=*
 	q = Query{"MedicationRequest", "_include=*&_revinclude=*"}
 	c.Assert(q.SupportsPaging(), Equals, true)
 
+	// ... and supported for an OR on _id
+	q = Query{"Patient", "_id=58b3663e3425def0f0f69505,58b3663e3425def0f0f69506,58b3663e3425def0f0f69507&_include=*&_revinclude=*"}
+	c.Assert(q.SupportsPaging(), Equals, true)
+
 	// Not supported for _summary=count
 	q = Query{"Observation", "_summary=count"}
 	c.Assert(q.SupportsPaging(), Equals, false)
+}
+
+func (s *SearchPTSuite) TestIsDollarEverything(c *C) {
+	q := Query{"Patient", "_id=58b3663e3425def0f0f69505&_include=*&_revinclude=*"}
+	c.Assert(q.isDollarEverything(), Equals, true)
+
+	q = Query{"Observation", "code=1234-5"}
+	c.Assert(q.isDollarEverything(), Equals, false)
+
+	// Specifically, an OR on _id violates $everything
+	q = Query{"Patient", "_id=58b3663e3425def0f0f69505,58b3663e3425def0f0f69506,58b3663e3425def0f0f69507&_include=*&_revinclude=*"}
+	c.Assert(q.isDollarEverything(), Equals, false)
 }
 
 func (s *SearchPTSuite) TestSearchParamInfoClone(c *C) {

--- a/search/search_param_types_test.go
+++ b/search/search_param_types_test.go
@@ -1869,6 +1869,30 @@ func (s *SearchPTSuite) TestQueryUsesReverseChainedSearchAndPipeline(c *C) {
 	c.Assert(q.UsesPipeline(), Equals, false)
 }
 
+func (s *SearchPTSuite) TestQuerySupportsPaging(c *C) {
+	// Supported for common searches
+	q := Query{"Patient", "gender=male"}
+	c.Assert(q.SupportsPaging(), Equals, true)
+
+	q = Query{"Observation", "code=1234-5"}
+	c.Assert(q.SupportsPaging(), Equals, true)
+
+	q = Query{"Encounter", ""}
+	c.Assert(q.SupportsPaging(), Equals, true)
+
+	// Not supported for $everything...
+	q = Query{"Patient", "_id=123&_include=*&_revinclude=*"}
+	c.Assert(q.SupportsPaging(), Equals, false)
+
+	// ... but supported for any old _include=*&_revinclude=*
+	q = Query{"MedicationRequest", "_include=*&_revinclude=*"}
+	c.Assert(q.SupportsPaging(), Equals, true)
+
+	// Not supported for _summary=count
+	q = Query{"Observation", "_summary=count"}
+	c.Assert(q.SupportsPaging(), Equals, false)
+}
+
 func (s *SearchPTSuite) TestSearchParamInfoClone(c *C) {
 	original := SearchParamInfo{
 		Name:  "foo",


### PR DESCRIPTION
Added the `_summary=count` search option, and refined the way paging links are built. Queries that don't support paging (e.g. `$everything`, or `_summary=count`) only return a self link now (built from the raw query, without the _offset or _count params included). 

Also, `_summary=count` will return a total even if `Config.CountTotalResults = false`. Otherwise this search would be completely useless in that scenario.
